### PR TITLE
Rework tab handling

### DIFF
--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -485,9 +485,9 @@ nemo_notebook_remove (GtkContainer *container,
 }
 
 void
-nemo_notebook_reorder_current_child_relative (NemoNotebook *notebook,
-					      int    	    page_num,
-					      int 	    offset)
+nemo_notebook_reorder_child_relative (NemoNotebook *notebook,
+				      int    	    page_num,
+				      int 	    offset)
 {
 	GtkNotebook *gnotebook;
 	GtkWidget *page;

--- a/src/nemo-notebook.h
+++ b/src/nemo-notebook.h
@@ -77,9 +77,9 @@ void		nemo_notebook_sync_tab_label (NemoNotebook *nb,
 void		nemo_notebook_sync_loading   (NemoNotebook *nb,
 						  NemoWindowSlot *slot);
 
-void		nemo_notebook_reorder_current_child_relative (NemoNotebook *notebook,
-							      int	    page_num,
-					      		      int 	    offset);
+void		nemo_notebook_reorder_child_relative (NemoNotebook *notebook,
+						      int	    page_num,
+						      int 	    offset);
 void		nemo_notebook_set_current_page_relative (NemoNotebook *notebook,
 							     int offset);
 

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1000,7 +1000,7 @@ reorder_tab (NemoWindowPane *pane, int offset)
 	page_num = gtk_notebook_get_current_page (
 		GTK_NOTEBOOK (pane->notebook));
 	g_return_if_fail (page_num != -1);
-	nemo_notebook_reorder_current_child_relative (
+	nemo_notebook_reorder_child_relative (
 		NEMO_NOTEBOOK (pane->notebook), page_num, offset);
 }
 

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -474,7 +474,7 @@ reorder_tab (NemoWindowPane *pane, int offset)
 
 	num_target_tab = GPOINTER_TO_INT (
 		g_object_get_data (G_OBJECT (pane), "num_target_tab"));
-	nemo_notebook_reorder_current_child_relative (
+	nemo_notebook_reorder_child_relative (
 		NEMO_NOTEBOOK (pane->notebook), num_target_tab, offset);
 }
 


### PR DESCRIPTION
This reworks the way tab events are handled in Nemo. Most importantly, right-click events on a tab to show its popup menu no longer cause a page change. This makes Nemo behave more akin to applications like Firefox, Chromium, etc.
