### PR TITLE
Escaping spaces of a selected file in application chooser [Issue-63]

### DIFF
--- a/libnemo-private/nemo-mime-application-chooser.c
+++ b/libnemo-private/nemo-mime-application-chooser.c
@@ -426,6 +426,50 @@ custom_app_set_cb (GtkFileChooserButton *button,
 
 }
 
+static gchar *
+escape_spaces(const gchar *path)
+{
+    int spaces;
+    char *pathPointer;
+    char *escapedPointer;
+    char *escaped;
+
+    if (path == NULL) {
+        return NULL:
+    }
+
+    spaces = char_frequency(' ', path);
+
+    if (spaces == 0) {
+        return path;
+    }
+
+    escaped = g_new (char, strlen (path) + (spaces * 2) + 1);
+    for (pathPointer = path, escapedPointer = escaped; *pathPointer != '\0'; pathPointer++, escapedPointer++) {
+        if (*pathPointer == ' ') {
+            *escapedPointer++ = '\\';
+        }
+        *escapedPointer = *pathPointer;
+    }
+    *escapedPointer = '\0';
+    
+    return escaped;
+}
+
+static int *
+char_frequency(const char needle, const gchar *haystack)
+{
+    int i = 0;
+    char *pointer=strchr(haystack,needle);
+    
+    while (pointer!=NULL) {
+        i++;
+        pointer=strchr(pointer+1,needle);
+    }
+
+    return i;
+}
+
 static char *
 get_extension (const char *basename)
 {


### PR DESCRIPTION
Please note, this code has not been compiled as I have not worked out how to compile.  It is likely to have bugs as I am very new to C code.  The logic for the escape_spaces method is heavily borrowed from eel_str_double_underscores.
