### PR TITLE
Show tooltips in action config

### DIFF
--- a/data/add-desklets.nemo_action.in
+++ b/data/add-desklets.nemo_action.in
@@ -2,7 +2,7 @@
 
 Name=Add Desklets
 
-Comment=Add Desklets
+Comment=Add Cinamon desklets
 
 Exec=cinnamon-settings desklets
 

--- a/data/change-background.nemo_action.in
+++ b/data/change-background.nemo_action.in
@@ -2,7 +2,7 @@
 
 Name=Change Desktop _Background
 
-Comment=Change Desktop _Background
+Comment=Change the Cinnamon desktop background
 
 Exec=cinnamon-settings backgrounds
 

--- a/data/set-as-background.nemo_action.in
+++ b/data/set-as-background.nemo_action.in
@@ -2,7 +2,7 @@
 
 Name=Set as Wallpaper...
 
-Comment=Set the selected image as your desktop wallpaper
+Comment=Set the selected image as your Cinnamon desktop wallpaper
 
 Exec=gsettings set org.cinnamon.desktop.background picture-uri "%U"
 

--- a/src/nemo-action-config-widget.c
+++ b/src/nemo-action-config-widget.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE (NemoActionConfigWidget, nemo_action_config_widget, NEMO_TYPE_CONF
 #define ACTION_FILE_GROUP "Nemo Action"
 #define KEY_ACTIVE "Active"
 #define KEY_NAME "Name"
+#define KEY_COMMENT "Comment"
 #define KEY_ICON_NAME "Icon-Name"
 #define KEY_STOCK_ID "Stock-Id"
 
@@ -25,6 +26,7 @@ typedef struct {
     NemoActionConfigWidget *widget;
 
     gchar *name;
+    gchar *comment;
     gchar *stock_id;
     gchar *icon_name;
     gchar *filename;
@@ -34,6 +36,7 @@ static void
 action_proxy_free (ActionProxy *proxy)
 {
     g_clear_pointer (&proxy->name, g_free);
+    g_clear_pointer (&proxy->comment, g_free);
     g_clear_pointer (&proxy->stock_id, g_free);
     g_clear_pointer (&proxy->icon_name, g_free);
     g_clear_pointer (&proxy->filename, g_free);
@@ -120,15 +123,21 @@ make_action_proxy (const gchar *filename, const gchar *fullpath)
                                                 KEY_NAME,
                                                 NULL,
                                                 NULL);
-
     if (name != NULL)
         proxy->name = g_strdup (name);
+
+    gchar *comment = g_key_file_get_string (key_file,
+                                            ACTION_FILE_GROUP,
+                                            KEY_COMMENT,
+                                            NULL);
+    if (comment != NULL)
+        proxy->comment = g_strdup (comment);
+
 
     gchar *icon_name = g_key_file_get_string (key_file,
                                               ACTION_FILE_GROUP,
                                               KEY_ICON_NAME,
                                               NULL);
-
     if (icon_name != NULL)
         proxy->icon_name = g_strdup (icon_name);
 
@@ -268,6 +277,8 @@ refresh_widget (NemoActionConfigWidget *widget)
             gchar *display_name = strip_accel (proxy->name);
             w = gtk_label_new (display_name);
             g_free (display_name);
+
+            gtk_widget_set_tooltip_text(w, proxy->comment);
 
             gtk_box_pack_start (GTK_BOX (box), w, FALSE, FALSE, 2);
 


### PR DESCRIPTION
This PR shows the action comments in the action config view. 
This is a workaround to distinguish for actions with the same name, but different conditions. 
In this case the action autor can place different comments. 

