### PR TITLE
Use regular icons for the zoom buttons so they grey out properly

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -12,8 +12,8 @@ public_icons = \
 	hicolor_apps_scalable_nemo.svg \
 	hicolor_actions_scalable_view-compact-symbolic.svg \
 	hicolor_actions_scalable_location-symbolic.svg \
-	hicolor_actions_scalable_nemo-zoom-in-symbolic.svg \
-	hicolor_actions_scalable_nemo-zoom-out-symbolic.svg
+	hicolor_actions_scalable_nemo-zoom-in.svg \
+	hicolor_actions_scalable_nemo-zoom-out.svg
 	$(NULL)
 
 private_icons = \

--- a/data/icons/hicolor_actions_scalable_nemo-zoom-in.svg
+++ b/data/icons/hicolor_actions_scalable_nemo-zoom-in.svg
@@ -14,7 +14,7 @@
    width="15.982"
    version="1.1"
    inkscape:version="0.48.3.1 r9886"
-   sodipodi:docname="hicolor_actions_scalable_nemo-zoom-in-symbolic.svg">
+   sodipodi:docname="hicolor_actions_scalable_nemo-zoom-in.svg">
   <defs
      id="defs9" />
   <sodipodi:namedview
@@ -27,14 +27,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="995"
      id="namedview7"
      showgrid="false"
      inkscape:zoom="20.85965"
-     inkscape:cx="17.223374"
+     inkscape:cx="9.0257293"
      inkscape:cy="6.6180572"
      inkscape:window-x="0"
-     inkscape:window-y="25"
+     inkscape:window-y="30"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer12" />
   <metadata
@@ -55,7 +55,14 @@
      id="layer12"
      transform="translate(-181 -667)">
     <rect
-       style="fill:#bebebe;fill-opacity:1;stroke:none"
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       id="rect3754"
+       width="3"
+       height="10"
+       x="187.37595"
+       y="669.9798" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none"
        id="rect3756"
        width="10"
        height="3"

--- a/data/icons/hicolor_actions_scalable_nemo-zoom-out.svg
+++ b/data/icons/hicolor_actions_scalable_nemo-zoom-out.svg
@@ -14,7 +14,7 @@
    width="15.982"
    version="1.1"
    inkscape:version="0.48.3.1 r9886"
-   sodipodi:docname="hicolor_actions_scalable_nemo-zoom-in-symbolic.svg">
+   sodipodi:docname="hicolor_actions_scalable_nemo-zoom-out.svg">
   <defs
      id="defs9" />
   <sodipodi:namedview
@@ -27,14 +27,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="995"
      id="namedview7"
      showgrid="false"
      inkscape:zoom="20.85965"
-     inkscape:cx="17.223374"
+     inkscape:cx="9.0257293"
      inkscape:cy="6.6180572"
      inkscape:window-x="0"
-     inkscape:window-y="25"
+     inkscape:window-y="30"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer12" />
   <metadata
@@ -55,14 +55,7 @@
      id="layer12"
      transform="translate(-181 -667)">
     <rect
-       style="fill:#bebebe;fill-opacity:1;stroke:none"
-       id="rect3754"
-       width="3"
-       height="10"
-       x="187.37595"
-       y="669.9798" />
-    <rect
-       style="fill:#bebebe;fill-opacity:1;stroke:none"
+       style="fill:#000000;fill-opacity:1;stroke:none"
        id="rect3756"
        width="10"
        height="3"

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1314,7 +1314,7 @@ nemo_window_create_toolbar_action_group (NemoWindow *window)
                       G_CALLBACK (action_zoom_out_callback),
                       window);
     gtk_action_group_add_action (action_group, action);
-    gtk_action_set_icon_name (GTK_ACTION (action), "nemo-zoom-out-symbolic");
+    gtk_action_set_icon_name (GTK_ACTION (action), "nemo-zoom-out");
     g_object_unref (action);
 
     action = GTK_ACTION (gtk_action_new (NEMO_ACTION_TOOLBAR_ZOOM_NORMAL,
@@ -1336,7 +1336,7 @@ nemo_window_create_toolbar_action_group (NemoWindow *window)
                       G_CALLBACK (action_zoom_in_callback),
                       window);
     gtk_action_group_add_action (action_group, action);
-    gtk_action_set_icon_name (GTK_ACTION (action), "nemo-zoom-in-symbolic");
+    gtk_action_set_icon_name (GTK_ACTION (action), "nemo-zoom-in");
     g_object_unref (action);
 
     action = GTK_ACTION (gtk_toggle_action_new (NEMO_ACTION_ICON_VIEW,


### PR DESCRIPTION
when maximum zoom limits are reached.
