### PR TITLE
Add fg color to base breadcrumb widget style

### DIFF
--- a/src/nemo-style-fallback.css
+++ b/src/nemo-style-fallback.css
@@ -8,6 +8,7 @@ NemoPathbarButton {
                                      color-stop (.7, shade(alpha(@bg_color, 0.8), 0.90)),
                                      color-stop (1, shade(alpha(@bg_color, 0.8), 0.80)));
     border-color: #808080;
+    color: @fg_color;
     -NemoPathbarButton-border-radius: 3px;
 }
 


### PR DESCRIPTION
In Mint-X we inherit an appropriate color, but this isn't necessarily the case on other
themes, where it can become unreadable without this.
