### PR TITLE
Silence a bunch of allocation warnings when using GTK 3.20

### DIFF
--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -491,7 +491,11 @@ nemo_path_bar_get_preferred_width (GtkWidget *widget,
         *minimum = MAX (*minimum, child_min);
         *natural = MAX (*natural, child_nat);
     }
-    path_bar->priv->slider_width = MIN (height * 2 / 3 + 5, height);
+
+    gtk_widget_get_preferred_width (path_bar->priv->down_slider_button,
+                                    &path_bar->priv->slider_width,
+                                    NULL);
+
     *minimum += path_bar->priv->slider_width * 2;
     *natural += path_bar->priv->slider_width * 2;
 }

--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -618,6 +618,10 @@ nemo_path_bar_size_allocate (GtkWidget     *widget,
     }
     direction = gtk_widget_get_direction (widget);
 
+    gtk_widget_get_preferred_width (path_bar->priv->up_slider_button,
+                                    &path_bar->priv->slider_width,
+                                    NULL);
+
     gtk_widget_get_preferred_size (BUTTON_DATA (path_bar->priv->button_list->data)->button,
                        NULL, &child_requisition);
     width = child_requisition.width;

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1030,45 +1030,6 @@ nemo_window_set_active_slot (NemoWindow *window, NemoWindowSlot *new_slot)
 }
 
 static void
-nemo_window_get_preferred_width (GtkWidget *widget,
-				     gint *minimal_width,
-				     gint *natural_width)
-{
-	GdkScreen *screen;
-	gint max_w, min_w, default_w;
-
-	screen = gtk_window_get_screen (GTK_WINDOW (widget));	
-
-	max_w = get_max_forced_width (screen);
-	min_w = NEMO_WINDOW_MIN_WIDTH;
-
-	default_w = NEMO_WINDOW_DEFAULT_WIDTH;
-
-	*minimal_width = MIN (min_w, max_w);
-	*natural_width = MIN (default_w, max_w);
-}
-
-static void
-nemo_window_get_preferred_height (GtkWidget *widget,
-				      gint *minimal_height,
-				      gint *natural_height)
-{
-	GdkScreen *screen;
-	gint max_h, min_h, default_h;
-
-	screen = gtk_window_get_screen (GTK_WINDOW (widget));	
-
-	max_h = get_max_forced_height (screen);
-
-	min_h = NEMO_WINDOW_MIN_HEIGHT;
-
-	default_h = NEMO_WINDOW_DEFAULT_HEIGHT;
-
-	*minimal_height = MIN (min_h, max_h);
-	*natural_height = MIN (default_h, max_h);
-}
-
-static void
 nemo_window_realize (GtkWidget *widget)
 {
 	GTK_WIDGET_CLASS (nemo_window_parent_class)->realize (widget);
@@ -2138,8 +2099,6 @@ nemo_window_class_init (NemoWindowClass *class)
 
 	wclass->destroy = nemo_window_destroy;
 	wclass->show = nemo_window_show;
-	wclass->get_preferred_width = nemo_window_get_preferred_width;
-	wclass->get_preferred_height = nemo_window_get_preferred_height;
 	wclass->realize = nemo_window_realize;
 	wclass->key_press_event = nemo_window_key_press_event;
     wclass->key_release_event = nemo_window_key_release_event;


### PR DESCRIPTION
A few still remain, but this should make logs readable again.

Edit: I haven't tracked down the NemoWindow warnings yet and the NemoWindowPane warnings are fixed by this gtk commit https://github.com/GNOME/gtk/commit/ddcf47026dbbe58dca3b34c7bb1ec63bb50a861

Fixes #1153