### PR TITLE
use non-legacy icon name for "open in terminal"

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -8029,7 +8029,7 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("Open in New _Tab"), "<control><shift>o",
   /* tooltip */                  N_("Open each selected item in a new tab"),
 				 G_CALLBACK (action_open_new_tab_callback) },
-  /* name, stock id */         { NEMO_ACTION_OPEN_IN_TERMINAL, "terminal",
+  /* name, stock id */         { NEMO_ACTION_OPEN_IN_TERMINAL, "utilities-terminal",
   /* label, accelerator */       N_("Open in Terminal"), "",
   /* tooltip */                  N_("Open terminal in the selected folder"),
 				 G_CALLBACK (action_open_in_terminal_callback) },


### PR DESCRIPTION
utilities-terminal icon already exists in mint x icon theme

https://github.com/linuxmint/Cinnamon/issues/3403
