### PR TITLE
Preference to sort dotfiles and dotfolders first

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -2884,14 +2884,25 @@ compare_by_display_name (NemoFile *file_1, NemoFile *file_2)
 	const char *name_1, *name_2;
 	const char *key_1, *key_2;
 	gboolean sort_last_1, sort_last_2;
+	gboolean sort_dotfiles_first;
 	int compare;
 
 	name_1 = nemo_file_peek_display_name (file_1);
 	name_2 = nemo_file_peek_display_name (file_2);
 
-	sort_last_1 = name_1[0] == SORT_LAST_CHAR1 || name_1[0] == SORT_LAST_CHAR2;
-	sort_last_2 = name_2[0] == SORT_LAST_CHAR1 || name_2[0] == SORT_LAST_CHAR2;
+	// Check if we want to sort dotfiles first
+	sort_dotfiles_first = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_DOTFILES_FIRST);
 
+	if (sort_dotfiles_first) {
+	    // Only consider "#" as sorting last
+	    sort_last_1 = name_1[0] == SORT_LAST_CHAR2;
+	    sort_last_2 = name_2[0] == SORT_LAST_CHAR2;
+	} else {
+	    // Consider both "." and "#" to sorting last
+	    sort_last_1 = name_1[0] == SORT_LAST_CHAR1 || name_1[0] == SORT_LAST_CHAR2;
+	    sort_last_2 = name_2[0] == SORT_LAST_CHAR1 || name_2[0] == SORT_LAST_CHAR2;
+	}
+        
 	if (sort_last_1 && !sort_last_2) {
 		compare = +1;
 	} else if (!sort_last_1 && sort_last_2) {

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -101,6 +101,7 @@ typedef enum
 #define NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST		"sort-directories-first"
 #define NEMO_PREFERENCES_DEFAULT_SORT_ORDER			"default-sort-order"
 #define NEMO_PREFERENCES_DEFAULT_SORT_IN_REVERSE_ORDER	"default-sort-in-reverse-order"
+#define NEMO_PREFERENCES_SORT_DOTFILES_FIRST            "sort-dotfiles-first"
 
 /* The default folder viewer - one of the two enums below */
 #define NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER		"default-folder-viewer"

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -198,6 +198,11 @@
       <_summary>Show folders first in windows</_summary>
       <_description>If set to true, then Nemo shows folders prior to showing files in the icon and list views.</_description>
     </key>
+    <key name="sort-dotfiles-first" type="b">
+      <default>false</default>
+      <_summary>Show dotfiles first in windows</_summary>
+      <_description>If set to true, then Nemo shows dotfiles first instead of intermixed with regular files. Respects folder-first preference.</_description>
+    </key>
     <key name="default-sort-order" enum="org.nemo.SortOrder">
       <aliases>
 	<alias value='modification_date' target='mtime'/>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -54,6 +54,7 @@
 
 /* bool preferences */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_FOLDERS_FIRST_WIDGET "sort_folders_first_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DOTFILES_FIRST_WIDGET "sort_dotfiles_first_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_COMPACT_LAYOUT_WIDGET "compact_layout_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LABELS_BESIDE_ICONS_WIDGET "labels_beside_icons_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_ALL_COLUMNS_SAME_WIDTH "all_columns_same_width_checkbutton"
@@ -840,6 +841,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
 	bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_FOLDERS_FIRST_WIDGET,
 			   NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST);
+        bind_builder_bool (builder, nemo_preferences,
+                           NEMO_FILE_MANAGEMENT_PROPERTIES_DOTFILES_FIRST_WIDGET,
+                           NEMO_PREFERENCES_SORT_DOTFILES_FIRST);
 	bind_builder_bool_inverted (builder, nemo_preferences,
 				    NEMO_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_BROWSER_WIDGET,
 				    NEMO_PREFERENCES_ALWAYS_USE_BROWSER);

--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -215,6 +215,22 @@
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
+				    <child>
+                                      <object class="GtkCheckButton" id="sort_dotfiles_first_checkbutton">
+                                        <property name="label" translatable="yes">Sort _dotfiles first</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -260,6 +260,7 @@ struct NemoViewDetails
 	gboolean is_renaming;
 
 	gboolean sort_directories_first;
+        gboolean sort_dotfiles_first;
 
 	gboolean show_foreign_files;
 	gboolean show_hidden_files;
@@ -2245,6 +2246,19 @@ sort_directories_first_changed_callback (gpointer callback_data)
 	}
 }
 
+gboolean
+nemo_view_should_sort_dotfiles_first (NemoView *view)
+{
+    return view->details->sort_dotfiles_first;
+}
+
+static void
+sort_dotfiles_first_changed_callback (NemoView *view)
+{
+    view->details->sort_dotfiles_first = 
+            g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_DOTFILES_FIRST);
+}
+
 static void
 swap_delete_keybinding_changed_callback (gpointer callback_data)
 {
@@ -2686,6 +2700,9 @@ nemo_view_init (NemoView *view)
 
 	view->details->sort_directories_first =
 		g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST);
+        
+        view->details->sort_dotfiles_first =
+                g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_DOTFILES_FIRST);
 
 	g_signal_connect_object (nemo_trash_monitor_get (), "trash_state_changed",
 				 G_CALLBACK (nemo_view_trash_state_changed_callback), view, 0);
@@ -2713,6 +2730,9 @@ nemo_view_init (NemoView *view)
 	g_signal_connect_swapped (nemo_preferences,
 				  "changed::" NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST, 
 				  G_CALLBACK(sort_directories_first_changed_callback), view);
+        g_signal_connect_swapped (nemo_preferences,
+                                  "changed::" NEMO_PREFERENCES_SORT_DOTFILES_FIRST,
+                                  G_CALLBACK(sort_dotfiles_first_changed_callback), view);
 	g_signal_connect_swapped (gnome_lockdown_preferences,
 				  "changed::" NEMO_PREFERENCES_LOCKDOWN_COMMAND_LINE,
 				  G_CALLBACK (schedule_update_menus), view);


### PR DESCRIPTION
Adds a preference for dotfiles and dotfolders to be sorted first in the displayed list. This is in contrast to the currently hardcoded method of "last sorting" the dotfiles/folders.