### PR TITLE
Show icons for templates in the "create new document" menu

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -4567,9 +4567,7 @@ add_submenu (GtkUIManager *ui_manager,
 						 NULL,
 						 NULL);
 			if (pixbuf != NULL) {
-				g_object_set_data_full (G_OBJECT (action), "menu-icon",
-							g_object_ref (pixbuf),
-							g_object_unref);
+				gtk_action_set_gicon (action, G_ICON (pixbuf));
 			}
 			
 			g_object_set (action, "hide-if-empty", FALSE, NULL);
@@ -4594,6 +4592,24 @@ add_submenu (GtkUIManager *ui_manager,
 }
 
 static void
+menu_item_show_image (GtkUIManager *ui_manager,
+		      const char   *parent_path,
+		      const char   *action_name)
+{
+	char *path;
+	GtkWidget *menuitem;
+
+	path = g_strdup_printf ("%s/%s", parent_path, action_name);
+	menuitem = gtk_ui_manager_get_widget (ui_manager,
+					      path);
+	if (menuitem != NULL) {
+		gtk_image_menu_item_set_always_show_image (GTK_IMAGE_MENU_ITEM (menuitem),
+							   TRUE);
+	}
+	g_free (path);
+}
+
+static void
 add_application_to_open_with_menu (NemoView *view,
 				   GAppInfo *application, 
 				   GList *files,
@@ -4607,10 +4623,9 @@ add_application_to_open_with_menu (NemoView *view,
 	char *label;
 	char *action_name;
 	char *escaped_app;
-	char *path;
 	GtkAction *action;
 	GIcon *app_icon;
-	GtkWidget *menuitem;
+	GtkUIManager *ui_manager;
 
 	launch_parameters = application_launch_parameters_new 
 		(application, files, view);
@@ -4651,8 +4666,9 @@ add_application_to_open_with_menu (NemoView *view,
 	gtk_action_group_add_action (view->details->open_with_action_group,
 				     action);
 	g_object_unref (action);
-	
-	gtk_ui_manager_add_ui (nemo_window_get_ui_manager (view->details->window),
+
+	ui_manager = nemo_window_get_ui_manager (view->details->window);
+	gtk_ui_manager_add_ui (ui_manager,
 			       view->details->open_with_merge_id,
 			       menu_placeholder,
 			       action_name,
@@ -4660,14 +4676,9 @@ add_application_to_open_with_menu (NemoView *view,
 			       GTK_UI_MANAGER_MENUITEM,
 			       FALSE);
 
-	path = g_strdup_printf ("%s/%s", menu_placeholder, action_name);
-	menuitem = gtk_ui_manager_get_widget (
-					      nemo_window_get_ui_manager (view->details->window),
-					      path);
-	gtk_image_menu_item_set_always_show_image (GTK_IMAGE_MENU_ITEM (menuitem), TRUE);
-	g_free (path);
+	menu_item_show_image (ui_manager, menu_placeholder, action_name);
 
-	gtk_ui_manager_add_ui (nemo_window_get_ui_manager (view->details->window),
+	gtk_ui_manager_add_ui (ui_manager,
 			       view->details->open_with_merge_id,
 			       popup_placeholder,
 			       action_name,
@@ -4675,13 +4686,8 @@ add_application_to_open_with_menu (NemoView *view,
 			       GTK_UI_MANAGER_MENUITEM,
 			       FALSE);
 
-	path = g_strdup_printf ("%s/%s", popup_placeholder, action_name);
-	menuitem = gtk_ui_manager_get_widget (
-					      nemo_window_get_ui_manager (view->details->window),
-					      path);
-	gtk_image_menu_item_set_always_show_image (GTK_IMAGE_MENU_ITEM (menuitem), TRUE);
+	menu_item_show_image (ui_manager, popup_placeholder, action_name);
 
-	g_free (path);
 	g_free (action_name);
 	g_free (label);
 	g_free (tip);
@@ -5959,9 +5965,8 @@ add_script_to_scripts_menus (NemoView *directory_view,
 
 	pixbuf = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (pixbuf != NULL) {
-		g_object_set_data_full (G_OBJECT (action), "menu-icon",
-					pixbuf,
-					g_object_unref);
+		gtk_action_set_gicon (action, G_ICON (pixbuf));
+		g_object_unref (pixbuf);
 	}
 
 	g_signal_connect_data (action, "activate",
@@ -5996,6 +6001,10 @@ add_script_to_scripts_menus (NemoView *directory_view,
 			       action_name,
 			       GTK_UI_MANAGER_MENUITEM,
 			       FALSE);
+
+	menu_item_show_image (ui_manager, menu_path, action_name);
+	menu_item_show_image (ui_manager, popup_path, action_name);
+	menu_item_show_image (ui_manager, popup_bg_path, action_name);
 
 	g_free (name);
 	g_free (uri);
@@ -6338,9 +6347,8 @@ add_template_to_templates_menus (NemoView *directory_view,
 	
 	pixbuf = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (pixbuf != NULL) {
-		g_object_set_data_full (G_OBJECT (action), "menu-icon",
-					pixbuf,
-					g_object_unref);
+		gtk_action_set_gicon (action, G_ICON (pixbuf));
+		g_object_unref (pixbuf);
 	}
 
 	g_signal_connect_data (action, "activate",
@@ -6369,7 +6377,10 @@ add_template_to_templates_menus (NemoView *directory_view,
 			       action_name,
 			       GTK_UI_MANAGER_MENUITEM,
 			       FALSE);
-	
+
+	menu_item_show_image (ui_manager, menu_path, action_name);
+	menu_item_show_image (ui_manager, popup_bg_path, action_name);
+
 	g_free (escaped_label);
 	g_free (name);
 	g_free (tip);


### PR DESCRIPTION
Cherry-picked from [this Nautilus commit](https://git.gnome.org/browse/nautilus/commit/?id=1a1fa464fd16f93d9a9fbb73b894f4f6c0a098f8), adapted for Nemo.

Fixes https://bugs.launchpad.net/bugs/1418141.