### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,8 +38,6 @@ DISTCLEANFILES = \
 
 DISTCHECK_CONFIGURE_FLAGS = --disable-update-mimedb --enable-gtk-doc
 
-ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
-
 distclean-local:
 	if test "$(srcdir)" = "."; then :; else \
 		rm -f ChangeLog; \

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,13 +1,40 @@
 #!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="nemo"
+cd $srcdir
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Git (or from"
-    echo "your OS vendor's package manager)."
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+gtkdocize --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ dnl ===========================================================================
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIR([m4])
+AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
+AX_IS_RELEASE([git-directory])
 
 AM_INIT_AUTOMAKE([foreign 1.11 dist-xz no-dist-gzip tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
@@ -170,50 +172,7 @@ AM_CONDITIONAL(ENABLE_EMPTY_VIEW, test "x$ENABLE_EMPTY_VIEW" = "x1")
 
 dnl ==========================================================================
 
-dnl Turn on the additional warnings last, so -Werror doesn't affect other tests.
-
-WARNING_CFLAGS=""
-
-AC_ARG_ENABLE(more-warnings,
-AC_HELP_STRING([--enable-more-warnings], [Maximum compiler warnings]),
-set_more_warnings="$enableval",[
-if test -f $srcdir/.git; then
-	set_more_warnings=yes
-else
-	set_more_warnings=no
-fi
-])
-AC_MSG_CHECKING(for more warnings, including -Werror)
-if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
-	AC_MSG_RESULT(yes)
-	WARNING_CFLAGS="\
-	-Wall \
-	-Wmissing-declarations -Wmissing-prototypes \
-	-Wnested-externs -Wpointer-arith \
-	-Wcast-align \
-	-Werror"
-
-	for option in -Wstrict-aliasing=0 -Wno-pointer-sign; do
-		SAVE_CFLAGS="$CFLAGS"
-		CFLAGS="$CFLAGS $option"
-		AC_MSG_CHECKING([whether gcc understands $option])
-		AC_TRY_COMPILE([], [],
-			has_option=yes,
-			has_option=no,)
-		if test $has_option = yes; then
-		   	WARNING_CFLAGS="$WARNING_CFLAGS $option"
-		fi
-		AC_MSG_RESULT($has_option)
-		CFLAGS="$SAVE_CFLAGS"
-		unset has_option
-		unset SAVE_CFLAGS
-	done
-	unset option
-else
-	AC_MSG_RESULT(no)
-fi
-
-AC_SUBST(WARNING_CFLAGS)
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
 
 dnl ===========================================================================
 dnl Check for Tracker

--- a/cut-n-paste-code/libegg/Makefile.am
+++ b/cut-n-paste-code/libegg/Makefile.am
@@ -2,7 +2,7 @@ NULL=
 
 noinst_LTLIBRARIES = libegg.la
 
-AM_CPPFLAGS = $(BASE_CFLAGS)
+AM_CPPFLAGS = $(WARN_CFLAGS) $(BASE_CFLAGS)
 
 EGG_TREE_DND_FILES = 		\
 	eggtreemultidnd.c	\
@@ -15,7 +15,7 @@ libegg_la_SOURCES = 		\
 
 libegg_la_CFLAGS =				\
 	$(BASE_CFLAGS)			\
-	$(WARNING_CFLAGS)			\
+	$(WARN_CFLAGS)			\
 	$(DISABLE_DEPRECATED)
 
 libegg_la_LIBADD = 	\

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,8 @@ TYPELIBDIR=$(shell pkg-config gobject-introspection-1.0 --variable libdir | sed 
 
 CONFIGURE_EXTRA_FLAGS = --libexecdir=/usr/lib/nemo \
                         --disable-update-mimedb \
-			--enable-gtk-doc
+			--enable-gtk-doc \
+			--enable-compile-warnings=yes
 
 export LDFLAGS+=-Wl,-z,defs -Wl,-O1 -Wl,--as-needed
 

--- a/eel/Makefile.am
+++ b/eel/Makefile.am
@@ -8,13 +8,14 @@ AM_CPPFLAGS =						\
 	-I$(top_builddir)				\
 	$(BASE_CFLAGS)					\
 	$(COMMON_CFLAGS)				\
-	$(WARNING_CFLAGS)				\
+	$(WARN_CFLAGS)				\
 	$(DISABLE_DEPRECATED_CFLAGS)			\
 	-DDATADIR=\""$(datadir)"\"			\
 	-DSOURCE_DATADIR=\""$(top_srcdir)/data"\"	\
 	$(NULL)
 
 libeel_2_la_LDFLAGS =				\
+	$(WARN_LDFLAGS)				\
 	-no-undefined				\
 	$(NULL)
 
@@ -68,7 +69,7 @@ noinst_PROGRAMS = check-program
 check_program_SOURCES = check-program.c
 check_program_DEPENDENCIES = libeel-2.la
 check_program_LDADD = $(EEL_LIBS)
-check_program_LDFLAGS =	$(check_program_DEPENDENCIES) -lm
+check_program_LDFLAGS =	$(WARN_LDFLAGS) $(check_program_DEPENDENCIES) -lm
 
 TESTS = check-eel
 

--- a/libnemo-extension/Makefile.am
+++ b/libnemo-extension/Makefile.am
@@ -8,13 +8,14 @@ AM_CPPFLAGS =\
 	-I$(top_srcdir) \
 	-I$(top_builddir) \
 	$(BASE_CFLAGS) \
-	$(WARNING_CFLAGS) \
+	$(WARN_CFLAGS) \
 	$(DISABLE_DEPRECATED_CFLAGS) \
     -DLIBEXECDIR=\""$(libexecdir)"\" \
 	-DDATADIR=\""$(datadir)"\" \
 	$(NULL)
 
 libnemo_extension_la_LDFLAGS=\
+	$(WARN_LDFLAGS) \
 	-version-info @NEMO_EXTENSION_VERSION_INFO@ \
 	-no-undefined \
 	$(NULL)
@@ -77,11 +78,13 @@ introspection_files =					\
 Nemo-3.0.gir: libnemo-extension.la Makefile
 Nemo_3_0_gir_INCLUDES = Gtk-3.0 Gio-2.0 GLib-2.0
 Nemo_3_0_gir_CFLAGS = \
+	$(WARN_CFLAGS) \
 	-I$(top_srcdir) \
 	-I$(top_builddir) \
 	$(BASE_CFLAGS)
 Nemo_3_0_gir_LIBS = libnemo-extension.la
 Nemo_3_0_gir_FILES = $(addprefix $(srcdir)/, $(introspection_files))
+Nemo_3_0_gir_SCANNERFLAGS = $(AM_SCANNERFLAGS) $(WARN_SCANNERFLAGS)
 INTROSPECTION_GIRS += Nemo-3.0.gir
 
 girdir = @INTROSPECTION_GIRDIR@

--- a/libnemo-private/Makefile.am
+++ b/libnemo-private/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = 						\
 	$(BASE_CFLAGS)					\
 	$(COMMON_CFLAGS)				\
 	$(NEMO_CFLAGS)				\
-	$(WARNING_CFLAGS)				\
+	$(WARN_CFLAGS)				\
 	$(DISABLE_DEPRECATED_CFLAGS)			\
 	$(TRACKER_CFLAGS)				\
 	-DDATADIR=\""$(datadir)"\" 			\
@@ -43,6 +43,7 @@ dependency_static_libs = \
 	$(NULL)
 
 libnemo_private_la_LDFLAGS =	\
+	$(WARN_LDFLAGS)			\
 	-no-undefined			\
 	$(NULL)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS =							\
 	$(BASE_CFLAGS) 						\
 	$(COMMON_CFLAGS)					\
 	$(NEMO_CFLAGS)					\
-	$(WARNING_CFLAGS)					\
+	$(WARN_CFLAGS)					\
 	$(EXIF_CFLAGS)						\
 	$(EXEMPI_CFLAGS)                                        \
 	-DDATADIR=\""$(datadir)"\" 				\

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS =\
 	$(BASE_CFLAGS) \
 	$(COMMON_CFLAGS) \
 	$(NEMO_CFLAGS) \
-	$(WARNING_CFLAGS) \
+	$(WARN_CFLAGS) \
 	-DVERSION="\"$(VERSION)\"" \
 	-DNEMO_DATADIR=\""$(datadir)/nemo"\" \
 	$(NULL)


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration