### PR TITLE
nemo-window.c: save sidebar width 100ms after last change

### DIFF
--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -392,7 +392,7 @@ side_pane_size_allocate_callback (GtkWidget *widget,
 		window->details->side_pane_width = allocation->width;
 
 		window->details->sidebar_width_handler_id =
-			g_idle_add (save_sidebar_width_cb, window);
+			g_timeout_add (100, save_sidebar_width_cb, window);
 	}
 }
 


### PR DESCRIPTION
As pointed out in #1096, the sidebar width setting is written an excessive
amount of times during a resize operation. Instead of using a likely
immediate callback with g_idle_add, use g_timeout_add with a 100ms interval.

The timeout is removed and re-added every time the sidebar width changes,
so the callback will not fire until 100ms after the last change.

This setting may still be written multiple times during a single resize
operation.

Fixes #1096