### PR TITLE
window: use F5 for refresh view

### DIFF
--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1131,7 +1131,7 @@ static const GtkActionEntry main_entries[] = {
   /* tooltip */                  N_("Stop loading the current location"),
                                  G_CALLBACK (action_stop_callback) },
   /* name, stock id */         { "Reload", GTK_STOCK_REFRESH,
-  /* label, accelerator */       N_("_Reload"), "<control>R",
+  /* label, accelerator */       N_("_Reload"), "F5",
   /* tooltip */                  N_("Reload the current location"),
                                  G_CALLBACK (action_reload_callback) },
   /* name, stock id */         { "NemoHelp", GTK_STOCK_HELP,


### PR DESCRIPTION
Based on

https://git.gnome.org/browse/nautilus/commit/?id=b3d37f7fe1b37e1594fb76edbbbc575858faf5e8

I have also got used to F5 being the refresh key for browsers.