### PR TITLE
file-operations: reduce the time for reliable transfer rate

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -184,7 +184,7 @@ typedef struct {
 	int last_reported_files_left;
 } TransferInfo;
 
-#define SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE 15
+#define SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE 8
 #define NSEC_PER_MICROSEC 1000
 
 #define MAXIMUM_DISPLAYED_FILE_NAME_LENGTH 50


### PR DESCRIPTION
Currently it was 15 seconds, which is a little too much. Most
of the time 8 seconds is enough, and even more with SSDs. In this
way we are able to provide feedback of the remaining time to the
user in a more reasonable time.

https://github.com/GNOME/nautilus/commit/7d40ce7f94390a646c54273225fc1cd08aa9ccec