### PR TITLE
Fix regression from previous merge for network locations

### DIFF
--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -801,17 +801,14 @@ update_places (NemoPlacesSidebar *sidebar)
                 GFile *actual_file = g_file_new_for_uri (ptr);
                 if (g_file_is_native(actual_file)) {
                     really_network = FALSE;
-                } else {
-                    network_mounts = g_list_prepend (network_mounts, mount);
                 }
                 g_object_unref(actual_file);
-            } else {
-                network_mounts = g_list_prepend (network_mounts, mount);
             }
             g_free (path);
             g_free (escaped1);
             g_free (escaped2);
             if (really_network) {
+                network_mounts = g_list_prepend (network_mounts, mount);
                 g_object_unref (root);
                 continue;
             }


### PR DESCRIPTION
Nothing was showing up in the network category of the places sidebar.
Ever.

Cause: https://github.com/linuxmint/nemo/commit/578a6b3b879ee944dcca52c51b9f83eb7fe22094

Fixes:#287
