### PR TITLE
reanable no-desktop command line option and add force-desktop

### DIFF
--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -116,6 +116,7 @@ struct _NemoApplicationPriv {
     NemoDesktopManager *desktop_manager;
 
 	gboolean no_desktop;
+	gboolean force_desktop;
 	gchar *geometry;
 
     gboolean cache_problem;
@@ -695,9 +696,11 @@ nemo_application_local_command_line (GApplication *application,
 		{ "no-default-window", 'n', 0, G_OPTION_ARG_NONE, &no_default_window,
 		  N_("Only create windows for explicitly specified URIs."), NULL },
 		{ "no-desktop", '\0', 0, G_OPTION_ARG_NONE, &self->priv->no_desktop,
-		  N_("Do not manage the desktop (ignore the preference set in the preferences dialog)."), NULL },
-        { "fix-cache", '\0', 0, G_OPTION_ARG_NONE, &fix_cache,
-          N_("Repair the user thumbnail cache - this can be useful if you're having trouble with file thumbnails.  Must be run as root"), NULL },
+		  N_("Never manage the desktop (ignore the GSettings preference)."), NULL },
+		{ "force-desktop", '\0', 0, G_OPTION_ARG_NONE, &self->priv->force_desktop,
+		  N_("Always manage the desktop (ignore the GSettings preference)."), NULL },
+		{ "fix-cache", '\0', 0, G_OPTION_ARG_NONE, &fix_cache,
+		  N_("Repair the user thumbnail cache - this can be useful if you're having trouble with file thumbnails.  Must be run as root"), NULL },
 		{ "quit", 'q', 0, G_OPTION_ARG_NONE, &kill_shell, 
 		  N_("Quit Nemo."), NULL },
 		{ G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &remaining, NULL,  N_("[URI...]") },
@@ -823,6 +826,17 @@ nemo_application_local_command_line (GApplication *application,
 	return TRUE;	
 }
 
+gboolean 
+nemo_application_get_show_desktop (NemoApplication *self) {
+	if (self->priv->force_desktop) {
+		return TRUE;
+	} 
+	if (self->priv->no_desktop) {
+		return FALSE;
+	}
+	return g_settings_get_boolean (nemo_desktop_preferences, NEMO_PREFERENCES_SHOW_DESKTOP);
+}
+
 static gboolean
 css_provider_load_from_resource (GtkCssProvider *provider,
                      const char     *resource_path,
@@ -907,8 +921,6 @@ init_icons_and_styles (void)
 static void
 init_desktop (NemoApplication *self)
 {
-	GdkScreen *screen;
-	screen = gdk_display_get_default_screen (gdk_display_get_default ());
 	/* Initialize the desktop link monitor singleton */
 	nemo_desktop_link_monitor_get ();
 

--- a/src/nemo-application.h
+++ b/src/nemo-application.h
@@ -93,5 +93,6 @@ void nemo_application_clear_cache_flag (NemoApplication *application);
 void nemo_application_set_cache_flag (NemoApplication *application);
 void nemo_application_ignore_cache_problem (NemoApplication *application);
 gboolean nemo_application_get_cache_problem_ignored (NemoApplication *application);
+gboolean nemo_application_get_show_desktop (NemoApplication *application);
 
 #endif /* __NEMO_APPLICATION_H__ */

--- a/src/nemo-desktop-manager.h
+++ b/src/nemo-desktop-manager.h
@@ -40,7 +40,8 @@ typedef struct {
   GdkWindow *root_window;
 
   gulong size_changed_id;
-  gulong setting_changed_id;
+  gulong desktop_layout_changed_id;
+  gulong show_desktop_changed_id;
   gulong home_dir_changed_id;
   gulong cinnamon_panel_layout_changed_id;
   gulong orphaned_icon_handling_id;


### PR DESCRIPTION
I have done this during my work merging the recent master changes into my Nautilus merge branch
https://github.com/linuxmint/nemo/pull/1041

Since I cannot compile master on stock Ubuntu, it is untested. 
