### PR TITLE
Don't draw the desktop on a cloned monitor

### DIFF
--- a/libnemo-private/nemo-desktop-utils.c
+++ b/libnemo-private/nemo-desktop-utils.c
@@ -53,3 +53,28 @@ nemo_desktop_utils_get_monitor_for_widget (GtkWidget *widget)
 
     return monitor;
 }
+
+gboolean
+nemo_desktop_utils_get_monitor_cloned (gint monitor, gint x_primary)
+{
+    GdkRectangle rect_primary;
+    GdkRectangle rect_test;
+
+    ensure_screen ();
+
+    gint n_monitors = gdk_screen_get_n_monitors (default_screen);
+
+	g_return_val_if_fail (monitor >= 0 && monitor < n_monitors, FALSE);
+	g_return_val_if_fail (x_primary >= 0 && x_primary < n_monitors, FALSE);
+
+    gdk_screen_get_monitor_geometry(default_screen, x_primary, &rect_primary);
+    gdk_screen_get_monitor_geometry(default_screen, monitor, &rect_test);
+
+    if (rect_primary.x == rect_test.x &&
+    		rect_primary.y == rect_test.y) {
+    	return TRUE;
+    }
+    return FALSE;
+}
+
+

--- a/libnemo-private/nemo-desktop-utils.h
+++ b/libnemo-private/nemo-desktop-utils.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 
 void nemo_desktop_utils_get_monitor_work_rect (gint monitor, GdkRectangle *rect);
 gint nemo_desktop_utils_get_monitor_for_widget (GtkWidget *widget);
+gboolean nemo_desktop_utils_get_monitor_cloned (gint monitor, gint x_primary);
 
 G_END_DECLS
 

--- a/src/nemo-desktop-manager.c
+++ b/src/nemo-desktop-manager.c
@@ -8,6 +8,7 @@
 #include <gdk/gdkx.h>
 
 #include <libnemo-private/nemo-global-preferences.h>
+#include <libnemo-private/nemo-desktop-utils.h>
 
 G_DEFINE_TYPE (NemoDesktopManager, nemo_desktop_manager, G_TYPE_OBJECT);
 
@@ -123,7 +124,7 @@ layout_changed (NemoDesktopManager *manager)
         if (i == x_primary) {
             create_new_desktop_window (manager, i, show_desktop_on_primary, show_desktop_on_primary);
             primary_set = primary_set || show_desktop_on_primary;
-        } else {
+        } else if (!nemo_desktop_utils_get_monitor_cloned (i, x_primary)) {
             gboolean set_layout_primary = !primary_set && !show_desktop_on_primary && show_desktop_on_remaining;
             create_new_desktop_window (manager, i, set_layout_primary, show_desktop_on_remaining);
             primary_set = primary_set || set_layout_primary;
@@ -211,8 +212,8 @@ nemo_desktop_manager_constructed (GObject *object)
 
     manager->show_desktop_changed_id = g_signal_connect_swapped (nemo_desktop_preferences, 
                                                                  "changed::" NEMO_PREFERENCES_SHOW_DESKTOP,
-				  				 G_CALLBACK (layout_changed),
-				                                 manager);
+                                                                 G_CALLBACK (layout_changed),
+                                                                 manager);
 
     manager->desktop_layout_changed_id = g_signal_connect_swapped (nemo_desktop_preferences,
                                                                    "changed::" NEMO_PREFERENCES_DESKTOP_LAYOUT,


### PR DESCRIPTION
If you clone (mirror) the two monitors, both desktops of both monitors are drawn on both monitors. 
This is no harm if the empty monitor is at index 1. If the primary monitor is on 1, the empty desktop is on top of the desktop icons and catches all mouse actions. 