### PR TITLE
When using panes, don't reset the selection each time the inactive pane is made active again.

### DIFF
--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -2343,6 +2343,20 @@ focus_in_event_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_
 	return FALSE; 
 }
 
+static gboolean
+button_press_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_data)
+{
+    NemoIconView *view = NEMO_ICON_VIEW (user_data);
+
+    if (!nemo_view_get_active (NEMO_VIEW (view))) {
+        NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
+        nemo_window_slot_make_hosting_pane_active (slot);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 static NemoIconContainer *
 create_icon_container (NemoIconView *icon_view)
 {
@@ -2355,6 +2369,9 @@ create_icon_container (NemoIconView *icon_view)
 	
 	gtk_widget_set_can_focus (GTK_WIDGET (icon_container), TRUE);
 	
+
+    g_signal_connect_object (icon_container, "button_press_event",
+                 G_CALLBACK (button_press_callback), icon_view, 0);
 	g_signal_connect_object (icon_container, "focus_in_event",
 				 G_CALLBACK (focus_in_event_callback), icon_view, 0);
 	g_signal_connect_object (icon_container, "activate",	

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -659,6 +659,12 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
 		return FALSE;
 	}
 
+    if (!nemo_view_get_active (NEMO_VIEW (view))) {
+        NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
+        nemo_window_slot_make_hosting_pane_active (slot);
+        return TRUE;
+    }
+
 	nemo_list_model_set_drag_view
 		(NEMO_LIST_MODEL (gtk_tree_view_get_model (tree_view)),
 		 tree_view,


### PR DESCRIPTION
For example, you select some files in the left pane, then switch to the
right pane, do some navigation, then click back in the original (now
inactive) pane.

With the current behavior, the original selection is cleared as the pane
is made active again.  This patch prevents this, using the first click back
into the inactive pane to make the pane active _only_, not affecting the
existing selection.
