### PR TITLE
Properly render the thumbnail when viewing a folder in icon mode

### DIFF
--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -111,16 +111,29 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
 	if (emblem_icons != NULL) {
 		l = emblem_icons;
 
-		emblem = g_emblem_new (l->data);
+
 		pixbuf = nemo_icon_info_get_pixbuf (icon_info);
 
         gint w, h, s;
+        gboolean bad_ratio;
+
         w = gdk_pixbuf_get_width (pixbuf);
         h = gdk_pixbuf_get_height (pixbuf);
 
         s = MAX (w, h);
         if (s < size)
             size = s;
+
+        bad_ratio = nemo_icon_get_emblem_size_for_icon_size (size) > w ||
+                    nemo_icon_get_emblem_size_for_icon_size (size) > h;
+
+        if (bad_ratio)
+            goto skip_emblem; /* Would prefer to not use goto, but
+                               * I don't want to do these checks on
+                               * non-emblemed icons (the majority)
+                               * as it would be too costly */
+
+        emblem = g_emblem_new (l->data);
 
 		emblemed_icon = g_emblemed_icon_new (G_ICON (pixbuf), emblem);
 		g_object_unref (emblem);
@@ -134,9 +147,11 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
 
 		g_clear_object (&icon_info);
 		icon_info = nemo_icon_info_lookup (emblemed_icon, size);
+        g_object_unref (emblemed_icon);
 
+skip_emblem:
 		g_object_unref (pixbuf);
-		g_object_unref (emblemed_icon);
+
 	}
 
 	if (emblem_icons != NULL) {

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -313,7 +313,21 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
 				}
 			}
 
-			gicon = G_ICON (nemo_file_get_icon_pixbuf (file, icon_size, TRUE, flags));
+            GdkPixbuf *pixbuf = nemo_file_get_icon_pixbuf (file, icon_size, TRUE, flags);
+
+            gint w, h, s;
+            gboolean bad_ratio;
+            w = gdk_pixbuf_get_width (pixbuf);
+            h = gdk_pixbuf_get_height (pixbuf);
+
+            s = MAX (w, h);
+            if (s < icon_size)
+                icon_size = s;
+
+            bad_ratio = nemo_icon_get_emblem_size_for_icon_size (icon_size) > w ||
+                        nemo_icon_get_emblem_size_for_icon_size (icon_size) > h;
+
+			gicon = G_ICON (pixbuf);
 
 			/* render emblems with GEmblemedIcon */
 			parent_file = nemo_file_get_parent (file);
@@ -331,7 +345,7 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
 								       emblems_to_ignore);
 
 			/* pick only the first emblem we can render for the list view */
-			for (l = emblem_icons; l != NULL; l = l->next) {
+			for (l = emblem_icons; !bad_ratio && l != NULL; l = l->next) {
 				emblem_icon = l->data;
 				if (nemo_icon_theme_can_render (G_THEMED_ICON (emblem_icon))) {
 					emblem = g_emblem_new (emblem_icon);


### PR DESCRIPTION
and the file icons are smaller than the view-specified size.

To reproduce -

Enter /usr/share/icons/Mint-X/apps/16 at 'standard' zoom level.

You get lots of log spam, and the emblem for sym-linked files does
not scale with the icon size, or doesn't show at all, in the case
of a 16px icon, it is trying to place 24px emblem on top of it,
which doesn't work.  It works improperly for larger icon sizes -
the emblem renders, but is so large as to cover the file icon almost
completely.

This patch checks the _actual_ size of the pixmap before trying to
apply the emblems, and adjusts the desired size accordingly.  As a
result, the emblems apply and are scaled appropriately to the icon
size.

Second commit addresses above issue in list views, as well as doing some
sanity checking of extreme width/height pixmaps (like partial screenshots) - 
on icons where an emblem wants to be shown, it will be skipped if it would not
have fit in the pixmap (it already does this, but it does it by failing and throwing
an error - this simply prevents the error situation from occurring).
