### PR TITLE
Fix broken link

### DIFF
--- a/docs/style-guide.html
+++ b/docs/style-guide.html
@@ -9,7 +9,7 @@
 <p>To make code written for Nemo look and act in a predictable way,
 we follow a set of guidelines that specify some details of how we write code.
 To start, we follow all the guidelines outlined in the
-<a href="http://developer.gnome.org/doc/guides/programming-guidelines/">GNOME Programming Guidelines</a>.</p>
+<a href="https://help.gnome.org/users/programming-guidelines/stable/">GNOME Programming Guidelines</a>.</p>
 
 <p>This document covers both things that are not mentioned in the GNOME
 Programming Guidelines and things that are mentioned there but need


### PR DESCRIPTION
Fix broken link to gnome style guidelines.

Additionally, the link to "recommended-books.html" in line 40 is also broken, but I can't figure out where it should actually point to.
