### PR TITLE
remove deprecated function gdk_display_get_n_screens

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -1951,7 +1951,7 @@ eel_canvas_accessible_initialize (AtkObject *obj,
 
 static gint
 eel_canvas_accessible_get_n_children (AtkObject* obj)
-{;
+{
 	GtkWidget *widget;
 	EelCanvas *canvas;
 	EelCanvasGroup *root_group;

--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -1668,6 +1668,10 @@ group_add (EelCanvasGroup *group, EelCanvasItem *item)
 {
 	g_object_ref_sink (item);
 
+/* FIXME: relatively inefficient way to add to the list, appending to the list causes it to be read from the top each time. 
+ 	prepend, followed by a reverse if necessary is the recommended approach.  However as this list append is a number of
+  	levels of call down, correcting it is not as easy as it could be */
+
 	if (!group->item_list) {
 		group->item_list = g_list_append (group->item_list, item);
 		group->item_list_end = group->item_list;
@@ -1832,12 +1836,9 @@ static void
 eel_canvas_accessible_adjustment_changed (GtkAdjustment *adjustment,
 					  gpointer       data)
 {
-	AtkObject *atk_obj;
-
 	/* The scrollbars have changed */
-	atk_obj = ATK_OBJECT (data);
 
-	g_signal_emit_by_name (atk_obj, "visible_data_changed");
+	g_signal_emit_by_name (ATK_OBJECT (data), "visible_data_changed");
 }
 
 static void
@@ -1852,8 +1853,7 @@ static gboolean
 accessible_focus_cb (GtkWidget     *widget,
 		     GdkEventFocus *event)
 {
-	AtkObject* accessible = gtk_widget_get_accessible (widget);
-	atk_object_notify_state_change (accessible, ATK_STATE_FOCUSED, event->in);
+	atk_object_notify_state_change ((AtkObject *)gtk_widget_get_accessible (widget), ATK_STATE_FOCUSED, event->in);
 
 	return FALSE;
 }
@@ -1951,14 +1951,12 @@ eel_canvas_accessible_initialize (AtkObject *obj,
 
 static gint
 eel_canvas_accessible_get_n_children (AtkObject* obj)
-{
- 	GtkAccessible *accessible;
+{;
 	GtkWidget *widget;
 	EelCanvas *canvas;
 	EelCanvasGroup *root_group;
 
-	accessible = GTK_ACCESSIBLE (obj);
-	widget = gtk_accessible_get_widget (accessible);
+	widget = gtk_accessible_get_widget (GTK_ACCESSIBLE (obj));
 
 	if (widget == NULL) {
 		return 0;
@@ -1977,7 +1975,6 @@ static AtkObject*
 eel_canvas_accessible_ref_child (AtkObject *obj,
                                  gint       i)
 {
-	GtkAccessible *accessible;
 	GtkWidget *widget;
 	EelCanvas *canvas;
 	EelCanvasGroup *root_group;
@@ -1988,8 +1985,7 @@ eel_canvas_accessible_ref_child (AtkObject *obj,
         	return NULL;
 	}
 
-	accessible = GTK_ACCESSIBLE (obj);
-	widget = gtk_accessible_get_widget (accessible);
+	widget = gtk_accessible_get_widget (GTK_ACCESSIBLE (obj));
 
 	if (widget == NULL) {
 		return NULL;
@@ -2116,10 +2112,7 @@ eel_canvas_accessible_ref_state_set (AtkObject *accessible)
 		}
 
 		if (gtk_widget_has_focus (widget)) {
-			AtkObject *focus_obj;
-
-			focus_obj = g_object_get_data (G_OBJECT (accessible), "gail-focus-object");
-			if (focus_obj == NULL) {
+			if (g_object_get_data (G_OBJECT (accessible), "gail-focus-object") == NULL) {
 				atk_state_set_add_state (state_set, ATK_STATE_FOCUSED);
 			}
 		}
@@ -2267,13 +2260,9 @@ eel_canvas_accessible_factory_get_accessible_type (void)
 static AtkObject*
 eel_canvas_accessible_factory_create_accessible (GObject *obj)
 {
-	AtkObject *accessible;
-
 	g_return_val_if_fail (G_IS_OBJECT (obj), NULL);
 
-	accessible = eel_canvas_accessible_create (obj);
-
-	return accessible;
+	return eel_canvas_accessible_create (obj);
 }
 
 static void
@@ -2304,7 +2293,6 @@ eel_canvas_accessible_factory_get_type (void)
 					       "EelCanvasAccessibilityFactory",
 					       &tinfo, 0);
 	}
-
 	return type;
 }
 
@@ -3002,13 +2990,13 @@ eel_canvas_button (GtkWidget *widget, GdkEventButton *event)
 	g_return_val_if_fail (EEL_IS_CANVAS (widget), FALSE);
 	g_return_val_if_fail (event != NULL, FALSE);
 
-	retval = FALSE;
-
-	canvas = EEL_CANVAS (widget);
-
 	/* Don't handle extra mouse button events */
 	if (event->button > 5)
 		return FALSE;
+
+	retval = FALSE;
+
+	canvas = EEL_CANVAS (widget);
 
 	/*
 	 * dispatch normally regardless of the event's window if an item has
@@ -3205,7 +3193,7 @@ eel_cairo_get_clip_region (cairo_t *cr)
 static gboolean
 eel_canvas_draw (GtkWidget *widget, cairo_t *cr)
 {
-	EelCanvas *canvas = EEL_CANVAS (widget);
+	EelCanvas *canvas;
         GdkWindow *bin_window;
         cairo_region_t *region;
 
@@ -3232,6 +3220,7 @@ eel_canvas_draw (GtkWidget *widget, cairo_t *cr)
 	g_print ("Draw\n");
 #endif
 	/* If there are any outstanding items that need updating, do them now */
+	canvas = EEL_CANVAS (widget);
 	if (canvas->idle_id) {
 		g_source_remove (canvas->idle_id);
 		canvas->idle_id = 0;
@@ -3258,7 +3247,7 @@ eel_canvas_draw (GtkWidget *widget, cairo_t *cr)
 	if (canvas->root->flags & EEL_CANVAS_ITEM_MAPPED)
 		EEL_CANVAS_ITEM_GET_CLASS (canvas->root)->draw (canvas->root, cr, region);
 
-    cairo_restore (cr);
+    	cairo_restore (cr);
 
 	/* Chain up to get exposes on child widgets */
         if (GTK_WIDGET_CLASS (canvas_parent_class)->draw)
@@ -3389,7 +3378,6 @@ eel_canvas_set_scroll_region (EelCanvas *canvas, double x1, double y1, double x2
 {
 	double wxofs, wyofs;
 	int xofs, yofs;
-	GtkAdjustment *vadjustment, *hadjustment;
 
 	g_return_if_fail (EEL_IS_CANVAS (canvas));
 
@@ -3402,12 +3390,10 @@ eel_canvas_set_scroll_region (EelCanvas *canvas, double x1, double y1, double x2
 	 * Set the new scrolling region.  If possible, do not move the visible contents of the
 	 * canvas.
 	 */
-	hadjustment = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (canvas));
-	vadjustment = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (canvas));
 
 	eel_canvas_c2w (canvas,
-			  gtk_adjustment_get_value (hadjustment) + canvas->zoom_xofs,
-			  gtk_adjustment_get_value (vadjustment) + canvas->zoom_yofs,
+			  gtk_adjustment_get_value (gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (canvas))) + canvas->zoom_xofs,
+			  gtk_adjustment_get_value (gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (canvas))) + canvas->zoom_yofs,
 			  /*canvas->zoom_xofs,
 			  canvas->zoom_yofs,*/
 			  &wxofs, &wyofs);
@@ -3462,18 +3448,13 @@ void
 eel_canvas_set_center_scroll_region (EelCanvas *canvas,
 				     gboolean center_scroll_region)
 {
-	GtkAdjustment *vadjustment, *hadjustment;
-
 	g_return_if_fail (EEL_IS_CANVAS (canvas));
 
 	canvas->center_scroll_region = center_scroll_region != 0;
 
-	hadjustment = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (&canvas->layout));
-	vadjustment = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (&canvas->layout));
-
 	scroll_to (canvas,
-		   gtk_adjustment_get_value (hadjustment),
-		   gtk_adjustment_get_value (vadjustment));
+		   gtk_adjustment_get_value (gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (&canvas->layout))),
+		   gtk_adjustment_get_value (gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (&canvas->layout))));
 }
 
 
@@ -3598,18 +3579,13 @@ eel_canvas_scroll_to (EelCanvas *canvas, int cx, int cy)
 void
 eel_canvas_get_scroll_offsets (EelCanvas *canvas, int *cx, int *cy)
 {
-	GtkAdjustment *vadjustment, *hadjustment;
-
 	g_return_if_fail (EEL_IS_CANVAS (canvas));
 
-	hadjustment = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (canvas));
-	vadjustment = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (canvas));
-
 	if (cx)
-		*cx = gtk_adjustment_get_value (hadjustment);
+		*cx = gtk_adjustment_get_value (gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (canvas)));
 
 	if (cy)
-		*cy = gtk_adjustment_get_value (vadjustment);
+		*cy = gtk_adjustment_get_value (gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (canvas)));
 }
 
 /**
@@ -3869,14 +3845,12 @@ boolean_handled_accumulator (GSignalInvocationHint *ihint,
 			     const GValue          *handler_return,
 			     gpointer               dummy)
 {
-	gboolean continue_emission;
 	gboolean signal_handled;
 	
 	signal_handled = g_value_get_boolean (handler_return);
 	g_value_set_boolean (return_accu, signal_handled);
-	continue_emission = !signal_handled;
 	
-	return continue_emission;
+	return !signal_handled;
 }
 
 static guint
@@ -3961,7 +3935,6 @@ eel_canvas_item_accessible_get_extents (AtkComponent *component,
                                         gint		*height,
                                         AtkCoordType coord_type)
 {
- 	AtkGObjectAccessible *atk_gobj;
 	GObject *obj;
 	EelCanvasItem *item;
 	gint window_x, window_y;
@@ -3970,8 +3943,7 @@ eel_canvas_item_accessible_get_extents (AtkComponent *component,
 	GdkWindow *window;
 	GtkWidget *canvas;
 
-	atk_gobj = ATK_GOBJECT_ACCESSIBLE (component);
-	obj = atk_gobject_accessible_get_object (atk_gobj);
+	obj = atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (component));
 
 	if (obj == NULL) {
 		/* item is defunct */
@@ -4010,12 +3982,10 @@ eel_canvas_item_accessible_get_extents (AtkComponent *component,
 static gint
 eel_canvas_item_accessible_get_mdi_zorder (AtkComponent *component)
 {
-	AtkGObjectAccessible *atk_gobj;
 	GObject *g_obj;
 	EelCanvasItem *item;
 
-	atk_gobj = ATK_GOBJECT_ACCESSIBLE (component);
-	g_obj = atk_gobject_accessible_get_object (atk_gobj);
+	g_obj = atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (component));
 	if (g_obj == NULL) {
 		/* Object is defunct */
 		return -1;
@@ -4033,13 +4003,11 @@ eel_canvas_item_accessible_get_mdi_zorder (AtkComponent *component)
 static gboolean
 eel_canvas_item_accessible_grab_focus (AtkComponent *component)
 {
- 	AtkGObjectAccessible *atk_gobj;
 	GObject *obj;
 	EelCanvasItem *item;
 	GtkWidget *toplevel;
 
-	atk_gobj = ATK_GOBJECT_ACCESSIBLE (component);
-	obj = atk_gobject_accessible_get_object (atk_gobj);
+	obj = atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (component));
 
 	item = EEL_CANVAS_ITEM (obj);
 	if (item == NULL) {
@@ -4096,14 +4064,12 @@ eel_canvas_item_accessible_initialize (AtkObject *obj, gpointer data)
 static AtkStateSet*
 eel_canvas_item_accessible_ref_state_set (AtkObject *accessible)
 {
- 	AtkGObjectAccessible *atk_gobj;
 	GObject *obj;
  	EelCanvasItem *item;
 	AtkStateSet *state_set;
 
 	state_set = ATK_OBJECT_CLASS (accessible_item_parent_class)->ref_state_set (accessible);
-	atk_gobj = ATK_GOBJECT_ACCESSIBLE (accessible);
-	obj = atk_gobject_accessible_get_object (atk_gobj);
+	obj = atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (accessible));
 
 	item = EEL_CANVAS_ITEM (obj);
 	if (item == NULL) {
@@ -4174,7 +4140,6 @@ eel_canvas_item_accessible_get_type (void)
 					     &atk_component_info);
 
 	}
-
 	return type;
 }
 
@@ -4207,13 +4172,9 @@ eel_canvas_item_accessible_factory_get_accessible_type (void)
 static AtkObject*
 eel_canvas_item_accessible_factory_create_accessible (GObject *obj)
 {
-	AtkObject *accessible;
-
 	g_return_val_if_fail (G_IS_OBJECT (obj), NULL);
 
-	accessible = eel_canvas_item_accessible_create (obj);
-
-	return accessible;
+	return eel_canvas_item_accessible_create (obj);
 }
 
 static void
@@ -4244,7 +4205,6 @@ eel_canvas_item_accessible_factory_get_type (void)
 					       "EelCanvasItemAccessibilityFactory",
 					       &tinfo, 0);
 	}
-
 	return type;
 }
 

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -4063,14 +4063,13 @@ eel_editable_label_accessible_delete_text_cb (EelEditableLabel *label,
 					      gint             arg2)
 {
   AtkObject *accessible;
-
-  accessible = gtk_widget_get_accessible (GTK_WIDGET (label));
-
   /*
    * Zero length text deleted so ignore
    */
   if (arg2 - arg1 == 0)
     return;
+
+  accessible = gtk_widget_get_accessible (GTK_WIDGET (label));
 
   g_signal_emit_by_name (accessible, "text_changed::delete", arg1, arg2 - arg1);
 }

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -2575,7 +2575,7 @@ eel_editable_label_move_line (EelEditableLabel *label,
 			      gint      count)
 {
   int n_lines, i;
-  int x;
+  int x=0;
   PangoLayoutLine *line;
   int index;
   

--- a/eel/eel-glib-extensions.c
+++ b/eel/eel-glib-extensions.c
@@ -334,14 +334,9 @@ int
 eel_g_str_list_index (GList *str_list,
 		      const char *str)
 {
-	int i;
-	GList *l;
-	for (i = 0, l = str_list; l != NULL; l = l->next, i++) {
-		if (!strcmp (str, (const char*)l->data)) {
-			return i;
-		}
-	}
-	return -1;
+/* FIXME: replaced the code here with the glib equivalent
+   when sure ok then replace each instance of the call with this code */
+    return(g_list_index(str_list, (gconstpointer *)str));
 }
 
 /**

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -1188,8 +1188,6 @@ nemo_file_get_start_stop_type (NemoFile *file)
 
 	g_return_val_if_fail (NEMO_IS_FILE (file), FALSE);
 
-	ret = G_DRIVE_START_STOP_TYPE_UNKNOWN;
-
 	ret = file->details->start_stop_type;
 	if (ret != G_DRIVE_START_STOP_TYPE_UNKNOWN)
 		goto out;
@@ -2884,7 +2882,7 @@ compare_by_display_name (NemoFile *file_1, NemoFile *file_2)
 	const char *name_1, *name_2;
 	const char *key_1, *key_2;
 	gboolean sort_last_1, sort_last_2;
-	int compare;
+	int compare=0;
 
 	name_1 = nemo_file_peek_display_name (file_1);
 	name_2 = nemo_file_peek_display_name (file_2);
@@ -4020,15 +4018,9 @@ nemo_file_get_filesystem_use_preview (NemoFile *file)
 gboolean
 nemo_file_should_show_thumbnail (NemoFile *file)
 {
-	const char *mime_type;
 	GFilesystemPreviewType use_preview;
 
 	use_preview = nemo_file_get_filesystem_use_preview (file);
-
-	mime_type = eel_ref_str_peek (file->details->mime_type);
-	if (mime_type == NULL) {
-		mime_type = "application/octet-stream";
-	}
 
 	/* If the thumbnail has already been created, don't care about the size
 	 * of the original file.

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -458,7 +458,6 @@ nemo_icon_canvas_item_get_drag_surface (NemoIconCanvasItem *item)
 {
 	cairo_surface_t *surface;
 	EelCanvas *canvas;
-	GdkScreen *screen;
 	int width, height;
     int pix_width, pix_height;
 	int item_offset_x, item_offset_y;
@@ -471,7 +470,6 @@ nemo_icon_canvas_item_get_drag_surface (NemoIconCanvasItem *item)
 	g_return_val_if_fail (NEMO_IS_ICON_CANVAS_ITEM (item), NULL);
 
 	canvas = EEL_CANVAS_ITEM (item)->canvas;
-	screen = gtk_widget_get_screen (GTK_WIDGET (canvas));
 	context = gtk_widget_get_style_context (GTK_WIDGET (canvas));
 
 	gtk_style_context_save (context);

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -1416,9 +1416,6 @@ lay_down_icons_horizontal (NemoIconContainer *container,
 			}
 		
 		lay_down_one_line (container, line_start, NULL, y, max_height_above, positions, TRUE);
-		
-		/* Advance to next line. */
-		y += max_height_below + ICON_PAD_BOTTOM;
 	}
 
 	g_array_free (positions, TRUE);

--- a/libnemo-private/nemo-icon-dnd.c
+++ b/libnemo-private/nemo-icon-dnd.c
@@ -586,8 +586,6 @@ nemo_icon_container_selection_items_local (NemoIconContainer *container,
 	/* must have at least one item */
 	g_assert (items);
 
-	result = FALSE;
-
 	/* get the URI associated with the container */
 	container_uri_string = get_container_uri (container);
 	

--- a/libnemo-private/nemo-icon-info.c
+++ b/libnemo-private/nemo-icon-info.c
@@ -410,7 +410,7 @@ nemo_icon_info_lookup (GIcon *icon,
 
 		filename = gtk_icon_info_get_filename (gtkicon_info);
 		if (filename == NULL) {
-			gtk_icon_info_free (gtkicon_info);
+			g_object_unref (gtkicon_info);
 			return nemo_icon_info_new_for_pixbuf (NULL, scale);
 		}
 
@@ -419,7 +419,7 @@ nemo_icon_info_lookup (GIcon *icon,
 
 		icon_info = g_hash_table_lookup (themed_icon_cache, &lookup_key);
 		if (icon_info) {
-			gtk_icon_info_free (gtkicon_info);
+			g_object_unref (gtkicon_info);
 			return g_object_ref (icon_info);
 		}
 		
@@ -428,7 +428,7 @@ nemo_icon_info_lookup (GIcon *icon,
 		key = themed_icon_key_new (filename, size);
 		g_hash_table_insert (themed_icon_cache, key, icon_info);
 
-		gtk_icon_info_free (gtkicon_info);
+		g_object_unref (gtkicon_info);
 
 		return g_object_ref (icon_info);
 	} else {
@@ -442,7 +442,7 @@ nemo_icon_info_lookup (GIcon *icon,
                                                                           GTK_ICON_LOOKUP_GENERIC_FALLBACK);
                 if (gtk_icon_info != NULL) {
                         pixbuf = gtk_icon_info_load_icon (gtk_icon_info, NULL);
-                        gtk_icon_info_free (gtk_icon_info);
+                        g_object_unref (gtk_icon_info);
                 } else {
                         pixbuf = NULL;
                 }

--- a/libnemo-private/nemo-tree-view-drag-dest.c
+++ b/libnemo-private/nemo-tree-view-drag-dest.c
@@ -609,11 +609,6 @@ receive_uris (NemoTreeViewDragDest *dest,
 			(GTK_WIDGET (dest->details->tree_view), action);
 	}
 
-	/* We only want to copy external uris */
-	if (dest->details->drag_type == NEMO_ICON_DND_URI_LIST) {
-		action = GDK_ACTION_COPY;
-	}
-
 	if (real_action > 0) {
 		if (!nemo_drag_uris_local (drop_target, source_uris)
 			|| real_action != GDK_ACTION_MOVE) {

--- a/libnemo-private/nemo-widget-menu-item.c
+++ b/libnemo-private/nemo-widget-menu-item.c
@@ -246,12 +246,9 @@ nemo_widget_menu_item_update (GtkActivatable *activatable,
                             const gchar    *property_name)
 {
   NemoWidgetMenuItem *widget_menu_item;
-  gboolean   use_appearance;
   widget_menu_item = NEMO_WIDGET_MENU_ITEM (activatable);
 
-  use_appearance = gtk_activatable_get_use_action_appearance (activatable);
-
-  if (!use_appearance)
+  if (!gtk_activatable_get_use_action_appearance (activatable))
     return;
 
   if (strcmp (property_name, "widget-a") == 0)
@@ -266,7 +263,6 @@ nemo_widget_menu_item_sync_action_properties (GtkActivatable *activatable,
 {
   NemoWidgetMenuItem *widget_menu_item;
   GtkWidget *widget;
-  gboolean   use_appearance;
 
   widget_menu_item = NEMO_WIDGET_MENU_ITEM (activatable);
 
@@ -274,9 +270,7 @@ nemo_widget_menu_item_sync_action_properties (GtkActivatable *activatable,
   if (!action)
     return;
 
-  use_appearance = gtk_activatable_get_use_action_appearance (activatable);
-
-  if (!use_appearance)
+  if (!gtk_activatable_get_use_action_appearance (activatable))
     return;
 
   widget = nemo_widget_menu_item_get_child_widget (widget_menu_item);

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -1313,4 +1313,3 @@ nemo_application_get_singleton (void)
 			     "flags", G_APPLICATION_HANDLES_OPEN,
 			     NULL);
 }
-

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -1313,3 +1313,4 @@ nemo_application_get_singleton (void)
 			     "flags", G_APPLICATION_HANDLES_OPEN,
 			     NULL);
 }
+

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -107,7 +107,6 @@ struct NemoIconViewDetails
 	guint icon_merge_id;
 	
 	gboolean filter_by_screen;
-	int num_screens;
 
 	gboolean compact;
 
@@ -481,29 +480,13 @@ nemo_icon_view_clear (NemoView *view)
 static gboolean
 should_show_file_on_screen (NemoView *view, NemoFile *file)
 {
-	char *screen_string;
-	int screen_num;
 	NemoIconView *icon_view;
-	GdkScreen *screen;
 
 	icon_view = NEMO_ICON_VIEW (view);
 
 	if (!nemo_view_should_show_file (view, file)) {
 		return FALSE;
-	}
-	
-	/* Get the screen for this icon from the metadata. */
-	screen_string = nemo_file_get_metadata
-		(file, NEMO_METADATA_KEY_SCREEN, "0");
-	screen_num = atoi (screen_string);
-	g_free (screen_string);
-	screen = gtk_widget_get_screen (GTK_WIDGET (view));
-
-	if (screen_num != gdk_screen_get_number (screen) &&
-	    (screen_num < icon_view->details->num_screens ||
-	     gdk_screen_get_number (screen) > 0)) {
-		return FALSE;
-	}
+	}	
 
 	return TRUE;
 }
@@ -1860,7 +1843,6 @@ nemo_icon_view_filter_by_screen (NemoIconView *icon_view,
 				     gboolean filter)
 {
 	icon_view->details->filter_by_screen = filter;
-	icon_view->details->num_screens = gdk_display_get_n_screens (gtk_widget_get_display (GTK_WIDGET (icon_view)));
 }
 
 static void

--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -2016,7 +2016,7 @@ nemo_path_bar_update_path (NemoPathBar *path_bar,
     fake_root = NULL;
     result = TRUE;
     first_directory = TRUE;
-    last_directory = FALSE;
+    last_directory;
     new_buttons = NULL;
     current_button_data = NULL;
 

--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -2058,7 +2058,6 @@ directory_contents_value_field_update (NemoPropertiesWindow *window)
 	g_assert (NEMO_IS_PROPERTIES_WINDOW (window));
 
 	status = NEMO_REQUEST_DONE;
-	file_status = NEMO_REQUEST_NOT_STARTED;
 	total_count = window->details->total_count;
 	total_size = window->details->total_size;
     total_hidden = window->details->hidden_count;
@@ -4177,9 +4176,7 @@ create_simple_permissions (NemoPropertiesWindow *window, GtkGrid *page_grid)
 					   !has_directory);
 	}
 
-	append_blank_slim_row (page_grid);
-
-	group_label = attach_title_field (page_grid, _("Others"));
+	append_blank_slim_row (page_grid);;
 	
 	if (has_directory) {
 		add_permissions_combo_box (window, page_grid,

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -2536,7 +2536,6 @@ update_undo_actions (NemoView *view)
 
 	undo_label = undo_description = redo_label = redo_description = NULL;
 
-	is_undo = FALSE;
 	undo_active = FALSE;
 	redo_active = FALSE;
 
@@ -4762,8 +4761,6 @@ reset_open_with_menu (NemoView *view, GList *selection)
 				      "OpenWithGroup",
 				      &view->details->open_with_merge_id,
 				      &view->details->open_with_action_group);
-	
-	num_applications = 0;
 
 	other_applications_visible = (selection != NULL);
 	filter_default = (selection != NULL);
@@ -8033,7 +8030,6 @@ nemo_view_init_show_hidden_files (NemoView *view)
 		return;
 	}
 
-	show_hidden_changed = FALSE;
 	mode = nemo_window_get_hidden_files_mode (view->details->window);
 
     if (mode == NEMO_WINDOW_SHOW_HIDDEN_FILES_ENABLE) {

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -2530,7 +2530,7 @@ update_undo_actions (NemoView *view)
 	NemoFileUndoManagerState undo_state;
 	GtkAction *action;
 	const gchar *label, *tooltip;
-	gboolean available, is_undo;
+	gboolean available;
 	gboolean undo_active, redo_active;
 	gchar *undo_label, *undo_description, *redo_label, *redo_description;
 
@@ -2544,9 +2544,7 @@ update_undo_actions (NemoView *view)
 
 	if (info != NULL && 
 	    (undo_state > NEMO_FILE_UNDO_MANAGER_STATE_NONE)) {
-		is_undo = (undo_state == NEMO_FILE_UNDO_MANAGER_STATE_UNDO);
-
-		if (is_undo) {
+		if (undo_state == NEMO_FILE_UNDO_MANAGER_STATE_UNDO) {
 			undo_active = TRUE;
 		} else {
 			redo_active = TRUE;

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1631,11 +1631,7 @@ nemo_window_initialize_menus (NemoWindow *window)
 void
 nemo_window_finalize_menus (NemoWindow *window)
 {
-	NemoTrashMonitor *monitor;
-
-	monitor = nemo_trash_monitor_get ();
-
-	g_signal_handlers_disconnect_by_func (monitor,
+	g_signal_handlers_disconnect_by_func (nemo_trash_monitor_get(),
 					      trash_state_changed_cb, window);
 }
 

--- a/src/nemo-window-slot-dnd.c
+++ b/src/nemo-window-slot-dnd.c
@@ -58,16 +58,14 @@ slot_proxy_drag_motion (GtkWidget          *widget,
   NemoWindowSlot *target_slot;
   GtkWidget *window;
   GdkAtom target;
-  int action;
+  int action = 0;
   char *target_uri;
-
-  drag_info = user_data;
-
-  action = 0;
 
   if (gtk_drag_get_source_widget (context) == widget) {
     goto out;
   }
+
+  drag_info = user_data;
 
   window = gtk_widget_get_toplevel (widget);
   g_assert (NEMO_IS_WINDOW (window));
@@ -163,13 +161,9 @@ slot_proxy_drag_leave (GtkWidget          *widget,
 		       unsigned int        time,
 		       gpointer            user_data)
 {
-    NemoDragSlotProxyInfo *drag_info;
-
-    drag_info = user_data;
-
     gtk_drag_unhighlight (widget);
 
-    drag_info_clear (drag_info);
+    drag_info_clear ((NemoDragSlotProxyInfo *)user_data);
 }
 
 static gboolean

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1607,7 +1607,6 @@ nemo_window_sync_zoom_widgets (NemoWindow *window)
 		can_zoom_in = can_zoom && nemo_view_can_zoom_in (view);
 		can_zoom_out = can_zoom && nemo_view_can_zoom_out (view);
 	} else {
-		zoom_level = NEMO_ZOOM_LEVEL_STANDARD;
 		supports_zooming = FALSE;
 		can_zoom = FALSE;
 		can_zoom_in = FALSE;
@@ -1984,7 +1983,6 @@ nemo_window_button_press_event (GtkWidget *widget,
 	NemoWindow *window;
 	gboolean handled;
 
-	handled = FALSE;
 	window = NEMO_WINDOW (widget);
 
 	if (mouse_extra_buttons && (event->button == mouse_back_button)) {

--- a/src/nemo-x-content-bar.c
+++ b/src/nemo-x-content-bar.c
@@ -61,11 +61,13 @@ content_bar_response_cb (GtkInfoBar *infobar,
 			 gpointer user_data)
 {
 	GAppInfo *default_app;
-	NemoXContentBar *bar = user_data;
+	NemoXContentBar *bar;
 
 	if (response_id != CONTENT_BAR_RESPONSE_APP) {
 		return;
 	}
+
+	bar = user_data;
 
 	if (bar->priv->x_content_type == NULL ||
 	    bar->priv->mount == NULL)
@@ -193,9 +195,7 @@ nemo_x_content_bar_get_property (GObject    *object,
 				     GValue     *value,
 				     GParamSpec *pspec)
 {
-	NemoXContentBar *bar;
-
-	bar = NEMO_X_CONTENT_BAR (object);
+	NemoXContentBar *bar = NEMO_X_CONTENT_BAR (object);
 
 	switch (prop_id) {
 	case PROP_MOUNT:


### PR DESCRIPTION
gdk_display_get_n_screens always returns 1, since GTK3.10, so calls to find the screen can be replaced by gdk_display_get_default_screen