### PR TITLE
Recommend app-install-data:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,8 @@ Depends: ${shlibs:Depends},
 Recommends: eject,
             librsvg2-common,
             gvfs-backends,
-            nemo-fileroller
+            nemo-fileroller,
+            app-install-data
 Suggests: eog,
           evince | pdf-viewer,
           totem | mp3-decoder,


### PR DESCRIPTION
This is needed for the "Find applications online" selection in the
Open with other application dialog. (I believe this is an Ubuntu GTK-
only thing)
