### PR TITLE
Add "always show location entry" checkbox to preferences

### DIFF
--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -775,6 +775,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
 	bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_FOLDERS_FIRST_WIDGET,
 			   NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST);
+	bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LOCATION_ENTRY_WIDGET,
+			   NEMO_PREFERENCES_SHOW_LOCATION_ENTRY);
 	bind_builder_bool_inverted (builder, nemo_preferences,
 				    NEMO_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_BROWSER_WIDGET,
 				    NEMO_PREFERENCES_ALWAYS_USE_BROWSER);

--- a/src/nemo-file-management-properties.ui
+++ b/src/nemo-file-management-properties.ui
@@ -223,6 +223,23 @@
                                 <property name="position">3</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="show_location_entry_checkbutton">
+                                <property name="label"
+                                     translatable="yes">Always show location ent_ry</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
This exposes the 'show-location-entry' setting (previously known as
always_use_location_entry in nautilus)
