### PR TITLE
Add an option to bring back the old behavior of closing the tab or window

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -109,6 +109,7 @@ typedef enum
 
 #define NEMO_PREFERENCES_SHOW_FULL_PATH_TITLES      "show-full-path-titles"
 
+#define NEMO_PREFERENCES_CLOSE_DEVICE_VIEW_ON_EJECT "close-device-view-on-device-eject"
 
 enum
 {

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -250,6 +250,11 @@
         <_summary>Prefixes used for file sizes</_summary>
         <_description>Determines whether Nemo uses base-10, base-10 long, base-2 or base-2 long file size prefixes</_description>
     </key>
+    <key name="close-device-view-on-device-eject" type="b">
+      <default>false</default>
+      <_summary>Whether to close a view of a removeable device instead of navigating Home</_summary>
+      <_description>If set to true, a view open for a removeable device will be closed instead of sent Home if the device is ejected</_description>
+    </key>
   </schema>
 
   <schema id="org.nemo.icon-view" path="/org/nemo/icon-view/" gettext-domain="nemo">

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -679,7 +679,10 @@ mount_removed_callback (GVolumeMonitor *monitor,
 		slot = node->data;
 
 		if (slot != force_no_close_slot) {
-            nemo_window_slot_go_home (slot, FALSE);
+            if (g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_CLOSE_DEVICE_VIEW_ON_EJECT))
+                nemo_window_pane_slot_close (slot->pane, slot);
+            else
+                nemo_window_slot_go_home (slot, FALSE);
 		} else {
 			computer = g_file_new_for_path (g_get_home_dir ());
 			nemo_window_slot_go_to (slot, computer, FALSE);

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -73,6 +73,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SEARCH_ICON_TOOLBAR_WIDGET "show_search_icon_toolbar_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LABEL_SEARCH_ICON_TOOLBAR_WIDGET "show_label_search_icon_toolbar_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_FULL_PATH_IN_TITLE_BARS_WIDGET "show_full_path_in_title_bars_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_CLOSE_DEVICE_VIEW_ON_EJECT_WIDGET "close_device_view_on_eject_checkbutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTOMOUNT_MEDIA_WIDGET "media_automount_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTOOPEN_MEDIA_WIDGET "media_autoopen_checkbutton"
@@ -873,6 +874,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
     bind_builder_bool_inverted (builder, gnome_media_handling_preferences,
                NEMO_FILE_MANAGEMENT_PROPERTIES_AUTORUN_MEDIA_WIDGET,
                GNOME_DESKTOP_MEDIA_HANDLING_AUTORUN);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_CLOSE_DEVICE_VIEW_ON_EJECT_WIDGET,
+                       NEMO_PREFERENCES_CLOSE_DEVICE_VIEW_ON_EJECT);
 
 	nemo_file_management_properties_dialog_setup_icon_caption_page (builder);
 	nemo_file_management_properties_dialog_setup_list_column_page (builder);

--- a/src/nemo-file-management-properties.ui
+++ b/src/nemo-file-management-properties.ui
@@ -1015,6 +1015,22 @@
                                 <property name="position">2</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="close_device_view_on_eject_checkbutton">
+                                <property name="label" translatable="yes">Automatically close the device's tab, pane, or window when a device is unmounted or ejected</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
of a device when it is unmounted or ejected.  This defaults to off (maintaining
the current behavior of going to the Home folder on eject.

See #180
