### PR TITLE
raise thumbnail size limit

### DIFF
--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -191,7 +191,8 @@ static const guint64 thumbnail_limit_values[] = {
 	104857600,
 	1073741824,
 	2147483648U,
-	4294967295U
+	4294967295U,
+	8589934592U
 };
 
 static const char * const icon_captions_components[] = {

--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -242,6 +242,9 @@
       <row>
         <col id="0" translatable="yes">4 GB</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">8 GB</col>
+      </row>
     </data>
   </object>
   <object class="GtkDialog" id="file_management_dialog">


### PR DESCRIPTION
Raise thumbnail size limit to account for larger rip sizes of HD media.