### PR TITLE
Fix Open in Terminal - currently selecting the option with a file

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -6521,7 +6521,6 @@ action_open_in_terminal_callback(GtkAction *action,
 {
 	NemoView *view;
 	GList *selection;
-    GFile *location;
 
 	view = NEMO_VIEW (callback_data);
 	selection = nemo_view_get_selection (view);


### PR DESCRIPTION
selected does nothing, and selecting the option from the desktop
background opens either the home directory instead, or, if another
terminal window is open, another copy of that terminal location.

This opens the parent directory of the selected file, and also
correctly opens the desktop directory when right-clicking from
the desktop background.

Fixes #131
