### PR TITLE
nemo-application.c: fix maximized window state preservation

### DIFF
--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -456,6 +456,7 @@ open_window (NemoApplication *application,
 {
 	NemoWindow *window;
 	gchar *uri;
+	gboolean have_geometry;
 
 	uri = g_file_get_uri (location);
 	DEBUG ("Opening new window at uri %s", uri);
@@ -464,7 +465,9 @@ open_window (NemoApplication *application,
 						     screen);
 	nemo_window_go_to (window, location);
 
-	if (geometry != NULL && !gtk_widget_get_visible (GTK_WIDGET (window))) {
+	have_geometry = geometry != NULL && strcmp(geometry, "") != 0;
+
+	if (have_geometry && !gtk_widget_get_visible (GTK_WIDGET (window))) {
 		/* never maximize windows opened from shell if a
 		 * custom geometry has been requested.
 		 */
@@ -813,7 +816,11 @@ nemo_application_local_command_line (GApplication *application,
 	}
 	/* Invoke "Open" to create new windows */
 	if (len > 0) {
-		g_application_open (application, files, len, self->priv->geometry);
+		if (self->priv->geometry != NULL) {
+			g_application_open (application, files, len, self->priv->geometry);
+		} else {
+			g_application_open (application, files, len, "");
+		}
 	}
 
 	for (idx = 0; idx < len; idx++) {


### PR DESCRIPTION
This commit fixes the maximized window state not being preserved properly since #1268 and the followup commit.  While trying to track this down, I found that we are in some cases passing NULL to g_application_open in the hint parameter which is explicitly forbidden and results in unexpected strings being passed to nemo_application_open. I have added a NULL check there to prevent this.

Aside from that, I also had to add a check for an empty string in open_window otherwise we override the previously restored window state in too many cases.