### PR TITLE
use g_hash_table_remove_all and get rid of some callbacks

### DIFF
--- a/libnemo-private/nemo-desktop-directory.c
+++ b/libnemo-private/nemo-desktop-directory.c
@@ -461,8 +461,8 @@ update_desktop_directory (NemoDesktopDirectory *desktop)
 
 	real_directory = desktop->details->real_directory;
 	if (real_directory != NULL) {
-		g_hash_table_foreach_remove (desktop->details->callbacks, (GHRFunc) gtk_true, NULL);
-		g_hash_table_foreach_remove (desktop->details->monitors, (GHRFunc) gtk_true, NULL);
+		g_hash_table_remove_all (desktop->details->callbacks);
+		g_hash_table_remove_all (desktop->details->monitors);
 
 		g_signal_handlers_disconnect_by_func (real_directory, done_loading_callback, desktop);
 		g_signal_handlers_disconnect_by_func (real_directory, forward_files_added_cover, desktop);

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -1060,12 +1060,6 @@ directory_load_cancel (NemoDirectory *directory)
 	}
 }
 
-static gboolean
-remove_callback (gpointer key, gpointer value, gpointer user_data)
-{
-	return TRUE;
-}
-
 static void
 file_list_cancel (NemoDirectory *directory)
 {
@@ -1082,7 +1076,7 @@ file_list_cancel (NemoDirectory *directory)
 	}
 
 	if (directory->details->hidden_file_hash) {
-		g_hash_table_foreach_remove (directory->details->hidden_file_hash, remove_callback, NULL);
+		g_hash_table_remove_all (directory->details->hidden_file_hash);
 	}
 }
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -10484,12 +10484,6 @@ nemo_view_select_file (NemoView *view, NemoFile *file)
 	nemo_view_call_set_selection (view, &file_list);
 }
 
-static gboolean
-remove_all (gpointer key, gpointer value, gpointer callback_data)
-{
-	return TRUE;
-}
-
 /**
  * nemo_view_stop_loading:
  * 
@@ -10512,7 +10506,7 @@ nemo_view_stop_loading (NemoView *view)
 	file_and_directory_list_free (view->details->new_changed_files);
 	view->details->new_changed_files = NULL;
 
-	g_hash_table_foreach_remove (view->details->non_ready_files, remove_all, NULL);
+	g_hash_table_remove_all (view->details->non_ready_files);
 
 	file_and_directory_list_free (view->details->old_added_files);
 	view->details->old_added_files = NULL;


### PR DESCRIPTION
I'm seeing reports in fedora

https://bugzilla.redhat.com/attachment.cgi?id=1163002

caja had a similar issue

https://bugs.launchpad.net/ubuntu/+source/caja/+bug/1469784

Fix from caja

https://github.com/mate-desktop/caja/commit/883201a49341d588f5a6ffe2b7fd54676eb71019
