### PR TITLE
Improve control over which file manager manages the desktop.

### DIFF
--- a/data/nemo-autostart.desktop.in
+++ b/data/nemo-autostart.desktop.in
@@ -4,4 +4,5 @@ Name=Files
 Comment=Start Nemo desktop at log in
 Exec=nemo -n
 OnlyShowIn=GNOME;Unity;
+AutostartCondition=GSettings org.nemo.desktop show-desktop-icons
 NoDisplay=true

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -349,12 +349,16 @@
       <_description>If set to true, Nemo will only show folders in the tree side pane. Otherwise it will show both folders and files.</_description>
     </key>
   </schema>
-
   <schema id="org.nemo.desktop" path="/org/nemo/desktop/" gettext-domain="nemo">
     <key name="font" type="s">
       <default l10n="messages" context="desktop-font">''</default>
       <_summary>Desktop font</_summary>
       <_description>The font _description used for the icons on the desktop.</_description>
+    </key>
+    <key name="show-desktop-icons" type="b">
+      <default>true</default>
+      <_summary>Allow Nemo to manage the desktop</_summary>
+      <_description>If this is set to true, Nemo will autostart and manage the desktop</_description>
     </key>
     <key name="home-icon-visible" type="b">
       <default>true</default>

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -563,7 +563,7 @@ desktop_changed_callback (gpointer user_data)
 {
 	NemoApplication *application;
 	application = NEMO_APPLICATION (user_data);
-	if (g_settings_get_boolean (gnome_background_preferences, NEMO_PREFERENCES_SHOW_DESKTOP)) {
+	if (g_settings_get_boolean (nemo_desktop_preferences, NEMO_PREFERENCES_SHOW_DESKTOP)) {
 		nemo_application_open_desktop (application);
 	} else {
 		nemo_application_close_desktop ();
@@ -573,7 +573,7 @@ desktop_changed_callback (gpointer user_data)
 static void
 monitors_changed_callback (GdkScreen *screen, NemoApplication *application)
 {
-	if (g_settings_get_boolean (gnome_background_preferences, NEMO_PREFERENCES_SHOW_DESKTOP)) {
+	if (g_settings_get_boolean (nemo_desktop_preferences, NEMO_PREFERENCES_SHOW_DESKTOP)) {
 		nemo_application_close_desktop ();
 		nemo_application_open_desktop (application);
 	} else {
@@ -1111,7 +1111,7 @@ init_desktop (NemoApplication *self)
 	nemo_desktop_link_monitor_get ();
 
 	if (!self->priv->no_desktop &&
-	    !g_settings_get_boolean (gnome_background_preferences,
+	    !g_settings_get_boolean (nemo_desktop_preferences,
 				     NEMO_PREFERENCES_SHOW_DESKTOP)) {
 		self->priv->no_desktop = TRUE;
 	}
@@ -1121,7 +1121,7 @@ init_desktop (NemoApplication *self)
 	}
 
 	/* Monitor the preference to show or hide the desktop */
-	g_signal_connect_swapped (gnome_background_preferences, "changed::" NEMO_PREFERENCES_SHOW_DESKTOP,
+	g_signal_connect_swapped (nemo_desktop_preferences, "changed::" NEMO_PREFERENCES_SHOW_DESKTOP,
 				  G_CALLBACK (desktop_changed_callback),
 				  self);
 

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -294,7 +294,7 @@ get_eject_icon (NemoPlacesSidebar *sidebar,
 static gboolean
 should_show_desktop (void)
 {
-	return g_settings_get_boolean (gnome_background_preferences, NEMO_PREFERENCES_SHOW_DESKTOP) &&
+	return g_settings_get_boolean (nemo_desktop_preferences, NEMO_PREFERENCES_SHOW_DESKTOP) &&
 	       !g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_DESKTOP_IS_HOME_DIR);
 }
 
@@ -3775,7 +3775,7 @@ nemo_places_sidebar_init (NemoPlacesSidebar *sidebar)
 				  G_CALLBACK(desktop_setting_changed_callback),
 				  sidebar);
 
-	g_signal_connect_swapped (gnome_background_preferences, "changed::" NEMO_PREFERENCES_SHOW_DESKTOP,
+	g_signal_connect_swapped (nemo_desktop_preferences, "changed::" NEMO_PREFERENCES_SHOW_DESKTOP,
 				  G_CALLBACK(desktop_setting_changed_callback),
 				  sidebar);
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -9216,7 +9216,7 @@ real_update_menus (NemoView *view)
 
 
 	show_desktop_target =
-		g_settings_get_boolean (gnome_background_preferences, NEMO_PREFERENCES_SHOW_DESKTOP) &&
+		g_settings_get_boolean (nemo_desktop_preferences, NEMO_PREFERENCES_SHOW_DESKTOP) &&
 		!g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_DESKTOP_IS_HOME_DIR);
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,


### PR DESCRIPTION
This adds a new show-desktop-icons gsettings key to Nemo's preferences, along with adding control over the traditional key that Nautilus uses.  

Nautilus has an autostart condition that checks for schema org.gnome.desktop.background, key show-desktop-icons being true.  If we move Nemo's check to a different key, we can then reliably control which file manager autostarts and provides the desktop.

If Nautilus is not installed, the 'prevent Nautilus' option is not displayed, to prevent confusion.

This could partially address #38.
