### PR TITLE
nemo-file-management-properties: Fix an accidental removal

### DIFF
--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -257,6 +257,7 @@
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
+        <property name="border_width">0</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>


### PR DESCRIPTION
https://github.com/linuxmint/nemo/commit/70753fac0eb1483ad828ed78a5401a3834bcc4c7#diff-0db86c32c4fbff82c6f9e6f2571fbe10 removed the "Show text in icons" preference but also removed a bit too much from the glade file. Set the border width back to 0 so the dialog looks correct again