### PR TITLE
Share show-hidden preference with GTK Filechooser

### DIFF
--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -825,7 +825,8 @@ static gboolean show_hidden_files = TRUE;
 static void
 show_hidden_files_changed_callback (gpointer callback_data)
 {
-	show_hidden_files = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
+	show_hidden_files = g_settings_get_boolean (gtk_filechooser_preferences,
+                                                NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
 }
 
 static gboolean
@@ -835,7 +836,7 @@ should_skip_file (NemoDirectory *directory, GFileInfo *info)
 
 	/* Add the callback once for the life of our process */
 	if (!show_hidden_files_changed_callback_installed) {
-		g_signal_connect_swapped (nemo_preferences,
+		g_signal_connect_swapped (gtk_filechooser_preferences,
 					  "changed::" NEMO_PREFERENCES_SHOW_HIDDEN_FILES,
 					  G_CALLBACK(show_hidden_files_changed_callback),
 					  NULL);

--- a/libnemo-private/nemo-directory.c
+++ b/libnemo-private/nemo-directory.c
@@ -300,7 +300,7 @@ add_preferences_callbacks (void)
 {
 	nemo_global_preferences_init ();
 
-	g_signal_connect_swapped (nemo_preferences,
+	g_signal_connect_swapped (gtk_filechooser_preferences,
 				  "changed::" NEMO_PREFERENCES_SHOW_HIDDEN_FILES,
 				  G_CALLBACK(filtering_changed_callback),
 				  NULL);

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -78,4 +78,7 @@ nemo_global_preferences_init (void)
 	gnome_lockdown_preferences = g_settings_new("org.gnome.desktop.lockdown");
 	gnome_background_preferences = g_settings_new("org.gnome.desktop.background");
     gnome_media_handling_preferences = g_settings_new("org.gnome.desktop.media-handling");
+
+    gtk_filechooser_preferences = g_settings_new_with_path ("org.gtk.Settings.FileChooser",
+                                                            "/org/gtk/settings/file-chooser/");
 }

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 #define NEMO_PREFERENCES_DESKTOP_IS_HOME_DIR                "desktop-is-home-dir"
 
 /* Display  */
-#define NEMO_PREFERENCES_SHOW_HIDDEN_FILES			"show-hidden-files"
+#define NEMO_PREFERENCES_SHOW_HIDDEN_FILES			"show-hidden"
 #define NEMO_PREFERENCES_SHOW_ADVANCED_PERMISSIONS		"show-advanced-permissions"
 #define NEMO_PREFERENCES_DATE_FORMAT			"date-format"
 
@@ -222,6 +222,8 @@ GSettings *nemo_window_state;
 GSettings *gnome_lockdown_preferences;
 GSettings *gnome_background_preferences;
 GSettings *gnome_media_handling_preferences;
+
+GSettings *gtk_filechooser_preferences;
 
 G_END_DECLS
 

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -233,7 +233,7 @@
     <key name="show-hidden-files" type="b">
       <default>false</default>
       <_summary>Whether to show hidden files</_summary>
-      <_description>If set to true, then hidden files are shown by default in the file manager.  Hidden files are either dotfiles, listed in the folder's .hidden file or backup files ending with a tilde (~).</_description>
+      <_description>This key is deprecated and ignored. The "show-hidden" key from "org.gtk.Settings.FileChooser" is now used instead.</_description>
     </key>
     <key name="show-full-path-titles" type="b">
       <default>false</default>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -795,7 +795,7 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
 	bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_DELETE_WIDGET,
 			   NEMO_PREFERENCES_ENABLE_DELETE);
-	bind_builder_bool (builder, nemo_preferences,
+	bind_builder_bool (builder, gtk_filechooser_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_HIDDEN_WIDGET,
 			   NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
 	bind_builder_bool (builder, nemo_preferences,

--- a/src/nemo-tree-sidebar.c
+++ b/src/nemo-tree-sidebar.c
@@ -1441,7 +1441,7 @@ update_filtering_from_preferences (FMTreeView *view)
 	if (mode == NEMO_WINDOW_SHOW_HIDDEN_FILES_DEFAULT) {
 		fm_tree_model_set_show_hidden_files
 			(view->details->child_model,
-			 g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
+			 g_settings_get_boolean (gtk_filechooser_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
 	} else {
 		fm_tree_model_set_show_hidden_files
 			(view->details->child_model,
@@ -1506,7 +1506,7 @@ fm_tree_view_init (FMTreeView *view)
 	
 	view->details->selecting = FALSE;
 
-	g_signal_connect_swapped (nemo_preferences,
+	g_signal_connect_swapped (gtk_filechooser_preferences,
 				  "changed::" NEMO_PREFERENCES_SHOW_HIDDEN_FILES,
 				  G_CALLBACK(filtering_changed_callback),
 				  view);

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7471,7 +7471,7 @@ nemo_view_init_show_hidden_files (NemoView *view)
 	mode = nemo_window_get_hidden_files_mode (view->details->window);
 
 	if (mode == NEMO_WINDOW_SHOW_HIDDEN_FILES_DEFAULT) {
-		show_hidden_default_setting = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
+		show_hidden_default_setting = g_settings_get_boolean (gtk_filechooser_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
 		if (show_hidden_default_setting != view->details->show_hidden_files) {
 			view->details->show_hidden_files = show_hidden_default_setting;
 			show_hidden_changed = TRUE;

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -286,7 +286,7 @@ show_hidden_files_preference_callback (gpointer callback_data)
 		/* update button */
 		g_signal_handlers_block_by_func (action, action_show_hidden_files_callback, window);
 		gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
-					      g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
+					      g_settings_get_boolean (gtk_filechooser_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
 		g_signal_handlers_unblock_by_func (action, action_show_hidden_files_callback, window);
 
 		/* inform views */
@@ -1505,11 +1505,11 @@ nemo_window_initialize_menus (NemoWindow *window)
 	action = gtk_action_group_get_action (action_group, NEMO_ACTION_SHOW_HIDDEN_FILES);
 	g_signal_handlers_block_by_func (action, action_show_hidden_files_callback, window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
-				      g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
+				      g_settings_get_boolean (gtk_filechooser_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES));
 	g_signal_handlers_unblock_by_func (action, action_show_hidden_files_callback, window);
 
 
-	g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_SHOW_HIDDEN_FILES,
+	g_signal_connect_swapped (gtk_filechooser_preferences, "changed::" NEMO_PREFERENCES_SHOW_HIDDEN_FILES,
 				  G_CALLBACK(show_hidden_files_preference_callback),
 				  window);
 


### PR DESCRIPTION
Note in ubuntu this has appears to have limited effect (for now)
since many apps still use the gtk-2.0 folder location for gtk settings
#120

from:
https://bugzilla.gnome.org/show_bug.cgi?id=143599
