### PR TITLE
 Add context menu item 'Follow link to original file' when a symbolic link file is selected

### DIFF
--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -148,4 +148,6 @@
 
 #define NEMO_ACTION_ADD_DESKLETS_DESKTOP "Add Desklets"
 
+#define NEMO_ACTION_FOLLOW_SYMLINK "FollowSymbolicLink"
+
 #endif /* NEMO_ACTIONS_H */

--- a/src/nemo-directory-view-ui.xml
+++ b/src/nemo-directory-view-ui.xml
@@ -186,6 +186,7 @@
 	<separator name="Advanced separator"/>
 	<menuitem name="OpenInTerminal" action="OpenInTerminal"/>
 	<menuitem name="OpenAsRoot" action="OpenAsRoot"/>
+    <menuitem name="FollowSymbolicLink" action="FollowSymbolicLink"/>
 	<menuitem name="MailToThunderbird" action="MailToThunderbird"/>
 	<menuitem name="MailToOther" action="MailToOther"/>
 	<menuitem name="SetAsWallPaper" action="SetAsWallPaper"/>


### PR DESCRIPTION
Upon selecting this, the current view will navigate to the folder containing the target, and select that file.

Addresses #134 
