### PR TITLE
Let Nemo provide its own style information, regardless of system GTK theme

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -19,6 +19,11 @@ autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
 mimedir = $(datadir)/mime/packages
 mime_DATA = $(xml_files)
 
+cssdir = $(datadir)/nemo
+css_DATA = \
+    nemo.css \
+    $(NULL)
+
 servicedir = $(datadir)/dbus-1/services
 service_DATA = $(service_in_files:.service.in=.service)
 service_in_files = 				\
@@ -47,6 +52,7 @@ EXTRA_DIST = $(nemodata_DATA) 	\
 	$(desktop_in_files)		\
 	$(service_in_files)		\
 	$(autostart_in_files)		\
+    $(css_DATA)     \
 	$(NULL)
 
 CLEANFILES = $(xml_files)	\

--- a/data/nemo.css
+++ b/data/nemo.css
@@ -1,0 +1,39 @@
+/* sidebar */
+
+NemoWindow .sidebar .view {
+	background-color: #3F3F3F;
+	color: #EEEEEE;
+	text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+
+/* inactive pane */
+
+.nemo-inactive-pane .view {
+    background-color: shade(@theme_base_color, 0.9);
+}
+
+.nemo-toolbar-upperhalf.toolbar {
+    -GtkWidget-window-dragging: true;
+
+    background-image: -gtk-gradient(linear, left top, left bottom,
+                                     from (shade(@theme_bg_color, 1.0)),
+                                     to (shade(@theme_bg_color, 0.94)));
+    padding: 2px;
+    color: @theme_fg_color;
+}
+
+.nemo-toolbar-lowerhalf.toolbar {
+    -GtkWidget-window-dragging: true;
+
+    background-image: -gtk-gradient(linear, left top, left bottom,
+                                     from (shade(@theme_bg_color, .94)),
+                                     to (shade(@theme_bg_color, 0.88)));
+
+    border-color: shade(@theme_bg_color, 0.7);
+    border-style: solid;
+    border-width: 0px 0 1px 0;
+    padding: 2px;
+    color: @theme_fg_color;
+}
+

--- a/libnemo-private/nemo-file-utilities.c
+++ b/libnemo-private/nemo-file-utilities.c
@@ -1368,6 +1368,23 @@ nemo_get_cached_x_content_types_for_mount (GMount *mount)
 	return NULL;
 }
 
+gchar *
+nemo_file_lookup (const gchar *filename, const gchar *subdir)
+{
+    gchar *path;
+
+    if (subdir == NULL)
+        subdir = ".";
+
+    path = g_build_filename (g_getenv ("NEMO_SRCDIR"), subdir, filename, NULL);
+    if (!g_file_test (path, G_FILE_TEST_EXISTS)) {
+        g_free (path);
+        path = g_build_filename (DATADIR, "nemo", filename, NULL);
+    }
+
+    return path;
+}
+
 #if !defined (NEMO_OMIT_SELF_CHECK)
 
 void

--- a/libnemo-private/nemo-file-utilities.h
+++ b/libnemo-private/nemo-file-utilities.h
@@ -101,4 +101,6 @@ void nemo_get_x_content_types_for_mount_async (GMount *mount,
 						   GCancellable *cancellable,
 						   gpointer user_data);
 
+gchar *nemo_file_lookup (const gchar *filename, const gchar *subdir);
+
 #endif /* NEMO_FILE_UTILITIES_H */

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -1053,6 +1053,39 @@ init_icons_and_styles (void)
 					   NEMO_DATADIR G_DIR_SEPARATOR_S "icons");
 }
 
+void
+nemo_application_set_css_provider (GtkWidget *widget)
+{
+  GtkCssProvider *provider;
+  gchar *filename;
+  GError *error = NULL;
+  GdkScreen *screen;
+
+  filename = nemo_file_lookup ("nemo.css", "data");
+
+  provider = gtk_css_provider_new ();
+
+  if (!gtk_css_provider_load_from_path (provider, filename, &error))
+    {
+      g_warning ("Failed to load css file '%s': %s", filename, error->message);
+      g_error_free (error);
+      goto out;
+    }
+
+  if (widget != NULL)
+    screen = gtk_widget_get_screen (widget);
+  else
+    screen = gdk_screen_get_default ();
+
+  gtk_style_context_add_provider_for_screen (screen,
+      GTK_STYLE_PROVIDER (provider),
+      GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+out:
+  g_free (filename);
+  g_object_unref (provider);
+}
+
 static void
 init_desktop (NemoApplication *self)
 {

--- a/src/nemo-application.h
+++ b/src/nemo-application.h
@@ -71,6 +71,8 @@ NemoApplication *nemo_application_get_singleton (void);
 
 void nemo_application_quit (NemoApplication *self);
 
+void nemo_application_set_css_provider (GtkWidget *widget);
+
 NemoWindow *     nemo_application_create_window (NemoApplication *application,
 							 GdkScreen           *screen);
 

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -548,6 +548,8 @@ nemo_window_constructed (GObject *self)
 
 	G_OBJECT_CLASS (nemo_window_parent_class)->constructed (self);
 
+    nemo_application_set_css_provider (GTK_WIDGET (window));
+
 	grid = gtk_grid_new ();
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (grid), GTK_ORIENTATION_VERTICAL);
 	gtk_widget_show (grid);


### PR DESCRIPTION
I'd like to discuss this a little bit - I know we already tried this briefly...

From http://developer.gnome.org/gtk3/3.5/GtkStyleContext.html#gtk-style-context-add-class :

> **If you are using custom styling on an applications, you probably want then to make your style
> information prevail to the theme's**, so you must use a GtkStyleProvider with the GTK_STYLE_PROVIDER_PRIORITY_APPLICATION priority, keep in mind that the user settings in 
> XDG_CONFIG_HOME/gtk-3.0/gtk.css will still take precedence over your changes, as it uses the GTK_STYLE_PROVIDER_PRIORITY_USER priority.

I believe this is a pretty good thought.

I think that if I'm Joe Appdeveloper, if I decide to package a custom .css file with my app, I want my app to use that file.  It will ensure consistent appearance regardless of what GTK theme I'm using on my system.  It also simplifies maintenance of the application - if I want to make a style change, I update the app, which makes sense - I don't go make a change to my system theme!

This also simplifies backporting.  For instance, right now, Nemo looks great on Nadia, which is what I develop on mostly.  But if you install it in Maya, or any system that doesn't have GTK 3.6 Mint-X theme active, it looks **awful**.

I don't think there should ANY Nemo style information in our mint-themes.  That should apply to generic dialogs and widgets.  Any Nemo-specific items should live IN Nemo.

So I think we got it right the first time, and shouldn't have reverted it.  This new patch is simpler - you really only need to apply the new style provider once, not on every class initialization.

Okay I await productive discussion!
