### PR TITLE
Fix custom style classes for nemo-cell-renderer-disk.c:

### DIFF
--- a/libnemo-private/nemo-cell-renderer-disk.c
+++ b/libnemo-private/nemo-cell-renderer-disk.c
@@ -173,39 +173,8 @@ nemo_cell_renderer_disk_render (GtkCellRenderer       *cell,
 
 
     if (show) {
+
         context = gtk_widget_get_style_context (widget);
-
-        GtkCssProvider *provider = gtk_css_provider_new ();
-        gtk_style_context_add_provider (context, GTK_STYLE_PROVIDER (provider),
-                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        gtk_css_provider_load_from_data (GTK_CSS_PROVIDER (provider),
-                                         ".nemo-disk-renderer-bg {"
-                                         "      border-radius: 1px;"
-                                         "      border-style: solid;"
-                                         "      border-width: 1px;"
-                                         "      border-color: shade(@theme_bg_color, .65);"
-                                         "}"
-                                         ".nemo-disk-renderer-bg row:selected {"
-                                         "      border-radius: 1px;"
-                                         "      border-style: solid;"
-                                         "      border-width: 1px;"
-                                         "      border-color: shade(@theme_bg_color, 2.0);"
-                                         "}"
-                                         ".nemo-disk-renderer-fg {"
-                                         "      border-radius: 1px;"
-                                         "      border-style: solid;"
-                                         "      border-width: 1px;"
-                                         "      border-color: shade(@theme_selected_bg_color, 1.0);"
-                                         "}"
-                                         ".nemo-disk-renderer-fg row:selected {"
-                                         "      border-radius: 1px;"
-                                         "      border-style: solid;"
-                                         "      border-width: 1px;"
-                                         "      border-color: shade(@theme_fg_color, 2.0);"
-                                         "}",
-                                         -1, NULL);
-        g_object_unref (provider);
 
         gtk_cell_renderer_get_padding (cell, &xpad, &ypad);
         x = cell_area->x + xpad;

--- a/src/nemo-style.css
+++ b/src/nemo-style.css
@@ -1,0 +1,35 @@
+/* for nemo-cell-renderer-disk.c */
+
+.nemo-disk-renderer-bg {
+    border-radius: 1px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: shade(@theme_bg_color, .65);
+}
+
+.nemo-disk-renderer-bg row:selected {
+    border-radius: 1px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: shade(@theme_bg_color, 2.0);
+}
+
+.nemo-disk-renderer-fg {
+    border-radius: 1px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: shade(@theme_selected_bg_color, 1.0);
+}
+
+.nemo-disk-renderer-fg row:selected {
+    border-radius: 1px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: shade(@theme_fg_color, 2.0);
+}
+
+
+
+.nemo-inactive-pane .view {
+    background-color: shade(@theme_base_color, 0.9);
+}

--- a/src/nemo.gresource.xml
+++ b/src/nemo.gresource.xml
@@ -11,5 +11,6 @@
     <file>nemo-shell-ui.xml</file>
     <file alias="icons/thumbnail_frame.png">../icons/thumbnail_frame.png</file>
     <file alias="icons/knob.png">../icons/knob.png</file>
+    <file>nemo-style.css</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
On most themes, the way we had it worked just fine, however
on Adwaita, or, it seems, any theme using a compiled .gresource
file, we would get a 100% cpu draw on Nemo.

Applying the custom styles from our own .gresource file and loading
it once only on startup solves this issue.
