### PR TITLE
Remove inactive pane style from nemo-application.css... let the theme handle it always

### DIFF
--- a/src/nemo-style-application.css
+++ b/src/nemo-style-application.css
@@ -3,10 +3,6 @@
     -GtkButton-child-displacement-y: 0;
 }
 
-.nemo-inactive-pane .view {
-    background-color: shade(@theme_base_color, 0.9);
-}
-
 .nemo-big-arrow {
     -GtkArrow-arrow-scaling: 1.0;
 }


### PR DESCRIPTION
Until GTK is fixed to correctly prioritize fallback theme elements.
