### PR TITLE
Fix target directory of typelib file

### DIFF
--- a/debian/gir1.2-nemo-3.0.install
+++ b/debian/gir1.2-nemo-3.0.install
@@ -1,1 +1,1 @@
-usr/lib/*/girepository-1.0/Nemo-3.0.typelib
+usr/lib/girepository-1.0/Nemo-3.0.typelib

--- a/libnemo-extension/Makefile.am
+++ b/libnemo-extension/Makefile.am
@@ -78,10 +78,10 @@ Nemo_3_0_gir_LIBS = libnemo-extension.la
 Nemo_3_0_gir_FILES = $(addprefix $(srcdir)/, $(introspection_files))
 INTROSPECTION_GIRS += Nemo-3.0.gir
 
-girdir = $(datadir)/gir-1.0/
+girdir = @INTROSPECTION_GIRDIR@
 gir_DATA = $(INTROSPECTION_GIRS)
 
-typelibsdir = $(libdir)/girepository-1.0/
+typelibsdir = @INTROSPECTION_TYPELIBDIR@
 typelibs_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
 CLEANFILES += $(gir_DATA) $(typelibs_DATA)


### PR DESCRIPTION
This enables the Nemo python bindings to work properly, by installing the GIR typelib file in /usr/lib rather than /usr/lib/<arch>/gir folder.

Still needs testing to see if this breaks anything existing - I'm not 100% sure this is the correct fix.
