### PR TITLE
Fix segfault on changing the number of colums when in list view

### DIFF
--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -1985,7 +1985,7 @@ apply_columns_settings (NemoListView *list_view,
 	old_view_columns = gtk_tree_view_get_columns (list_view->details->tree_view);
 	for (l = old_view_columns; l != NULL; l = l->next) {
 		if (g_list_find (view_columns, l->data) == NULL) {
-			gtk_tree_view_remove_column (list_view->details->tree_view, l->data);
+			gtk_tree_view_column_set_visible (l->data, FALSE);
 		}
 	}
 	g_list_free (old_view_columns);
@@ -2001,6 +2001,7 @@ apply_columns_settings (NemoListView *list_view,
                              G_CALLBACK (column_header_clicked),
                              list_view);
         }
+        gtk_tree_view_column_set_visible (l->data, TRUE);
 	}
     g_list_free (old_view_columns);
 


### PR DESCRIPTION
Fixes #1156 

So I figured out that `gtk_tree_view_column_get_button (l->data)` returned NULL after a column had been removed from the tree at line 1988 - this caused the segfault.
I'm suggesting to hide and show the columns instead of removing and adding them. This fixes the segfault for me and still allows to have different number of columns for different locations (e.g., Home and Trash as described in the issue).