### PR TITLE
Escape Percents in bulk rename

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7244,6 +7244,13 @@ invoke_external_bulk_rename_utility (NemoView *view,
 		cmd = g_string_append (cmd, quoted_parameter);
 		g_free (quoted_parameter);
 	}
+	
+	// Escape percents
+	for (int i = 0; i < strlen(cmd->str); i++) {
+		if (cmd->str[i] == '%') {
+			g_string_insert_c(cmd, i++, '%');
+		}
+	}
 
 	/* spawning and error handling */
 	nemo_launch_application_from_command (gtk_widget_get_screen (GTK_WIDGET (view)),


### PR DESCRIPTION
Fixes issue #614

`g_app_info_create_from_commandline` eats the percent signs in file names with spaces. This doubles all percent signs.

This works better than `g_uri_unescape_string` as it still works on file-names with percent signs in them.