### PR TITLE
Add application-specific theme for Adwaita

### DIFF
--- a/src/Adwaita.css
+++ b/src/Adwaita.css
@@ -1,0 +1,26 @@
+.nemo-canvas-item {
+    border-radius: 5px;
+}
+
+.nemo-desktop.nemo-canvas-item {
+    color: @theme_selected_fg_color;
+    text-shadow: 1px 1px black;
+}
+
+.nemo-desktop.nemo-canvas-item:active {
+    color: @theme_text_color;
+}
+
+.nemo-desktop.nemo-canvas-item:selected {
+    color: @theme_selected_fg_color;
+}
+
+.nemo-desktop.nemo-canvas-item:active,
+.nemo-desktop.nemo-canvas-item:prelight,
+.nemo-desktop.nemo-canvas-item:selected {
+    text-shadow: none;
+}
+
+.nemo-desktop.nemo-canvas-item:selected:backdrop {
+    color: @theme_unfocused_selected_fg_color;
+}

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -1041,6 +1041,56 @@ out_a:
 }
 
 static void
+theme_changed (GtkSettings *settings)
+{
+	static GtkCssProvider *adwaita_provider = NULL;
+	gchar *theme;
+	GdkScreen *screen;
+
+	g_object_get (settings, "gtk-theme-name", &theme, NULL);
+	screen = gdk_screen_get_default ();
+
+	if (g_str_equal (theme, "Adwaita"))
+	{
+		if (adwaita_provider == NULL)
+		{
+			GFile *file;
+
+			adwaita_provider = gtk_css_provider_new ();
+			file = g_file_new_for_uri ("resource:///org/nemo/Adwaita.css");
+			gtk_css_provider_load_from_file (adwaita_provider, file, NULL);
+			g_object_unref (file);
+		}
+
+		gtk_style_context_add_provider_for_screen (screen,
+							   GTK_STYLE_PROVIDER (adwaita_provider),
+							   GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	}
+	else if (adwaita_provider != NULL)
+	{
+		gtk_style_context_remove_provider_for_screen (screen,
+							      GTK_STYLE_PROVIDER (adwaita_provider));
+		g_clear_object (&adwaita_provider);
+	}
+
+	g_free (theme);
+}
+
+static void
+setup_theme_extensions (void)
+{
+	GtkSettings *settings;
+
+	/* Set up a handler to load our custom css for Adwaita.
+	 * See https://bugzilla.gnome.org/show_bug.cgi?id=732959
+	 * for a more automatic solution that is still under discussion.
+	 */
+	settings = gtk_settings_get_default ();
+	g_signal_connect (settings, "notify::gtk-theme-name", G_CALLBACK (theme_changed), NULL);
+	theme_changed (settings);
+}
+
+static void
 init_icons_and_styles (void)
 {
 	/* initialize search path for custom icons */
@@ -1052,6 +1102,8 @@ init_icons_and_styles (void)
                             NEMO_STATUSBAR_ICON_SIZE);
 
     nemo_application_add_app_css_provider ();
+
+    setup_theme_extensions ();
 }
 
 static void

--- a/src/nemo.gresource.xml
+++ b/src/nemo.gresource.xml
@@ -11,6 +11,7 @@
     <file>nemo-statusbar-ui.xml</file>
     <file alias="icons/thumbnail_frame.png">../icons/thumbnail_frame.png</file>
     <file alias="icons/knob.png">../icons/knob.png</file>
+    <file>Adwaita.css</file>
     <file>nemo-style-fallback.css</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
This patch adds some desktop style when the Adwaita theme is used. Adwaita is the default theme of GTK+ since version 3.14, so it would be worth if Nemo support it.

Based on this patch for Nautilus:
https://git.gnome.org/browse/nautilus/commit/?id=3fd7e847d531fbbfc4ebba24864bdd0f8b81c750