### PR TITLE
Desktop grid

### DIFF
--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -103,9 +103,9 @@
 
 /* Desktop layout mode defines */
 #define DESKTOP_PAD_HORIZONTAL 	10
-#define DESKTOP_PAD_VERTICAL 	10
+#define DESKTOP_PAD_VERTICAL 	1
 #define SNAP_SIZE_X 		78
-#define SNAP_SIZE_Y 		20
+#define SNAP_SIZE_Y 		88
 
 #define MINIMUM_EMBEDDED_TEXT_RECT_WIDTH       20
 #define MINIMUM_EMBEDDED_TEXT_RECT_HEIGHT      20

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -36,6 +36,7 @@
 
 #define ICON_TEXT_ATTRIBUTES_NUM_ITEMS		3
 #define ICON_TEXT_ATTRIBUTES_DEFAULT_TOKENS	"size,date_modified,type"
+#define DESKTOP_MAX_ICON_TEXT 			20
 
 G_DEFINE_TYPE (NemoIconViewContainer, nemo_icon_view_container, NEMO_TYPE_ICON_CONTAINER);
 
@@ -360,6 +361,20 @@ nemo_icon_view_container_get_icon_text (NemoIconContainer *container,
 		/* Strip the suffix for nemo object xml files. */
 		*editable_text = nemo_file_get_display_name (file);
 	}
+
+	/* If icon text is too long, strip it and add "..." */
+	if (strlen(*editable_text) > DESKTOP_MAX_ICON_TEXT)
+        {
+                char * new_str ;
+                if((new_str = malloc(DESKTOP_MAX_ICON_TEXT+3+1)) != NULL){
+                        new_str[0] = '\0';   // ensures the memory is an empty string
+                        strcat(new_str,strndup(*editable_text,DESKTOP_MAX_ICON_TEXT));
+                        strcat(new_str,"...");
+                        *editable_text = new_str;
+                }
+		/* TODO: Add tooltip with complete text */
+        }
+
 
 	if (!use_additional) {
 		return;

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -36,7 +36,6 @@
 
 #define ICON_TEXT_ATTRIBUTES_NUM_ITEMS		3
 #define ICON_TEXT_ATTRIBUTES_DEFAULT_TOKENS	"size,date_modified,type"
-#define DESKTOP_MAX_ICON_TEXT 			20
 
 G_DEFINE_TYPE (NemoIconViewContainer, nemo_icon_view_container, NEMO_TYPE_ICON_CONTAINER);
 
@@ -361,20 +360,6 @@ nemo_icon_view_container_get_icon_text (NemoIconContainer *container,
 		/* Strip the suffix for nemo object xml files. */
 		*editable_text = nemo_file_get_display_name (file);
 	}
-
-	/* If icon text is too long, strip it and add "..." */
-	if (strlen(*editable_text) > DESKTOP_MAX_ICON_TEXT)
-        {
-                char * new_str ;
-                if((new_str = malloc(DESKTOP_MAX_ICON_TEXT+3+1)) != NULL){
-                        new_str[0] = '\0';   // ensures the memory is an empty string
-                        strcat(new_str,strndup(*editable_text,DESKTOP_MAX_ICON_TEXT));
-                        strcat(new_str,"...");
-                        *editable_text = new_str;
-                }
-		/* TODO: Add tooltip with complete text */
-        }
-
 
 	if (!use_additional) {
 		return;


### PR DESCRIPTION
This pull request is an attempt to fix #108. It is not perfect yet, because it is only a workaround, but I wanted to create a pull request in order to be able to keep track of the changes and have a place for suggestions.

With the current changes, you will get a regular grid, if you disable preview thumbnails AND if you set the dconf-setting "/org/nemo/desktop/text-ellipsis-limit" to 2
TODO:
- [ ] automatically compute grid size from biggest icon
- [ ] maybe reduce preview-icon size to regular icon size?