### PR TITLE
[WIP] Make Nemo search files automatically when the contents change and display the results at the same time

### DIFF
--- a/libnemo-private/nemo-search-directory.c
+++ b/libnemo-private/nemo-search-directory.c
@@ -502,6 +502,8 @@ search_engine_hits_added (NemoSearchEngine *engine, GList *hits,
 	file = nemo_directory_get_corresponding_file (NEMO_DIRECTORY (search));
 	nemo_file_emit_changed (file);
 	nemo_file_unref (file);
+	
+	search_engine_finished (engine,search);
 }
 
 static void
@@ -568,6 +570,10 @@ search_engine_error (NemoSearchEngine *engine, const char *error_message, NemoSe
 static void
 search_engine_finished (NemoSearchEngine *engine, NemoSearchDirectory *search)
 {
+	if(search->details->search_finished){
+		return;
+		   }
+
 	search->details->search_finished = TRUE;
 
 	nemo_directory_emit_done_loading (NEMO_DIRECTORY (search));

--- a/src/nemo-search-bar.c
+++ b/src/nemo-search-bar.c
@@ -115,6 +115,15 @@ entry_has_text (NemoSearchBar *bar)
 }
 
 static void
+entry_changed_cb (GtkEntry *entry,
+                       GtkEntryIconPosition position,
+                       GdkEvent *event,
+                       NemoSearchBar *bar)
+{
+        g_signal_emit_by_name (entry, "activate", 0);
+}
+
+static void
 entry_icon_release_cb (GtkEntry *entry,
 		       GtkEntryIconPosition position,
 		       GdkEvent *event,
@@ -170,6 +179,8 @@ nemo_search_bar_init (NemoSearchBar *bar)
 			  G_CALLBACK (entry_activate_cb), bar);
 	g_signal_connect (bar->details->entry, "icon-release",
 			  G_CALLBACK (entry_icon_release_cb), bar);
+	g_signal_connect (bar->details->entry, "changed",
+			  G_CALLBACK (entry_changed_cb), bar);
 
 	gtk_widget_show (bar->details->entry);
 }

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -192,6 +192,8 @@ search_bar_activate_callback (NemoSearchBar *bar,
 	NemoQuery *query;
 	GFile *location;
 
+	remember_focus_widget (pane);//remember the focus in the search bar
+	
 	uri = nemo_search_directory_generate_new_uri ();
 	location = g_file_new_for_uri (uri);
 
@@ -216,6 +218,8 @@ search_bar_activate_callback (NemoSearchBar *bar,
 	nemo_directory_unref (directory);
 	g_object_unref (location);
 	g_free (uri);
+	
+	restore_focus_widget (pane);//restore the focus in the search bar
 }
 
 static void


### PR DESCRIPTION
I modified something so that the nemo search bar can search files automatically when the contents change and display search results incrementally at the same time.
And I fixed the bug that the nemo search bar can not remember and restore the focus when first input string.Now, the nemo search bar can continue to receive input when the contents change.  