### PR TITLE
support building against tracker 0.16

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl Interface break is not allowed.
 m4_define(nemo_extension_current,  5)
 m4_define(nemo_extension_revision, 0)
 
-AC_INIT(nemo, 1.7.2, http://bugzilla.gnome.org/enter_bug.cgi?product=nemo)
+AC_INIT(nemo, 1.7.3, http://bugzilla.gnome.org/enter_bug.cgi?product=nemo)
 
 dnl ===========================================================================
 
@@ -249,11 +249,13 @@ AC_ARG_ENABLE(tracker,
 
 build_tracker=no
 if test "x$enable_tracker" != "xno"; then
-  PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.14,
+  PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.16,
                     [build_tracker=yes],
-                    [PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.12,
+  		    [PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.14,
+                    	[build_tracker=yes],
+                    	[PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.12,
 		                       [build_tracker=yes],
-                                       [build_tracker=no])])
+                                       [build_tracker=no])])])
   if test "x$build_tracker" = "xyes"; then
     AC_DEFINE(ENABLE_TRACKER, 1, [Define to enable Tracker support])
   fi


### PR DESCRIPTION
--enable-tracker doesn't pick up tracker 0.16
