### PR TITLE
python2/3 compatibility fixes

### DIFF
--- a/data/extract_action_strings
+++ b/data/extract_action_strings
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import os
 import glob

--- a/data/merge_action_strings
+++ b/data/merge_action_strings
@@ -1,10 +1,16 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import os
 import glob
 import polib
 import codecs
 from gi.repository import GLib
+import sys
+# Python2 compatibility
+if sys.version_info <= (3, 0):
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
+
 
 GROUP = "Nemo Action"
 


### PR DESCRIPTION
This adds code to make sure that the python3 fixes to cinnamon also work
with python2.  This is important since cinnamon could be building on a
python2 only system.