### PR TITLE
Read the default terminal app from GSettings

### DIFF
--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -77,5 +77,6 @@ nemo_global_preferences_init (void)
 	nemo_tree_sidebar_preferences = g_settings_new("org.nemo.sidebar-panels.tree");
 	gnome_lockdown_preferences = g_settings_new("org.gnome.desktop.lockdown");
 	gnome_background_preferences = g_settings_new("org.gnome.desktop.background");
-    gnome_media_handling_preferences = g_settings_new("org.gnome.desktop.media-handling");
+	gnome_media_handling_preferences = g_settings_new("org.gnome.desktop.media-handling");
+	gnome_terminal_preferences = g_settings_new("org.gnome.desktop.default-applications.terminal");
 }

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -211,6 +211,9 @@ typedef enum
 #define GNOME_DESKTOP_MEDIA_HANDLING_AUTOMOUNT_OPEN "automount-open"
 #define GNOME_DESKTOP_MEDIA_HANDLING_AUTORUN        "autorun-never"
 
+/* Terminal */
+#define GNOME_DESKTOP_TERMINAL_EXEC        "exec"
+
 void nemo_global_preferences_init                      (void);
 char *nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void);
 
@@ -224,6 +227,7 @@ GSettings *nemo_window_state;
 GSettings *gnome_lockdown_preferences;
 GSettings *gnome_background_preferences;
 GSettings *gnome_media_handling_preferences;
+GSettings *gnome_terminal_preferences;
 
 G_END_DECLS
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -6723,7 +6723,8 @@ static void
 open_in_terminal (gchar *location)
 {	
     gchar *argv[2];
-    argv[0] = "x-terminal-emulator";
+    argv[0] = g_settings_get_string (gnome_terminal_preferences,
+				     GNOME_DESKTOP_TERMINAL_EXEC);
     argv[1] = NULL;
     g_spawn_async(location, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }


### PR DESCRIPTION
x-terminal-emulator is a Debian specific thing, which is not available
in other distros. The config is available in gsettings-desktop-shemas.
