### PR TITLE
make actions respect gtk setting for showing or not showing icons in menus

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -6174,7 +6174,6 @@ add_action_to_action_menus (NemoView *directory_view,
                                  GTK_ACTION (action));
 
     gtk_action_set_visible (GTK_ACTION (action), FALSE);
-    gtk_action_set_always_show_image (GTK_ACTION (action), TRUE);
 
     g_signal_connect (action, "activate",
                    G_CALLBACK (run_action_callback),


### PR DESCRIPTION
If Gtk is set to not display icons in menus, nemo actions still did it. Now they respect that setting
