### PR TITLE
remove deprecated and no longer necessary g_type_init

### DIFF
--- a/src/nemo-convert-metadata.c
+++ b/src/nemo-convert-metadata.c
@@ -304,8 +304,6 @@ main (int argc, char *argv[])
 	GError *error = NULL;
 	int i;
 
-	g_type_init ();
-
 	context = g_option_context_new ("<nemo metadata files> - convert nemo metadata");
 	g_option_context_add_main_entries (context, entries, NULL);
 	if (!g_option_context_parse (context, &argc, &argv, &error)) {

--- a/src/nemo-main.c
+++ b/src/nemo-main.c
@@ -75,8 +75,6 @@ main (int argc, char *argv[])
 	mallopt (M_MMAP_THRESHOLD, 128 *1024);
 #endif
 
-	g_type_init ();
-
 	/* This will be done by gtk+ later, but for now, force it to GNOME */
 	g_desktop_app_info_set_desktop_env ("GNOME");
 


### PR DESCRIPTION
removes some of the distracting build warnings