### PR TITLE
When navigating with the location entry bar, don't flip back to

### DIFF
--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -281,7 +281,6 @@ navigation_bar_location_changed_callback (GtkWidget *widget,
 {
 	GFile *location;
 
-	nemo_toolbar_set_show_location_entry (NEMO_TOOLBAR (pane->tool_bar), FALSE);
 	nemo_window_pane_hide_search_bar (pane);
 	nemo_window_pane_hide_temporary_bars (pane);
 


### PR DESCRIPTION
the pathbar upon hitting the enter key to change locations.

Fixes #67 core issue.
