### PR TITLE
Allowed hiding menu bar

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -90,6 +90,7 @@ typedef enum
 #define NEMO_WINDOW_STATE_START_WITH_STATUS_BAR		"start-with-status-bar"
 #define NEMO_WINDOW_STATE_START_WITH_SIDEBAR		"start-with-sidebar"
 #define NEMO_WINDOW_STATE_START_WITH_TOOLBAR		"start-with-toolbar"
+#define NEMO_WINDOW_STATE_START_WITH_MENU_BAR           "start-with-menu-bar"
 #define NEMO_WINDOW_STATE_SIDE_PANE_VIEW                    "side-pane-view"
 #define NEMO_WINDOW_STATE_GEOMETRY				"geometry"
 #define NEMO_WINDOW_STATE_MAXIMIZED				"maximized"

--- a/libnemo-private/org.gnome.nemo.gschema.xml.in
+++ b/libnemo-private/org.gnome.nemo.gschema.xml.in
@@ -427,6 +427,11 @@
       <_summary>Show side pane in new windows</_summary>
       <_description>If set to true, newly opened windows will have the side pane visible.</_description>
     </key>
+    <key name="start-with-menu-bar" type="b">
+      <default>true</default>
+      <_summary>Show menu bar in new windows</_summary>
+      <_description>If set to true, newly opened windows will have the menu bar visible.</_description>
+    </key>
     <key name="side-pane-view" type="s">
       <choices>
 	<choice value='places'/>

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -562,7 +562,12 @@ nemo_window_constructed (GObject *self)
 	menu = gtk_ui_manager_get_widget (window->details->ui_manager, "/MenuBar");
 	window->details->menubar = menu;
 	gtk_widget_set_hexpand (menu, TRUE);
-	gtk_widget_show (menu);
+	if (g_settings_get_boolean (nemo_window_state, NEMO_WINDOW_STATE_START_WITH_MENU_BAR)){
+		gtk_widget_show (menu);
+	} else {
+		gtk_widget_hide (menu);
+	}
+
 	gtk_container_add (GTK_CONTAINER (grid), menu);
 
 	/* Set up the toolbar place holder */


### PR DESCRIPTION
This pull allows users to hide and show the menu bar. There is currently no graphical way to change the settings. It must be done with gsettings.

Most of the buttons in the menu bar are pretty useless if all you do is clicking around to find the right file, and you wouldn't need to change the configs through "View" much, so it isn't unreasonable for one to want to disable the menu bar.
