### PR TITLE
prefs: Don't try to hardcode a minimum size for the preferences dialog

### DIFF
--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -107,6 +107,8 @@
 
 #define W(s) (gtk_builder_get_object (builder, s))
 
+#define TOOLBAR_PADDING 20
+
 static const char * const default_view_values[] = {
 	"icon-view",
 	"list-view",
@@ -765,6 +767,7 @@ static  void
 nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *window)
 {
 	GtkWidget *dialog;
+    GtkWidget *stack_switcher;
 
 	/* setup UI */
 	nemo_file_management_properties_size_group_create (builder,
@@ -1009,9 +1012,11 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
 		gtk_window_set_screen (GTK_WINDOW (dialog), gtk_window_get_screen(window));
 	}
 
-	gint width, height;
-	gtk_window_get_default_size (GTK_WINDOW (dialog), &width, &height);
-	gtk_widget_set_size_request (dialog, width, height);
+    stack_switcher = GTK_WIDGET (gtk_builder_get_object (builder, "stack-switcher"));
+
+    gint min_width, nat_width;
+    gtk_widget_get_preferred_width (stack_switcher, &min_width, &nat_width);
+    gtk_widget_set_size_request (dialog, nat_width + TOOLBAR_PADDING, -1);
 
 	preferences_dialog = dialog;
 	g_object_add_weak_pointer (G_OBJECT (dialog), (gpointer *) &preferences_dialog);

--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -251,7 +251,7 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">File Management Preferences</property>
     <property name="window_position">center</property>
-    <property name="default_width">850</property>
+    <property name="default_width">800</property>
     <property name="default_height">600</property>
     <style>
       <class name="nemo-properties-dialog"/>


### PR DESCRIPTION
This improves a bit on https://github.com/linuxmint/nemo/commit/aa19ff3ebdb29781a7a3cbd701c589d67ac707c5

Since a large number of user settings such as translations, font-scaling, etc. can affect this, don't attempt to guess a minimum size. Instead get the size wanted by the stack switcher plus a small value to compensate for padding on the toolbar and use that to determine the minimum size instead.