### PR TITLE
Only include the domain if the method is SMB (bugfix)

### DIFF
--- a/src/nemo-connect-server-dialog.c
+++ b/src/nemo-connect-server-dialog.c
@@ -568,7 +568,7 @@ connect_dialog_connect_to_server (NemoConnectServerDialog *dialog)
 	/* domain */
 	domain = gtk_editable_get_chars (GTK_EDITABLE (dialog->details->domain_entry), 0, -1);
 			
-	if (strlen (domain) != 0) {
+	if (strlen (domain) != 0 && strcmp(meth->scheme, "smb")) {
 		t = user;
 
 		user = g_strconcat (domain , ";" , t, NULL);


### PR DESCRIPTION
Fixes a bug where if the user first tries the SMB method, enters a domain, and then tries another method (e.g, ssh), the code would incorrectly prepend the domain to the username.