### PR TITLE
fix the growing size of the nemo statusbar in each new version of gtk

### DIFF
--- a/src/nemo-statusbar.c
+++ b/src/nemo-statusbar.c
@@ -190,7 +190,7 @@ nemo_status_bar_constructed (GObject *object)
 
     context = gtk_widget_get_style_context (GTK_WIDGET (bar));
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_TOOLBAR);
-    gtk_container_set_border_width (GTK_CONTAINER (bar), 1);
+    gtk_container_set_border_width (GTK_CONTAINER (bar), 2);
 
     GtkWidget *button, *icon;
 
@@ -236,6 +236,8 @@ nemo_status_bar_constructed (GObject *object)
                       G_CALLBACK (action_show_sidebar_callback), bar);
 
     gtk_box_pack_start (GTK_BOX (bar), statusbar, TRUE, TRUE, 10);
+    gtk_widget_set_margin_top (GTK_WIDGET (statusbar), 0);
+    gtk_widget_set_margin_bottom (GTK_WIDGET (statusbar), 0);
 
     GtkWidget *zoom_slider = gtk_scale_new_with_range (GTK_ORIENTATION_HORIZONTAL,
                                                        (gdouble) NEMO_ZOOM_LEVEL_SMALLEST,


### PR DESCRIPTION
The Mint-X theme will need a small tweak to work with this.

Edit:

Companion fix for the Mint-X theme: https://github.com/linuxmint/mint-themes-gtk3/pull/41