### PR TITLE
add runtime requirement for libcinnamon-desktop4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,7 @@ Depends: ${shlibs:Depends},
          desktop-file-utils (>= 0.7),
          gvfs (>= 1.3.2),
          libglib2.0-data,
+         libcinnamon-desktop4 (>= 2.6.1),
          cinnamon-desktop-data,
          cinnamon-translations
 Recommends: eject,


### PR DESCRIPTION
nemo should have a versioned requirement for  libcinnamon-desktop4-2.6.1