### PR TITLE
Add comment so description is given in gnome-session-properties

### DIFF
--- a/data/nemo-autostart.desktop.in
+++ b/data/nemo-autostart.desktop.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Files
+Comment=Start Nemo desktop at log in
 Exec=nemo -n
 OnlyShowIn=GNOME;Unity;
 AutostartCondition=GSettings org.gnome.desktop.background show-desktop-icons


### PR DESCRIPTION
Nemo and Nautilus autostart files look identical when viewed in gnome-session-properties.
