### PR TITLE
update cinnamon-desktop min version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ(2.54)
 dnl ===========================================================================
 
 m4_define(glib_minver,                 2.31.9)
-m4_define(cinnamon_desktop_minver,     2.6.0)
+m4_define(cinnamon_desktop_minver,     2.6.1)
 m4_define(pango_minver,                1.28.3)
 m4_define(gtk_minver,                  3.3.17)
 m4_define(xml_minver,                  2.7.8)

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ(2.54)
 dnl ===========================================================================
 
 m4_define(glib_minver,                 2.31.9)
-m4_define(cinnamon_desktop_minver,     1.0.0)
+m4_define(cinnamon_desktop_minver,     2.6.0)
 m4_define(pango_minver,                1.28.3)
 m4_define(gtk_minver,                  3.3.17)
 m4_define(xml_minver,                  2.7.8)


### PR DESCRIPTION
```
$ nemo
Initializing nemo-dropbox 2.4.0
nemo: symbol lookup error: nemo: undefined symbol: gnome_desktop_thumbnail_cache_check_permissions
```