### PR TITLE
add some style classes

### DIFF
--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -253,6 +253,9 @@
     <property name="window_position">center</property>
     <property name="default_width">800</property>
     <property name="default_height">600</property>
+    <style>
+      <class name="nemo-properties-dialog"/>
+    </style>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -983,6 +983,11 @@ nemo_window_pane_init (NemoWindowPane *pane)
 	pane->active_slot = NULL;
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (pane), GTK_ORIENTATION_VERTICAL);
+
+	GtkStyleContext *context;
+
+	context = gtk_widget_get_style_context (GTK_WIDGET (pane));
+	gtk_style_context_add_class (context, "nemo-window-pane");
 }
 
 NemoWindowPane *


### PR DESCRIPTION
Those classes we used already for fedora 24 with gtk+-3.20.
http://pkgs.fedoraproject.org/cgit/rpms/nemo.git/tree/

nemo-window-pane is very useful to style everything under it, ie views, placesbar, ......, to avoid a long widget chain with gtk+-3.20.
nemo-properties-dialog i use for submarine themes from Mate to style the stack-switcher and to remove unwanted frame borders, which is side effect of using nodes with gtk+-3.20 changes .

Needed class nemo-window is already requested by another PR.