### PR TITLE
Don't leave the view in a questionable state when trying to enter a...

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -3886,6 +3886,9 @@ load_error_callback (NemoDirectory *directory,
 	 */
 	nemo_view_stop_loading (view);
 
+    nemo_window_back_or_forward (nemo_view_get_containing_window (view),
+                                 TRUE, 0, FALSE);
+
 	/* Emit a signal to tell subclasses that a load error has
 	 * occurred, so they can handle it in the UI.
 	 */


### PR DESCRIPTION
forbidden directory.  Go back to the previous location.

Addresses #85.

If we try to enter a directory that isn't allowed, we should just stop - not enter some shadowy underworld of an empty view - just stay in the previous location.
