### PR TITLE
Scripts and actions path

### DIFF
--- a/libnemo-private/nemo-action-manager.c
+++ b/libnemo-private/nemo-action-manager.c
@@ -141,7 +141,7 @@ static void
 set_up_actions_directories (NemoActionManager *action_manager)
 {
 
-    gchar *sys_path = g_build_filename (NEMO_DATADIR, "actions", NULL);
+    gchar *sys_path = nemo_action_manager_get_sys_directory_path ();
     gchar *sys_uri = g_filename_to_uri (sys_path, NULL, NULL);
 
     gchar *user_path = g_build_filename (g_get_user_data_dir (), "nemo", "actions", NULL);
@@ -355,4 +355,16 @@ GList *
 nemo_action_manager_list_actions (NemoActionManager *action_manager)
 {
     return action_manager->action_list_dirty ? NULL : action_manager->actions;
+}
+
+gchar *
+nemo_action_manager_get_user_directory_path (void)
+{
+    return g_build_filename (g_get_user_data_dir (), "nemo", "actions", NULL);
+}
+
+gchar *
+nemo_action_manager_get_sys_directory_path (void)
+{
+    return g_build_filename (NEMO_DATADIR, "actions", NULL);
 }

--- a/libnemo-private/nemo-action-manager.h
+++ b/libnemo-private/nemo-action-manager.h
@@ -53,5 +53,7 @@ struct _NemoActionManagerClass {
 GType         nemo_action_manager_get_type             (void);
 NemoActionManager   *nemo_action_manager_new           (void);
 GList *       nemo_action_manager_list_actions (NemoActionManager *action_manager);
+gchar *       nemo_action_manager_get_user_directory_path (void);
+gchar *       nemo_action_manager_get_sys_directory_path (void);
 
 #endif /* NEMO_ACTION_MANAGER_H */

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1241,6 +1241,7 @@ try_vector (const gchar *op, gint vector)
     } else if (g_strcmp0 (op, GREATER_THAN) == 0) {
         return (vector > 0);
     }
+    return FALSE;
 }
 
 static gboolean

--- a/libnemo-private/nemo-file-utilities.c
+++ b/libnemo-private/nemo-file-utilities.c
@@ -151,6 +151,19 @@ nemo_get_accel_map_file (void)
 	}
 }
 
+/**
+ * nemo_get_scripts_directory_path:
+ *
+ * Get the path for the directory containing nemo scripts.
+ *
+ * Return value: the directory path containing nemo scripts
+ **/
+char *
+nemo_get_scripts_directory_path (void)
+{
+	return g_build_filename (g_get_user_data_dir (), "nemo", "scripts", NULL);
+}
+
 typedef struct {
 	char *type;
 	char *path;

--- a/libnemo-private/nemo-monitor.c
+++ b/libnemo-private/nemo-monitor.c
@@ -71,7 +71,7 @@ call_consume_changes_idle_cb (gpointer not_used)
 	return FALSE;
 }
 
-
+static void
 schedule_call_consume_changes (void)
 {
   if (call_consume_changes_idle_id == 0) {

--- a/src/nemo-action-config-widget.c
+++ b/src/nemo-action-config-widget.c
@@ -10,6 +10,7 @@
 #include "nemo-view.h"
 #include "nemo-file.h"
 #include <glib.h>
+#include <libnemo-private/nemo-action-manager.h>
 
 G_DEFINE_TYPE (NemoActionConfigWidget, nemo_action_config_widget, NEMO_TYPE_CONFIG_BASE_WIDGET);
 
@@ -209,11 +210,11 @@ refresh_widget (NemoActionConfigWidget *widget)
 
     gchar *path = NULL;
 
-    path = g_build_filename ("/", "usr", "share", "nemo", "actions", NULL);
+    path = nemo_action_manager_get_sys_directory_path ();
     populate_from_directory (widget, path);
     g_clear_pointer (&path, g_free);
 
-    path = g_build_filename (g_get_user_data_dir (), "nemo", "actions", NULL);
+    path = nemo_action_manager_get_user_directory_path ();
     populate_from_directory (widget, path);
     g_clear_pointer (&path, g_free);
 

--- a/src/nemo-interesting-folder-bar.c
+++ b/src/nemo-interesting-folder-bar.c
@@ -29,6 +29,7 @@
 #include <libnemo-private/nemo-file-utilities.h>
 #include <libnemo-private/nemo-file.h>
 #include <libnemo-private/nemo-trash-monitor.h>
+#include <libnemo-private/nemo-action-manager.h>
 
 #define NEMO_INTERESTING_FOLDER_BAR_GET_PRIVATE(o)\
 	(G_TYPE_INSTANCE_GET_PRIVATE ((o), NEMO_TYPE_INTERESTING_FOLDER_BAR, NemoInterestingFolderBarPrivate))
@@ -209,7 +210,7 @@ nemo_interesting_folder_bar_new_for_location (NemoView *view, GFile *location)
     gchar *path = NULL;
     GFile *tmp_loc = NULL;
 
-    path = g_build_filename (g_get_user_data_dir (), "nemo", "actions", NULL);
+    path = nemo_action_manager_get_user_directory_path ();
     tmp_loc = g_file_new_for_path (path);
 
     if (g_file_equal (location, tmp_loc)) {
@@ -220,7 +221,7 @@ nemo_interesting_folder_bar_new_for_location (NemoView *view, GFile *location)
     g_free (path);
     g_object_unref (tmp_loc);
 
-    path = g_build_filename (g_get_user_data_dir (), "nemo", "scripts", NULL);
+    path = nemo_get_scripts_directory_path ();
     tmp_loc = g_file_new_for_path (path);
 
     if (g_file_equal (location, tmp_loc))

--- a/src/nemo-script-config-widget.c
+++ b/src/nemo-script-config-widget.c
@@ -9,6 +9,7 @@
 #include "nemo-application.h"
 #include "nemo-view.h"
 #include "nemo-file.h"
+#include <libnemo-private/nemo-file-utilities.h>
 
 #include <glib.h>
 
@@ -133,11 +134,7 @@ refresh_widget (NemoScriptConfigWidget *widget)
 
     gchar *path = NULL;
 
-    path = g_build_filename ("/", "usr", "share", "nemo", "scripts", NULL);
-    populate_from_directory (widget, path);
-    g_clear_pointer (&path, g_free);
-
-    path = g_build_filename (g_get_user_data_dir (), "nemo", "scripts", NULL);
+    path = nemo_get_scripts_directory_path ();
     populate_from_directory (widget, path);
     g_clear_pointer (&path, g_free);
 
@@ -235,7 +232,7 @@ static void
 on_open_folder_clicked (GtkWidget *button, NemoScriptConfigWidget *widget)
 {
     gchar *path = NULL;
-    path = g_build_filename (g_get_user_data_dir (), "nemo", "scripts", NULL);
+    path = nemo_get_scripts_directory_path ();
     GFile *location = g_file_new_for_path (path);
 
     nemo_application_open_location (nemo_application_get_singleton (),

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -2312,10 +2312,7 @@ set_up_scripts_directory_global (void)
 		return TRUE;
 	}
 
-    scripts_directory_path = g_build_filename (g_get_user_data_dir (),
-                                               "nemo",
-                                               "scripts",
-                                               NULL);
+	scripts_directory_path = nemo_get_scripts_directory_path ();
 
 	if (g_mkdir_with_parents (scripts_directory_path, 0755) == 0) {
 		scripts_directory_uri = g_filename_to_uri (scripts_directory_path, NULL, NULL);


### PR DESCRIPTION
This PR replaces various string literals to build the scripts and actions path by function calls to a single place. I also removed the unused sys scripts path and fixes minor build issues that prevents to build the tree with Ubuntu Trusty. 