### PR TITLE
Use natural size for pathbar button

### DIFF
--- a/libnemo-private/nemo-pathbar-button.c
+++ b/libnemo-private/nemo-pathbar-button.c
@@ -262,7 +262,7 @@ void
 nemo_pathbar_button_get_preferred_size (GtkWidget *button, GtkRequisition *requisition, gint height)
 {
     GtkRequisition req;
-    gtk_widget_get_preferred_size (button, &req, NULL);
+    gtk_widget_get_preferred_size (button, NULL, &req);
     gint offset = rintf ((float) req.height / PATHBAR_BUTTON_OFFSET_FACTOR) + 4;
     if (!NEMO_PATHBAR_BUTTON (button)->is_left_end) {
         req.width -= offset;


### PR DESCRIPTION
This fixes that the pathbar may disapper with long folder names.

This is an improvement of the nautilus commit 79157f5617886401379a724f8c526c430c4876a6, intended to entirely fix:
https://bugzilla.gnome.org/show_bug.cgi?id=313854
