### PR TITLE
Avoid compiler warnings

### DIFF
--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -35,6 +35,7 @@
 #include "nemo-window.h"
 #include "nemo-desktop-window.h"
 #include "nemo-desktop-manager.h"
+#include "nemo-application.h"
 
 #include <stdlib.h>
 #include <eel/eel-vfs-extensions.h>

--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -129,7 +129,7 @@ struct _NemoPathBarDetails {
 	GtkWidget *down_slider_button;
 	guint settings_signal_id;
 	gint icon_size;
-	gint16 slider_width;
+	gint slider_width;
 	gint16 spacing;
 	gint16 button_offset;
 	guint timer;


### PR DESCRIPTION
https://github.com/linuxmint/nemo/commit/7f8245dbff1a61582d96f6aeff85bb2872553c5b - this header seems to have been missing since last year
https://github.com/linuxmint/nemo/commit/c0813b0e7e4f63c01bb150229c94ebe36d5b2c29 - we pass this gint16 to gtk where it specifies gint which triggers warnings. gtk seems to have always specified gint since the associated function was added in 3.0: https://developer.gnome.org/gtk3/3.0/GtkWidget.html#gtk-widget-get-preferred-width