### PR TITLE
Goto shortcuts

### DIFF
--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5499,7 +5499,9 @@ key_press_event (GtkWidget *widget,
 	 * start the typeahead find capabilities.
 	 * Copied from NemoIconContainer */
 	if (!handled &&
-	    event->keyval != GDK_KEY_slash /* don't steal slash key event, used for "go to" */ &&
+		event->keyval != GDK_KEY_asciitilde &&
+		event->keyval != GDK_KEY_KP_Divide &&
+	    event->keyval != GDK_KEY_slash /* don't steal slash key events, used for "go to" */ &&
 	    event->keyval != GDK_KEY_BackSpace &&
 	    event->keyval != GDK_KEY_Delete) {
 		GdkEvent *new_event;

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -820,6 +820,13 @@ action_toggle_location_entry_callback (GtkToggleAction *action,
     toggle_location_entry_setting(window, pane, FALSE);
 }
 
+void nemo_window_show_location_entry (NemoWindow *window) {
+	NemoWindowPane *pane;
+
+    pane = nemo_window_get_active_pane (window);
+    toggle_location_entry_setting(window, pane, TRUE);
+}
+
 static void
 action_menu_edit_location_callback (GtkAction *action,
 				gpointer user_data)

--- a/src/nemo-window-private.h
+++ b/src/nemo-window-private.h
@@ -184,5 +184,6 @@ void               nemo_window_update_show_hide_menu_items           (NemoWindow
 /* window toolbar */
 void               nemo_window_close_pane                            (NemoWindow    *window,
                                                                           NemoWindowPane *pane);
+void               nemo_window_show_location_entry                   (NemoWindow    *window);
 
 #endif /* NEMO_WINDOW_PRIVATE_H */

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -2185,6 +2185,12 @@ nemo_window_class_init (NemoWindowClass *class)
 	gtk_binding_entry_add_signal (binding_set, GDK_KEY_slash, 0,
 				      "prompt-for-location", 1,
 				      G_TYPE_STRING, "/");
+	gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Divide, 0,
+				      "prompt-for-location", 1,
+				      G_TYPE_STRING, "/");
+	gtk_binding_entry_add_signal (binding_set, GDK_KEY_asciitilde, 0,
+				      "prompt-for-location", 1,
+				      G_TYPE_STRING, "~");
 
 	class->reload = nemo_window_reload;
 	class->go_up = nemo_window_go_up_signal;

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -299,10 +299,9 @@ nemo_window_prompt_for_location (NemoWindow *window,
 
 	g_return_if_fail (NEMO_IS_WINDOW (window));
 
-	pane = window->details->active_pane;
-	nemo_window_pane_ensure_location_bar (pane);
-
 	if (initial) {
+		nemo_window_show_location_entry(window);
+		pane = window->details->active_pane;
 		nemo_location_bar_set_location (NEMO_LOCATION_BAR (pane->location_bar),
 						    initial);
 	}


### PR DESCRIPTION
This PR fixes a bug taht the location entry is not shown by the slash shortcut. 
It also adds the tilde and the numpad devide key as goto shortcuts. 
They are also assigned in the GtK file chooser for the same usage. 