### PR TITLE
Advanced search

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,8 @@ Depends: ${shlibs:Depends},
 Recommends: eject,
             librsvg2-common,
             gvfs-backends,
-            nemo-fileroller
+            nemo-fileroller,
+            gnome-search-tool
 Suggests: eog,
           evince | pdf-viewer,
           totem | mp3-decoder,

--- a/src/nemo-search-bar.c
+++ b/src/nemo-search-bar.c
@@ -38,6 +38,7 @@ struct NemoSearchBarDetails {
 enum {
        ACTIVATE,
        CANCEL,
+       ADVANCED,
        LAST_SIGNAL
 }; 
 
@@ -98,6 +99,15 @@ nemo_search_bar_class_init (NemoSearchBarClass *class)
 			      g_cclosure_marshal_VOID__VOID,
 			      G_TYPE_NONE, 0);
 
+	signals[ADVANCED] =
+		g_signal_new ("advanced",
+			      G_TYPE_FROM_CLASS (class),
+			      G_SIGNAL_RUN_LAST,
+			      G_STRUCT_OFFSET (NemoSearchBarClass, advanced),
+			      NULL, NULL,
+			      g_cclosure_marshal_VOID__VOID,
+			      G_TYPE_NONE, 0);
+
 	binding_set = gtk_binding_set_by_class (class);
 	gtk_binding_entry_add_signal (binding_set, GDK_KEY_Escape, 0, "cancel", 0);
 
@@ -126,7 +136,7 @@ entry_icon_release_cb (GtkEntry *entry,
 static void
 action_advanced_search_cb (GtkButton *advanced, NemoSearchBar *bar)
 {  
-	g_spawn_command_line_async ("gnome-search-tool", NULL);
+	g_signal_emit (bar, signals[ADVANCED], 0);
 }
 
 

--- a/src/nemo-search-bar.c
+++ b/src/nemo-search-bar.c
@@ -124,6 +124,13 @@ entry_icon_release_cb (GtkEntry *entry,
 }
 
 static void
+action_advanced_search_cb (GtkButton *advanced, NemoSearchBar *bar)
+{  
+	g_spawn_command_line_async ("gnome-search-tool", NULL);
+}
+
+
+static void
 entry_activate_cb (GtkWidget *entry, NemoSearchBar *bar)
 {
        if (entry_has_text (bar) && !bar->details->entry_borrowed) {
@@ -136,6 +143,8 @@ nemo_search_bar_init (NemoSearchBar *bar)
 {
 	GtkWidget *label;
 	GtkWidget *align;
+	GtkWidget *advanced;
+	gint exit_status;
 
 	bar->details =
 		G_TYPE_INSTANCE_GET_PRIVATE (bar, NEMO_TYPE_SEARCH_BAR,
@@ -165,6 +174,21 @@ nemo_search_bar_init (NemoSearchBar *bar)
 					   GTK_ENTRY_ICON_SECONDARY,
 					   "edit-find");
 	gtk_container_add (GTK_CONTAINER (align), bar->details->entry);
+
+
+	g_spawn_command_line_sync("which gnome-search-tool", NULL, NULL, &exit_status, NULL); 
+	if (exit_status == 0) {
+		// gnome-search-tool in at path 
+		advanced = gtk_button_new_with_label (_("advanced"));
+		gtk_widget_show (advanced);
+		// icon = gtk_image_new_from_icon_name ("sidebar-hide-symbolic", size);
+		// gtk_button_set_image (GTK_BUTTON (advanced), icon);
+		gtk_widget_set_tooltip_text (GTK_WIDGET (advanced), _("Open advanced search"));
+		gtk_box_pack_start (GTK_BOX (bar), advanced, FALSE, FALSE, 6);
+		g_signal_connect (GTK_BUTTON (advanced), "clicked",
+				  G_CALLBACK (action_advanced_search_cb), bar);
+	}
+	
 
 	g_signal_connect (bar->details->entry, "activate",
 			  G_CALLBACK (entry_activate_cb), bar);

--- a/src/nemo-search-bar.h
+++ b/src/nemo-search-bar.h
@@ -51,6 +51,7 @@ typedef struct {
 
 	void (* activate) (NemoSearchBar *bar);
 	void (* cancel)   (NemoSearchBar *bar);
+	void (* advanced) (NemoSearchBar *bar);
 } NemoSearchBarClass;
 
 GType      nemo_search_bar_get_type     	(void);

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -194,6 +194,34 @@ search_bar_activate_callback (NemoSearchBar *bar,
 }
 
 static void
+search_bar_advanced_callback (NemoSearchBar *bar,
+			      NemoWindowPane *pane)
+{
+	GFile *location;
+	char *path; 
+	const gchar *query_text;
+	gchar *advanced_command; 
+	GError *p_error = NULL; 
+
+	location = nemo_window_slot_get_location (pane->active_slot);	
+	path = g_file_get_path (location); 
+	query_text = gtk_entry_get_text (GTK_ENTRY (nemo_search_bar_get_entry (
+		NEMO_SEARCH_BAR (pane->search_bar))));
+
+	advanced_command = g_strconcat ("gnome-search-tool --named=\"", query_text, 
+		"\" --path=\"", path, "\" --contains=", NULL);
+	// empty --contains= is to display the advanced options by default 
+	g_debug("calling >%s<", advanced_command); 
+	if (!g_spawn_command_line_async (advanced_command, &p_error)) {
+		g_warning("calling >%s< failed: %s", advanced_command, p_error->message); 
+	}
+	g_free (path); 
+	g_free (advanced_command); 
+	g_object_unref(location); 
+}
+
+
+static void
 nemo_window_pane_hide_temporary_bars (NemoWindowPane *pane)
 {
 	NemoWindowSlot *slot;
@@ -921,6 +949,8 @@ nemo_window_pane_constructed (GObject *obj)
 
 	g_signal_connect_object (pane->search_bar, "activate",
 				 G_CALLBACK (search_bar_activate_callback), pane, 0);
+	g_signal_connect_object (pane->search_bar, "advanced",
+				 G_CALLBACK (search_bar_advanced_callback), pane, 0);
 	g_signal_connect_object (pane->search_bar, "cancel",
 				 G_CALLBACK (search_bar_cancel_callback), pane, 0);
 	g_signal_connect_object (nemo_search_bar_get_entry (NEMO_SEARCH_BAR (pane->search_bar)), "focus-in-event",


### PR DESCRIPTION
This patch adds an "advanced" button at the left side of the search bar to call gnome-search-tool with the current search. 

This fixes #426 