### PR TITLE
Fix --geometry option when Nemo is already running

### DIFF
--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -533,9 +533,18 @@ nemo_application_open (GApplication *app,
 
 	DEBUG ("Open called on the GApplication instance; %d files", n_files);
 
+	/*Get any geometry string passed by a local (2nd) invocation*/
+	if (strcmp(hint,"") != 0 ){
+        	self->priv->geometry = hint;
+	}
 	open_windows (self, files, n_files,
 		      gdk_screen_get_default (),
 		      self->priv->geometry);
+
+	/*Reset this or 3ed and later invocations will use same  
+	 *geometry even if the user has resized open window
+         */
+	self->priv->geometry = NULL;
 }
 
 static GObject *
@@ -681,8 +690,9 @@ nemo_application_local_command_line (GApplication *application,
 	gboolean browser = FALSE;
 	gboolean kill_shell = FALSE;
 	gboolean no_default_window = FALSE;
-    gboolean fix_cache = FALSE;
+	gboolean fix_cache = FALSE;
 	gchar **remaining = NULL;
+	const gchar *hint = "";
 	NemoApplication *self = NEMO_APPLICATION (application);
 
 	const GOptionEntry options[] = {
@@ -813,10 +823,13 @@ nemo_application_local_command_line (GApplication *application,
 		files[0] = g_file_new_for_path (g_get_home_dir ());
 		files[1] = NULL;
 	}
-
+	/* */
+    	    if (self->priv->geometry != NULL) {
+		hint = (g_strdup (self->priv->geometry));
+	}
 	/* Invoke "Open" to create new windows */
 	if (len > 0) {
-		g_application_open (application, files, len, "");
+		g_application_open (application, files, len, hint);
 	}
 
 	for (idx = 0; idx < len; idx++) {


### PR DESCRIPTION
Fix for https://github.com/linuxmint/nemo/issues/569
 based on
https://github.com/lukefromdc/caja/commit/9fb12116c1a09221a88f5c1a7e9010022c96df66

This fixes a GApplication command line issue inherited from Nautilus 3.4. The issue is that using --geometry in a second invocation of nemo sets self->priv->geometry in the local instance, but the windows are opened by the remote (already running) instance. That reads it's own version of self->priv->geometry, which is not written to by setting the same variable in the local instance. There are very few ways to pass data from a local command line to "open" but Gapplication provides the "hint" string variable. It can pass the geometry string, which can then be written to self->priv->geometry, making the geometry option work again.
