### PR TITLE
nemo-window: add new flag NEMO_WINDOW_OPEN_FLAG_SEARCH and use the

### DIFF
--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -459,7 +459,10 @@ nemo_window_slot_open_location_full (NemoWindowSlot *slot,
 		    (flags & NEMO_WINDOW_OPEN_FLAG_NEW_TAB) != 0));
 
 	/* and if the flags specify so, this is overridden */
-	if ((flags & NEMO_WINDOW_OPEN_FLAG_NEW_WINDOW) != 0) {
+	if ((flags & NEMO_WINDOW_OPEN_FLAG_SEARCH) != 0) {
+		use_same = TRUE;
+	}
+	else if ((flags & NEMO_WINDOW_OPEN_FLAG_NEW_WINDOW) != 0) {
 		use_same = FALSE;
 	}
 

--- a/src/nemo-window-slot.c
+++ b/src/nemo-window-slot.c
@@ -31,6 +31,7 @@
 #include "nemo-floating-bar.h"
 #include "nemo-window-private.h"
 #include "nemo-window-manage-views.h"
+#include "nemo-window-types.h"
 
 #include <glib/gi18n.h>
 
@@ -102,7 +103,7 @@ create_new_search (NemoWindowSlot *slot)
 	directory = nemo_directory_get (location);
 	g_assert (NEMO_IS_SEARCH_DIRECTORY (directory));
 
-	nemo_window_slot_open_location_full (slot, location, 0, NULL, sync_search_location_cb, slot);
+	nemo_window_slot_open_location_full (slot, location, NEMO_WINDOW_OPEN_FLAG_SEARCH, NULL, sync_search_location_cb, slot);
 
 	nemo_directory_unref (directory);
 	g_object_unref (location);

--- a/src/nemo-window-types.h
+++ b/src/nemo-window-types.h
@@ -43,7 +43,8 @@ typedef void (* NemoWindowGoToCallback) (NemoWindow *window,
 typedef enum {
         NEMO_WINDOW_OPEN_FLAG_CLOSE_BEHIND = 1<<0,
         NEMO_WINDOW_OPEN_FLAG_NEW_WINDOW = 1<<1,
-        NEMO_WINDOW_OPEN_FLAG_NEW_TAB = 1<<2
+        NEMO_WINDOW_OPEN_FLAG_NEW_TAB = 1<<2,
+        NEMO_WINDOW_OPEN_FLAG_SEARCH = 1<<3
 } NemoWindowOpenFlags;
 
 #endif /* __NEMO_WINDOW_TYPES_H__ */


### PR DESCRIPTION
same slot if this flag is passed to nemo_window_slot_open_location_full
to avoid opening a new window (and a crash) when starting a search
with the open in new window preference enabled