### PR TITLE
Update the nemo(1) man page

### DIFF
--- a/docs/nemo.1
+++ b/docs/nemo.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH Nemo 1 "24 May 2004"
+.TH Nemo 1 "October 2012"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -16,7 +16,7 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" for manpage-specific macros, see man(7)
 .SH NAME
-nemo \- the GNOME File Manager
+nemo \- the Cinnamon File Manager
 .SH SYNOPSIS
 .B nemo
 .RI [ options ] " URIs" ...
@@ -24,10 +24,9 @@ nemo \- the GNOME File Manager
 .SH DESCRIPTION
 This manual page documents briefly the
 .B nemo
-command. This manual page was written for the Debian GNU/Linux distribution
-because the original program does not have a manual page.
+command.
 .PP
-Nemo is the file manager for the GNOME desktop.
+Nemo is the file manager for the Cinnamon desktop.
 .br
 .SH OPTIONS
 Nemo follows the usual GNU command line syntax, with long options starting
@@ -64,11 +63,7 @@ Show a summary of options.
 Show Nemo' version.
 .TP
 Other standard GNOME options not listed here are also supported.
-.SH SEE ALSO
-Nemo documentation can be found from the "Help" menu, or by pressing the
-F1 key. Nemo also has a website at
-http://www.gnome.org/projects/nemo/
 .SH AUTHOR
-This manual page was written by Takuo KITAME <kitame@debian.org> and Dafydd
+This manual page was originally written for Nautilus by Takuo KITAME <kitame@debian.org> and Dafydd
 Harries <daf@muse.19inch.net> for the Debian GNU/Linux system (but may be used
 by others).


### PR DESCRIPTION
It seems the man page for Nemo is a direct copy of that of Nautilus, with some text substitutions. This pull request goes just a little step further, so maybe it serves best as a reminder of something that has to be done more thoroughly.
