### PR TITLE
Removed searchbar icon

### DIFF
--- a/src/nemo-search-bar.c
+++ b/src/nemo-search-bar.c
@@ -161,9 +161,10 @@ nemo_search_bar_init (NemoSearchBar *bar)
 	gtk_widget_show (align);
 
 	bar->details->entry = gtk_entry_new ();
-	gtk_entry_set_icon_from_icon_name (GTK_ENTRY (bar->details->entry),
-					   GTK_ENTRY_ICON_SECONDARY,
-					   "edit-find");
+	//FIXME: Icon was interacting strangely with tab close button
+	//gtk_entry_set_icon_from_icon_name (GTK_ENTRY (bar->details->entry),
+		//			   GTK_ENTRY_ICON_SECONDARY,
+		//			   "edit-find");
 	gtk_container_add (GTK_CONTAINER (align), bar->details->entry);
 
 	g_signal_connect (bar->details->entry, "activate",


### PR DESCRIPTION
It was interacting strangely with the close tab button, for e.g. after searching, and opening a new tab, then trying to close that tab, you would activate the search bar again.

Video: http://www.youtube.com/watch?v=HS7IRaO_qsQ
