### PR TITLE
add view style class on icon view scrolled window

### DIFF
--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -2850,6 +2850,9 @@ nemo_icon_view_create (NemoWindowSlot *slot)
 			     "window-slot", slot,
 			     "compact", FALSE,
 			     NULL);
+#if GTK_CHECK_VERSION (3, 20, 0)
+	gtk_style_context_add_class (gtk_widget_get_style_context (view), GTK_STYLE_CLASS_VIEW);
+#endif
 	return NEMO_VIEW (view);
 }
 
@@ -2862,6 +2865,9 @@ nemo_compact_view_create (NemoWindowSlot *slot)
 			     "window-slot", slot,
 			     "compact", TRUE,
 			     NULL);
+#if GTK_CHECK_VERSION (3, 20, 0)
+	gtk_style_context_add_class (gtk_widget_get_style_context (view), GTK_STYLE_CLASS_VIEW);
+#endif
 	return NEMO_VIEW (view);
 }
 


### PR DESCRIPTION
This is needed with gtk+-3.20 as view on
.nemo-window .nemo-window-pane > notebook box.vertical > overlay > scrolledwindow > widget.view {}
does not work, it is impossible to set a bg color.
In result you can only set the bg color with 
.nemo-window .nemo-window-pane > notebook box.vertical > overlay > scrolledwindow {}
, but than you have the wrong bg color for scrollbar junctions ( the little square beside srollbars) in nemo treeview.
This gtk+ bug affect all file-browsers (caja, nemo and nautilus), but you see that only if you don't use overlay-scrollbars.
A more detailed description you will find here.
https://github.com/mate-desktop/caja/commit/e5c29655e5301b6d4ba19a3d4970745804039c0e
With setting the view style class on the scrolledwindow we can use this setting in themes
(gtk+-3.20 syntax).
```
/* this sets the bg color for scrolledwindow junction, the little square beside the scrollbars */
.nemo-window .nemo-window-pane > notebook box.vertical > overlay scrolledwindow {
    background-color: @theme_bg_color;
}

/* treewiew, view and compact view */
.nemo-window .nemo-window-pane > notebook box.vertical > overlay > scrolledwindow.view,
.nemo-window .nemo-window-pane > notebook box.vertical > overlay > scrolledwindow > treeview.view {
    background-color: @theme_base_color;
}
```
Note: i added this settings to mate-themes and @leigh123linux use this patch for fedora.
Here is a screenshot how weird it looks without the PR.
![nemo-with-blue-submarine-2016-06-05 19-08-05](https://cloud.githubusercontent.com/assets/961604/15808791/3a8f6190-2b81-11e6-8efe-f469c1a33170.png)
