### PR TITLE
Replaced GNOME references with Cinnamon in packaging description.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,10 +52,10 @@ Breaks: gnome-volume-manager (<< 2.24),
         rhythmbox (<< 0.12),
         gnome-session (<< 2.28),
         gnome-bluetooth (<< 3.0)
-Description: file manager and graphical shell for GNOME
- Nemo is the official file manager for the GNOME desktop. It allows
+Description: file manager and graphical shell for Cinnamon
+ Nemo is the official file manager for the Cinnamon desktop. It allows
  to browse directories, preview files and launch applications associated
- with them. It is also responsible for handling the icons on the GNOME
+ with them. It is also responsible for handling the icons on the Cinnamon
  desktop. It works on local and remote filesystems.
  .
  Several icon themes and components for viewing different kinds of files
@@ -68,10 +68,10 @@ Priority: extra
 Depends: nemo (= ${binary:Version}),
          ${misc:Depends}
 Replaces: libnemo-extension1-dbg
-Description: file manager and graphical shell for GNOME - debugging version
- Nemo is the official file manager for the GNOME desktop. It allows
+Description: file manager and graphical shell for Cinnamon - debugging version
+ Nemo is the official file manager for the Cinnamon desktop. It allows
  to browse directories, preview files and launch applications associated
- with them. It is also responsible for handling the icons on the GNOME
+ with them. It is also responsible for handling the icons on the Cinnamon
  desktop. It works on local and remote filesystems.
  .
  Several icon themes and components for viewing different kinds of files
@@ -90,7 +90,7 @@ Replaces: libnemo-extension1a
 breaks: libnemo-extension1a
 Description: libraries for nemo components - runtime version
  Nemo is the official file manager and graphical shell for the
- GNOME desktop.
+ Cinnamon desktop.
  .
  This package contains a few runtime libraries needed by nemo' extensions.
 
@@ -105,7 +105,7 @@ Depends: libnemo-extension1 (= ${binary:Version}),
          ${misc:Depends}
 Description: libraries for nemo components - development version
  Nemo is the official file manager and graphical shell for the
- GNOME desktop.
+ Cinnamon desktop.
  .
  This package provides the necessary development libraries and include
  files to develop and compile Nemo extensions.
@@ -120,7 +120,7 @@ Conflicts: gir1.0-nemo-3.0
 Replaces: gir1.0-nemo-3.0
 Description: libraries for nemo components - gir bindings
  Nemo is the official file manager and graphical shell for the
- GNOME desktop.
+ Cinnamon desktop.
  .
  This package can be used by other packages using the GIRepository format to
  generate dynamic bindings.
@@ -131,7 +131,7 @@ Depends: ${misc:Depends}
 Suggests: nemo
 Description: data files for nemo
  Nemo is the official file manager and graphical shell for the
- GNOME desktop.
+ Cinnamon desktop.
  .
  This package contains pictures, localization files and other data
  needed by nemo.


### PR DESCRIPTION
Just a find/replace in the packaging details so Nemo is no longer
described as the official file manager of the GNOME desktop, but rather
the official file manager of the Cinnamon desktop.
