### PR TITLE
Fix GCC pointer signedness warnings

### DIFF
--- a/libnemo-private/nemo-clipboard-monitor.c
+++ b/libnemo-private/nemo-clipboard-monitor.c
@@ -306,7 +306,7 @@ nemo_get_clipboard_callback (GtkClipboard     *clipboard,
                 gsize len;
 
                 str = convert_file_list_to_string (clipboard_info, FALSE, &len);
-                gtk_selection_data_set (selection_data, copied_files_atom, 8, str, len);
+                gtk_selection_data_set (selection_data, copied_files_atom, 8, (guchar *) str, len);
                 g_free (str);
         }
 }

--- a/libnemo-private/nemo-clipboard.c
+++ b/libnemo-private/nemo-clipboard.c
@@ -585,13 +585,13 @@ nemo_clipboard_get_uri_list_from_selection_data (GtkSelectionData *selection_dat
 	    || gtk_selection_data_get_length (selection_data) <= 0) {
 		items = NULL;
 	} else {
-		guchar *data;
+		gchar *data;
 		/* Not sure why it's legal to assume there's an extra byte
 		 * past the end of the selection data that it's safe to write
 		 * to. But gtk_editable_selection_received does this, so I
 		 * think it is OK.
 		 */
-		data = (guchar *) gtk_selection_data_get_data (selection_data);
+		data = (gchar *) gtk_selection_data_get_data (selection_data);
 		data[gtk_selection_data_get_length (selection_data)] = '\0';
 		lines = g_strsplit (data, "\n", 0);
 		items = convert_lines_to_str_list (lines, cut);

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -3926,7 +3926,7 @@ get_pixbuf_for_content (goffset file_len,
 	res = TRUE;
 	while (res && file_len > 0) {
 		chunk_len = file_len;
-		res = gdk_pixbuf_loader_write (loader, file_contents, chunk_len, NULL);
+		res = gdk_pixbuf_loader_write (loader, (guchar *) file_contents, chunk_len, NULL);
 		file_contents += chunk_len;
 		file_len -= chunk_len;
 	}

--- a/libnemo-private/nemo-dnd.c
+++ b/libnemo-private/nemo-dnd.c
@@ -239,7 +239,7 @@ nemo_drag_build_selection_list (GtkSelectionData *data)
 
 		/* 2: Decode geometry information.  */
 
-		item->got_icon_position = sscanf (p, "%d:%d:%d:%d%*s",
+		item->got_icon_position = sscanf ((const gchar *) p, "%d:%d:%d:%d%*s",
 						  &item->icon_x, &item->icon_y,
 						  &item->icon_width, &item->icon_height) == 4;
 		if (!item->got_icon_position) {
@@ -690,7 +690,7 @@ nemo_drag_drag_data_get (GtkWidget *widget,
 	
 	gtk_selection_data_set (selection_data,
 				gtk_selection_data_get_target (selection_data),
-				8, result->str, result->len);
+				8, (guchar *) result->str, result->len);
 	g_string_free (result, TRUE);
 
 	return TRUE;

--- a/libnemo-private/nemo-icon-dnd.c
+++ b/libnemo-private/nemo-icon-dnd.c
@@ -397,7 +397,7 @@ get_direct_save_filename (GdkDragContext *context)
 		return NULL;
 	}
 	
-	return prop_text;
+	return (gchar *) prop_text;
 }
 
 static void
@@ -1479,8 +1479,8 @@ drag_data_received_callback (GtkWidget *widget,
 			     gpointer user_data)
 {
     	NemoDragInfo *drag_info;
-	char *tmp;
-	const char *tmp_raw;
+	guchar *tmp;
+	const guchar *tmp_raw;
 	int length;
 	gboolean success;
 
@@ -1553,7 +1553,7 @@ drag_data_received_callback (GtkWidget *widget,
 			tmp_raw = gtk_selection_data_get_data (data);
 			receive_dropped_raw
 				(NEMO_ICON_CONTAINER (widget),
-				 tmp_raw, length, drag_info->direct_save_uri,
+				 (const gchar *) tmp_raw, length, drag_info->direct_save_uri,
 				 context, x, y);
 			success = TRUE;
 			break;

--- a/libnemo-private/nemo-tree-view-drag-dest.c
+++ b/libnemo-private/nemo-tree-view-drag-dest.c
@@ -679,7 +679,7 @@ receive_dropped_text (NemoTreeViewDragDest *dest,
 		      int x, int y)
 {
 	char *drop_target;
-	char *text;
+	guchar *text;
 
 	if (!dest->details->drag_data) {
 		return;
@@ -795,7 +795,7 @@ drag_data_received_callback (GtkWidget *widget,
 			     gpointer data)
 {
 	NemoTreeViewDragDest *dest;
-	const char *tmp;
+	const gchar *tmp;
 	int length;
 	gboolean success, finished;
 	
@@ -834,7 +834,7 @@ drag_data_received_callback (GtkWidget *widget,
 			break;
 		case NEMO_ICON_DND_RAW:
 			length = gtk_selection_data_get_length (selection_data);
-			tmp = gtk_selection_data_get_data (selection_data);
+			tmp = (const gchar *) gtk_selection_data_get_data (selection_data);
 			receive_dropped_raw (dest, tmp, length, context, x, y);
 			success = TRUE;
 			break;
@@ -883,7 +883,7 @@ get_direct_save_filename (GdkDragContext *context)
 		return NULL;
 	}
 
-	return prop_text;
+	return (gchar *) prop_text;
 }
 
 static gboolean

--- a/src/nemo-convert-metadata.c
+++ b/src/nemo-convert-metadata.c
@@ -161,13 +161,13 @@ parse_xml_node (GFile *file,
 			continue;
 		}
 
-		new_key = convert_key_name (attr->name);
+		new_key = convert_key_name ((const gchar *) attr->name);
 		if (new_key) {
 			property = xmlGetProp (filenode, attr->name);
 			if (property) {
 				g_file_info_set_attribute_string (info,
 								  new_key,
-								  property);
+								  (const gchar *) property);
 				xmlFree (property);
 			}
 		}
@@ -176,7 +176,7 @@ parse_xml_node (GFile *file,
 	list_keys = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
 	for (node = filenode->children; node != NULL; node = node->next) {
 		for (attr = node->properties; attr != NULL; attr = attr->next) {
-			new_key = convert_key_name (node->name);
+			new_key = convert_key_name ((const gchar *) node->name);
 			if (new_key) {
 				property = xmlGetProp (node, attr->name);
 				if (property) {

--- a/src/nemo-desktop-item-properties.c
+++ b/src/nemo-desktop-item-properties.c
@@ -166,7 +166,7 @@ nemo_desktop_item_properties_url_drag_data_received (GtkWidget *widget, GdkDragC
 	gboolean exactly_one;
 	char *path;
 	
-	uris = g_strsplit (gtk_selection_data_get_data (selection_data), "\r\n", 0);
+	uris = g_strsplit ((gchar *) gtk_selection_data_get_data (selection_data), "\r\n", 0);
         exactly_one = uris[0] != NULL && (uris[1] == NULL || uris[1][0] == '\0');
 
 	if (!exactly_one) {
@@ -198,7 +198,7 @@ nemo_desktop_item_properties_exec_drag_data_received (GtkWidget *widget, GdkDrag
 	GKeyFile *key_file;
 	char *uri, *type, *exec;
 	
-	uris = g_strsplit (gtk_selection_data_get_data (selection_data), "\r\n", 0);
+	uris = g_strsplit ((gchar *) gtk_selection_data_get_data (selection_data), "\r\n", 0);
         exactly_one = uris[0] != NULL && (uris[1] == NULL || uris[1][0] == '\0');
 
 	if (!exactly_one) {

--- a/src/nemo-image-properties-page.c
+++ b/src/nemo-image-properties-page.c
@@ -484,7 +484,7 @@ file_read_callback (GObject      *object,
 
 #ifdef HAVE_EXIF
 		exif_still_loading = exif_loader_write (page->details->exifldr,
-				  		        page->details->buffer,
+				  		        (guchar *) page->details->buffer,
 				  			count_read);
 #else
 		exif_still_loading = 0;
@@ -492,7 +492,7 @@ file_read_callback (GObject      *object,
 
 		if (page->details->pixbuf_still_loading) {
 			if (!gdk_pixbuf_loader_write (page->details->loader,
-					      	      page->details->buffer,
+					      	      (const guchar *) page->details->buffer,
 					      	      count_read,
 					      	      NULL)) {
 				page->details->pixbuf_still_loading = FALSE;

--- a/src/nemo-location-bar.c
+++ b/src/nemo-location-bar.c
@@ -155,7 +155,7 @@ drag_data_received_callback (GtkWidget *widget,
 	g_assert (data != NULL);
 	g_assert (callback_data == NULL);
 
-	names = g_uri_list_extract_uris (gtk_selection_data_get_data (data));
+	names = g_uri_list_extract_uris ((const gchar *) gtk_selection_data_get_data (data));
 
 	if (names == NULL || *names == NULL) {
 		g_warning ("No D&D URI's");

--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -1741,7 +1741,7 @@ button_drag_data_get_cb (GtkWidget          *widget,
     if (info == NEMO_ICON_DND_GNOME_ICON_LIST) {
         tmp = g_strdup_printf ("%s\r\n", uri_list[0]);
         gtk_selection_data_set (selection_data, gtk_selection_data_get_target (selection_data),
-                    8, tmp, strlen (tmp));
+                    8, (const guchar *) tmp, strlen (tmp));
         g_free (tmp);
     } else if (info == NEMO_ICON_DND_URI_LIST) {
         gtk_selection_data_set_uris (selection_data, uri_list);

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -1959,7 +1959,7 @@ drag_data_received_callback (GtkWidget *widget,
 	if (!sidebar->drag_data_received) {
 		if (gtk_selection_data_get_target (selection_data) != GDK_NONE &&
 		    info == TEXT_URI_LIST) {
-			sidebar->drag_list = build_selection_list (gtk_selection_data_get_data (selection_data));
+			sidebar->drag_list = build_selection_list ((const gchar *) gtk_selection_data_get_data (selection_data));
 		} else {
 			sidebar->drag_list = NULL;
 		}
@@ -2041,7 +2041,7 @@ drag_data_received_callback (GtkWidget *widget,
 
 			switch (info) {
 			case TEXT_URI_LIST:
-				selection_list = build_selection_list (gtk_selection_data_get_data (selection_data));
+				selection_list = build_selection_list ((const gchar *) gtk_selection_data_get_data (selection_data));
 				uris = uri_list_from_selection (selection_list);
 				nemo_file_operations_copy_move (uris, NULL, drop_uri,
 								    real_action, GTK_WIDGET (tree_view),

--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -485,7 +485,7 @@ nemo_properties_window_drag_data_received (GtkWidget *widget, GdkDragContext *co
 	image = GTK_IMAGE (widget);
  	window = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (image)));
 
-	uris = g_strsplit (gtk_selection_data_get_data (selection_data), "\r\n", 0);
+	uris = g_strsplit ((const gchar *) gtk_selection_data_get_data (selection_data), "\r\n", 0);
 	exactly_one = uris[0] != NULL && (uris[1] == NULL || uris[1][0] == '\0');
 
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -10430,7 +10430,7 @@ metadata_for_files_in_directory_ready_callback (NemoDirectory *directory,
 }
 
 static void
-disconnect_handler (GObject *object, int *id)
+disconnect_handler (GObject *object, guint *id)
 {
 	if (*id != 0) {
 		g_signal_handler_disconnect (object, *id);
@@ -10439,13 +10439,13 @@ disconnect_handler (GObject *object, int *id)
 }
 
 static void
-disconnect_directory_handler (NemoView *view, int *id)
+disconnect_directory_handler (NemoView *view, guint *id)
 {
 	disconnect_handler (G_OBJECT (view->details->model), id);
 }
 
 static void
-disconnect_directory_as_file_handler (NemoView *view, int *id)
+disconnect_directory_as_file_handler (NemoView *view, guint *id)
 {
 	disconnect_handler (G_OBJECT (view->details->directory_as_file), id);
 }


### PR DESCRIPTION
based on 

https://git.gnome.org/browse/nautilus/patch/libnautilus-private/nautilus-directory-async.c?id=c00eb306ee711632072f761bfa4e814c405a82d2