### PR TITLE
Fix default sort order bug in list view

### DIFF
--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -197,6 +197,7 @@ get_default_sort_order (NemoFile *file, gboolean *reversed)
 		"name",
 		"size",
 		"type",
+		"detailed_type",
 		"date_modified",
 		"date_accessed",
 		"trashed_on",


### PR DESCRIPTION
This fixes a bug that occurs when selecting a default sort method for list view. Selecting options from detailed type on down actually enables the next option in the drop down box.

Fixes #776, fixes #803, fixes #889