### PR TITLE
Debian packaging: small fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Package: nemo
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         nemo-data (= ${binary:Version}),
+         nemo-data (= ${source:Version}),
          shared-mime-info (>= 0.50),
          desktop-file-utils (>= 0.7),
          gvfs (>= 1.3.2),
@@ -104,7 +104,6 @@ Depends: libnemo-extension1 (= ${binary:Version}),
          gir1.2-nemo-3.0 (= ${binary:Version}),
          libglib2.0-dev (>= 2.31.9),
          libgtk-3-dev (>= 3.3.18),
-         ${shlibs:Depends},
          ${misc:Depends}
 Description: libraries for nemo components - development version
  Nemo is the official file manager and graphical shell for the
@@ -117,7 +116,6 @@ Package: gir1.2-nemo-3.0
 Architecture: any
 Section: introspection
 Depends: ${gir:Depends},
-         ${shlibs:Depends},
          ${misc:Depends}
 Conflicts: gir1.0-nemo-3.0
 Replaces: gir1.0-nemo-3.0
@@ -131,7 +129,7 @@ Description: libraries for nemo components - gir bindings
 Package: nemo-data
 Architecture: all
 Depends: ${misc:Depends},
-         python
+         python2
 Suggests: nemo
 Description: data files for nemo
  Nemo is the official file manager and graphical shell for the

--- a/debian/control
+++ b/debian/control
@@ -129,7 +129,7 @@ Description: libraries for nemo components - gir bindings
 Package: nemo-data
 Architecture: all
 Depends: ${misc:Depends},
-         python2
+         python2.7
 Suggests: nemo
 Description: data files for nemo
  Nemo is the official file manager and graphical shell for the

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Build-Depends: debhelper (>= 8),
                cinnamon-translations,
                python-gi
 Homepage: http://www.github.com/linuxmint/nemo/
-Standards-Version: 3.9.2
+Standards-Version: 3.9.5
 
 Package: nemo
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ export LDFLAGS+=-Wl,-z,defs -Wl,-O1 -Wl,--as-needed
 
 
 %:
-	dh $@ --parallel --with autoreconf
+	dh $@ --parallel --with autoreconf,gir
 
 override_dh_autoreconf:
 	NOCONFIGURE=yes dh_autoreconf --as-needed -- ./autogen.sh


### PR DESCRIPTION
Fixes:
```
dpkg-gencontrol: warning: Depends field of package libnemo-extension-dev: unknown substitution variable ${shlibs:Depends}
dpkg-gencontrol: warning: Depends field of package gir1.2-nemo-3.0: unknown substitution variable ${gir:Depends}
dpkg-gencontrol: warning: Depends field of package gir1.2-nemo-3.0: unknown substitution variable ${shlibs:Depends}

W: nemo source: ancient-standards-version 3.9.2 (current is 3.9.5)
E: nemo source: not-binnmuable-any-depends-all nemo -> nemo-data
E: nemo-data: python-script-but-no-python-dep usr/share/nemo/actions/myaction.py
```