### PR TITLE
add standard settings for EelEditableLabel

### DIFF
--- a/src/nemo-style-application.css
+++ b/src/nemo-style-application.css
@@ -15,3 +15,40 @@
     color: #f5f5f5;
     text-shadow: none;
 }
+
+/* EelEditableLabel (icon labels) */
+.nemo-desktop.view .entry,
+.nemo-desktop.view .entry:active,
+.nemo-desktop.view .entry:focus,
+.nemo-desktop.view .entry:backdrop,
+.nemo-window .nemo-window-pane .view .entry,
+.nemo-window .nemo-window-pane .view .entry:active,
+.nemo-window .nemo-window-pane .view .entry:focus,
+.nemo-window .nemo-window-pane .view .entry:backdrop {
+    border-image: none;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #000000;
+    border-radius: 3px;
+    color: #000000;
+    text-shadow: none;
+    background-image: -gtk-gradient(linear,
+                                    left top, left bottom,
+                                    from       (shade(rgba(255,255,255,1), 0.86)),
+                                    color-stop (0.15, shade(rgba(255,255,255,1), 0.96)),
+                                    color-stop (0.50, shade(rgba(255,255,255,1), 0.98)),
+                                    to         (shade(rgba(255,255,255,1), 1.00)));
+}
+
+.nemo-desktop.view .entry:selected,
+.nemo-desktop.view .entry:focus:selected,
+.nemo-desktop.view .entry:backdrop:selected
+.nemo-window .nemo-window-pane .view .entry:active,
+.nemo-window .nemo-window-pane .view .entry:selected,
+.nemo-window .nemo-window-pane .view .entry:focus:selected,
+.nemo-window .nemo-window-pane .view .entry:backdrop:selected {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+    text-shadow: none;
+}
+


### PR DESCRIPTION
This set simply a background to this entry, other wise the font is hard to read if you rename a desktop icon, because you see simply the desktop bg.
It's better to set this here as in a theme.
Well, you can play around with the styling details but something like that you need to set.