### PR TITLE
Change file count behavior across the board to include hidden and backup files

### DIFF
--- a/libnemo-private/nemo-desktop-directory-file.c
+++ b/libnemo-private/nemo-desktop-directory-file.c
@@ -371,7 +371,8 @@ desktop_directory_file_check_if_ready (NemoFile *file,
 static gboolean
 desktop_directory_file_get_item_count (NemoFile *file, 
 				       guint *count,
-				       gboolean *count_unreadable)
+				       gboolean *count_unreadable,
+                       gboolean *has_hidden)
 {
 	NemoDesktopDirectoryFile *desktop_file;
 	gboolean got_count;
@@ -380,7 +381,8 @@ desktop_directory_file_get_item_count (NemoFile *file,
 	
 	got_count = nemo_file_get_directory_item_count (desktop_file->details->real_dir_file,
 							    count,
-							    count_unreadable);
+							    count_unreadable,
+                                has_hidden);
 
 	if (count) {
 		*count += g_list_length (file->details->directory->details->file_list);
@@ -394,7 +396,8 @@ desktop_directory_file_get_deep_counts (NemoFile *file,
 					guint *directory_count,
 					guint *file_count,
 					guint *unreadable_directory_count,
-					goffset *total_size)
+					goffset *total_size,
+                    gboolean *has_hidden)
 {
 	NemoDesktopDirectoryFile *desktop_file;
 	NemoRequestStatus status;
@@ -406,6 +409,7 @@ desktop_directory_file_get_deep_counts (NemoFile *file,
 						file_count,
 						unreadable_directory_count,
 						total_size,
+                        has_hidden,
 						TRUE);
 
 	if (file_count) {

--- a/libnemo-private/nemo-desktop-icon-file.c
+++ b/libnemo-private/nemo-desktop-icon-file.c
@@ -98,7 +98,8 @@ desktop_icon_file_check_if_ready (NemoFile *file,
 static gboolean
 desktop_icon_file_get_item_count (NemoFile *file, 
 				  guint *count,
-				  gboolean *count_unreadable)
+				  gboolean *count_unreadable,
+                  gboolean *has_hidden)
 {
 	if (count != NULL) {
 		*count = 0;
@@ -106,6 +107,9 @@ desktop_icon_file_get_item_count (NemoFile *file,
 	if (count_unreadable != NULL) {
 		*count_unreadable = FALSE;
 	}
+    if (has_hidden != NULL) {
+        *has_hidden = FALSE;
+    }
 	return TRUE;
 }
 
@@ -114,7 +118,8 @@ desktop_icon_file_get_deep_counts (NemoFile *file,
 				   guint *directory_count,
 				   guint *file_count,
 				   guint *unreadable_directory_count,
-				   goffset *total_size)
+				   goffset *total_size,
+                   gboolean *has_hidden)
 {
 	if (directory_count != NULL) {
 		*directory_count = 0;
@@ -128,6 +133,9 @@ desktop_icon_file_get_deep_counts (NemoFile *file,
 	if (total_size != NULL) {
 		*total_size = 0;
 	}
+    if (has_hidden != NULL) {
+        *has_hidden = FALSE;
+    }
 
 	return NEMO_REQUEST_DONE;
 }

--- a/libnemo-private/nemo-directory-private.h
+++ b/libnemo-private/nemo-directory-private.h
@@ -136,6 +136,8 @@ struct NemoDirectoryDetails
 	GList *file_operations_in_progress; /* list of FileOperation * */
 
 	GHashTable *hidden_file_hash;
+
+    gboolean has_hidden;
 };
 
 NemoDirectory *nemo_directory_get_existing                    (GFile                     *location);

--- a/libnemo-private/nemo-file-private.h
+++ b/libnemo-private/nemo-file-private.h
@@ -95,7 +95,10 @@ struct NemoFileDetails
 	guint deep_directory_count;
 	guint deep_file_count;
 	guint deep_unreadable_count;
+    gboolean deep_has_hidden;
 	goffset deep_size;
+
+    gboolean has_hidden;
 
 	GIcon *icon;
 	

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -196,13 +196,15 @@ gboolean                nemo_file_is_desktop_directory              (NemoFile   
 GError *                nemo_file_get_file_info_error               (NemoFile                   *file);
 gboolean                nemo_file_get_directory_item_count          (NemoFile                   *file,
 									 guint                          *count,
-									 gboolean                       *count_unreadable);
+									 gboolean                       *count_unreadable,
+                                     gboolean                       *has_hidden);
 void                    nemo_file_recompute_deep_counts             (NemoFile                   *file);
 NemoRequestStatus   nemo_file_get_deep_counts                   (NemoFile                   *file,
 									 guint                          *directory_count,
 									 guint                          *file_count,
 									 guint                          *unreadable_directory_count,
-									 goffset               *total_size,
+									 goffset                        *total_size,
+                                     gboolean                       *has_hidden,
 									 gboolean                        force);
 gboolean                nemo_file_should_show_thumbnail             (NemoFile                   *file);
 gboolean                nemo_file_should_show_directory_item_count  (NemoFile                   *file);
@@ -518,12 +520,14 @@ typedef struct {
 							  NemoFileAttributes  attributes);
 	gboolean              (* get_item_count)         (NemoFile           *file,
 							  guint                  *count,
-							  gboolean               *count_unreadable);
+							  gboolean               *count_unreadable,
+                              gboolean               *has_hidden);
 	NemoRequestStatus (* get_deep_counts)        (NemoFile           *file,
 							  guint                  *directory_count,
 							  guint                  *file_count,
 							  guint                  *unreadable_directory_count,
-							  goffset       *total_size);
+							  goffset       *total_size,
+                              gboolean               *has_hidden);
 	gboolean              (* get_date)               (NemoFile           *file,
 							  NemoDateType        type,
 							  time_t                 *date);

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -6901,9 +6901,16 @@ static void
 construct_tooltip (NemoFile *file, gchar **tooltip_text)
 {
     gint item_count;
+    gboolean has_hidden;
+    gchar *temp;
     if (nemo_file_is_directory (file)) {
-        nemo_file_get_directory_item_count (file, &item_count, NULL);
-        *tooltip_text = g_strdup_printf (ngettext ("%d item", "%d items", item_count), item_count);
+        nemo_file_get_directory_item_count (file, &item_count, NULL, &has_hidden);
+        temp = g_strdup_printf (ngettext ("%d item", "%d items", item_count), item_count);
+        if (has_hidden) {
+            *tooltip_text = g_strconcat (temp, "\n", _("(some hidden)"), NULL);
+        } else {
+            *tooltip_text = temp;
+        }
     } else {
         gchar *scheme = nemo_file_get_uri_scheme (file);
         if (g_strcmp0 (scheme, "x-nemo-desktop") != 0) {
@@ -6912,12 +6919,13 @@ construct_tooltip (NemoFile *file, gchar **tooltip_text)
 
             prefix = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SIZE_PREFIXES);
             size_string = g_format_size_full (nemo_file_get_size (file), prefix);
-            *tooltip_text = g_strdup (size_string);
+            temp = g_strdup (size_string);
             g_free (size_string);
         } else {
-            *tooltip_text = NULL;
+            temp = NULL;
         }
         g_free (scheme);
+        *tooltip_text = temp;
     }
 }
 

--- a/libnemo-private/nemo-search-directory-file.c
+++ b/libnemo-private/nemo-search-directory-file.c
@@ -95,7 +95,8 @@ search_directory_file_check_if_ready (NemoFile *file,
 static gboolean
 search_directory_file_get_item_count (NemoFile *file, 
 				      guint *count,
-				      gboolean *count_unreadable)
+				      gboolean *count_unreadable,
+                      gboolean *has_hidden)
 {
 	GList *file_list;
 
@@ -115,7 +116,8 @@ search_directory_file_get_deep_counts (NemoFile *file,
 				       guint *directory_count,
 				       guint *file_count,
 				       guint *unreadable_directory_count,
-				       goffset *total_size)
+				       goffset *total_size,
+                       gboolean *has_hidden)
 {
 	NemoFile *dir_file;
 	GList *file_list, *l;
@@ -148,6 +150,9 @@ search_directory_file_get_deep_counts (NemoFile *file,
 		/* FIXME: Maybe we want to calculate this? */
 		*total_size = 0;
 	}
+    if (has_hidden != NULL) {
+        *has_hidden = FALSE;
+    }
 	
 	nemo_file_list_free (file_list);
 	

--- a/libnemo-private/nemo-vfs-file.c
+++ b/libnemo-private/nemo-vfs-file.c
@@ -201,7 +201,8 @@ vfs_file_set_metadata_as_list (NemoFile           *file,
 static gboolean
 vfs_file_get_item_count (NemoFile *file, 
 			 guint *count,
-			 gboolean *count_unreadable)
+			 gboolean *count_unreadable,
+             gboolean *has_hidden)
 {
 	if (count_unreadable != NULL) {
 		*count_unreadable = file->details->directory_count_failed;
@@ -215,6 +216,9 @@ vfs_file_get_item_count (NemoFile *file,
 	if (count != NULL) {
 		*count = file->details->directory_count;
 	}
+    if (has_hidden != NULL) {
+        *has_hidden = file->details->has_hidden;
+    }
 	return TRUE;
 }
 
@@ -223,7 +227,8 @@ vfs_file_get_deep_counts (NemoFile *file,
 			  guint *directory_count,
 			  guint *file_count,
 			  guint *unreadable_directory_count,
-			  goffset *total_size)
+			  goffset *total_size,
+              gboolean *has_hidden)
 {
 	GFileType type;
 
@@ -239,6 +244,10 @@ vfs_file_get_deep_counts (NemoFile *file,
 	if (total_size != NULL) {
 		*total_size = 0;
 	}
+
+    if (has_hidden != NULL) {
+        *has_hidden = FALSE;
+    }
 
 	if (!nemo_file_is_directory (file)) {
 		return NEMO_REQUEST_DONE;
@@ -257,6 +266,9 @@ vfs_file_get_deep_counts (NemoFile *file,
 		if (total_size != NULL) {
 			*total_size = file->details->deep_size;
 		}
+        if (has_hidden != NULL) {
+            *has_hidden = file->details->deep_has_hidden;
+        }
 		return file->details->deep_counts_status;
 	}
 


### PR DESCRIPTION
Added a (some hidden) string to tooltips, statusbar text, file properties windows when the selected dir(s) contain hidden items.

This addresses #254
