### PR TITLE
Add option about mouse double click to go to parent folder

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -252,6 +252,8 @@ typedef enum
 /* File operations queue */
 #define NEMO_PREFERENCES_NEVER_QUEUE_FILE_OPS          "never-queue-file-ops"
 
+#define NEMO_PREFERENCES_CLICK_DOUBLE_PARENT_FOLDER    "click-double-parent-folder"
+
 void nemo_global_preferences_init                      (void);
 char *nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void);
 gboolean nemo_global_preferences_get_ignore_view_metadata (void);

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -358,6 +358,10 @@
       <default>false</default>
       <_summary>If true, all file operations will start immediately</_summary>
     </key>
+    <key name="click-double-parent-folder" type="b">
+      <default>false</default>
+      <_summary>If true, double click left on blank area will go to parent folder</_summary>
+    </key>
   </schema>
 
   <schema id="org.nemo.icon-view" path="/org/nemo/icon-view/" gettext-domain="nemo">

--- a/nemo.pot
+++ b/nemo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-20 13:14+0100\n"
+"POT-Creation-Date: 2016-10-01 19:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,72 +48,72 @@ msgid ""
 "that Nemo can create them."
 msgstr ""
 
-#: src/nemo-application.c:619
+#: src/nemo-application.c:618
 msgid "--check cannot be used with other options."
 msgstr ""
 
-#: src/nemo-application.c:625
+#: src/nemo-application.c:624
 msgid "--quit cannot be used with URIs."
 msgstr ""
 
-#: src/nemo-application.c:632
+#: src/nemo-application.c:631
 msgid "--geometry cannot be used with more than one URI."
 msgstr ""
 
-#: src/nemo-application.c:690
+#: src/nemo-application.c:692
 msgid "Perform a quick set of self-check tests."
 msgstr ""
 
-#: src/nemo-application.c:696
+#: src/nemo-application.c:698
 msgid "Show the version of the program."
 msgstr ""
 
-#: src/nemo-application.c:698
+#: src/nemo-application.c:700
 msgid "Create the initial window with the given geometry."
 msgstr ""
 
-#: src/nemo-application.c:698
+#: src/nemo-application.c:700
 msgid "GEOMETRY"
 msgstr ""
 
-#: src/nemo-application.c:700
+#: src/nemo-application.c:702
 msgid "Only create windows for explicitly specified URIs."
 msgstr ""
 
-#: src/nemo-application.c:702
+#: src/nemo-application.c:704
 msgid "Never manage the desktop (ignore the GSettings preference)."
 msgstr ""
 
-#: src/nemo-application.c:704
+#: src/nemo-application.c:706
 msgid "Always manage the desktop (ignore the GSettings preference)."
 msgstr ""
 
-#: src/nemo-application.c:706
+#: src/nemo-application.c:708
 msgid ""
 "Repair the user thumbnail cache - this can be useful if you're having "
 "trouble with file thumbnails.  Must be run as root"
 msgstr ""
 
-#: src/nemo-application.c:708
+#: src/nemo-application.c:710
 msgid "Quit Nemo."
 msgstr ""
 
-#: src/nemo-application.c:709
+#: src/nemo-application.c:711
 msgid "[URI...]"
 msgstr ""
 
-#: src/nemo-application.c:720
+#: src/nemo-application.c:722
 msgid ""
 "\n"
 "\n"
 "Browse the file system with the file manager"
 msgstr ""
 
-#: src/nemo-application.c:992
+#: src/nemo-application.c:997
 msgid "Nemo's main menu is now hidden"
 msgstr ""
 
-#: src/nemo-application.c:995
+#: src/nemo-application.c:1000
 msgid ""
 "You have chosen to hide the main menu.  You can get it back temporarily by:\n"
 "\n"
@@ -125,7 +125,7 @@ msgid ""
 "menu."
 msgstr ""
 
-#: src/nemo-application.c:1006
+#: src/nemo-application.c:1011
 msgid "Don't show this message again."
 msgstr ""
 
@@ -162,8 +162,8 @@ msgid "_Run"
 msgstr ""
 
 #: src/nemo-blank-desktop-window.c:203 src/nemo-desktop-window.c:103
-#: src/nemo-desktop-window.c:292 src/nemo-pathbar.c:1497
-#: src/nemo-places-sidebar.c:773 libnemo-private/nemo-action.c:947
+#: src/nemo-desktop-window.c:292 src/nemo-pathbar.c:1505
+#: src/nemo-places-sidebar.c:795 libnemo-private/nemo-action.c:947
 msgid "Desktop"
 msgstr ""
 
@@ -314,24 +314,24 @@ msgid ""
 "Add connect to server mount"
 msgstr ""
 
-#: src/nemo-desktop-icon-view.c:502 src/nemo-view.c:8181 src/nemo-view.c:9818
+#: src/nemo-desktop-icon-view.c:506 src/nemo-view.c:8189 src/nemo-view.c:9826
 msgid "E_mpty Trash"
 msgstr ""
 
-#: src/nemo-desktop-icon-view.c:515
+#: src/nemo-desktop-icon-view.c:519
 msgid "Empty Trash"
 msgstr ""
 
-#: src/nemo-desktop-icon-view.c:517 src/nemo-trash-bar.c:218
-#: src/nemo-view.c:8182
+#: src/nemo-desktop-icon-view.c:521 src/nemo-trash-bar.c:218
+#: src/nemo-view.c:8190
 msgid "Delete all items in the Trash"
 msgstr ""
 
-#: src/nemo-desktop-icon-view.c:580
+#: src/nemo-desktop-icon-view.c:584
 msgid "The desktop view encountered an error."
 msgstr ""
 
-#: src/nemo-desktop-icon-view.c:581
+#: src/nemo-desktop-icon-view.c:585
 msgid "The desktop view encountered an error while starting up."
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/nemo-file-management-properties.c:463 libnemo-private/nemo-file.c:4494
+#: src/nemo-file-management-properties.c:463 libnemo-private/nemo-file.c:4468
 msgid "today at %-I:%M:%S %p"
 msgstr ""
 
@@ -620,45 +620,45 @@ msgstr ""
 msgid "Restore Icon's Original Si_ze"
 msgstr ""
 
-#: src/nemo-icon-view.c:2901 src/nemo-icon-view-container.c:610
+#: src/nemo-icon-view.c:2920 src/nemo-icon-view-container.c:601
 #: src/nemo-window-menus.c:1439 src/nemo-file-management-properties.glade:12
 msgid "Icon View"
 msgstr ""
 
-#: src/nemo-icon-view.c:2903
+#: src/nemo-icon-view.c:2922
 msgid "_Icons"
 msgstr ""
 
-#: src/nemo-icon-view.c:2904
+#: src/nemo-icon-view.c:2923
 msgid "The icon view encountered an error."
 msgstr ""
 
-#: src/nemo-icon-view.c:2905
+#: src/nemo-icon-view.c:2924
 msgid "The icon view encountered an error while starting up."
 msgstr ""
 
-#: src/nemo-icon-view.c:2906
+#: src/nemo-icon-view.c:2925
 msgid "Display this location with the icon view."
 msgstr ""
 
-#: src/nemo-icon-view.c:2915 src/nemo-window-menus.c:1462
+#: src/nemo-icon-view.c:2934 src/nemo-window-menus.c:1462
 #: src/nemo-file-management-properties.glade:18
 msgid "Compact View"
 msgstr ""
 
-#: src/nemo-icon-view.c:2917
+#: src/nemo-icon-view.c:2936
 msgid "_Compact"
 msgstr ""
 
-#: src/nemo-icon-view.c:2918
+#: src/nemo-icon-view.c:2937
 msgid "The compact view encountered an error."
 msgstr ""
 
-#: src/nemo-icon-view.c:2919
+#: src/nemo-icon-view.c:2938
 msgid "The compact view encountered an error while starting up."
 msgstr ""
 
-#: src/nemo-icon-view.c:2920
+#: src/nemo-icon-view.c:2939
 msgid "Display this location with the compact view."
 msgstr ""
 
@@ -793,7 +793,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/nemo-image-properties-page.c:767 libnemo-private/nemo-file.c:6417
+#: src/nemo-image-properties-page.c:767 libnemo-private/nemo-file.c:6354
 msgid "Image"
 msgstr ""
 
@@ -824,11 +824,11 @@ msgstr ""
 msgid "(Empty)"
 msgstr ""
 
-#: src/nemo-list-view.c:1891
+#: src/nemo-list-view.c:1918
 msgid "Use Default"
 msgstr ""
 
-#: src/nemo-list-view.c:1902
+#: src/nemo-list-view.c:1929
 msgid "Temporarily disable auto-sort"
 msgstr ""
 
@@ -836,24 +836,24 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: src/nemo-list-view.c:2312 src/nemo-list-view.c:3872
+#: src/nemo-list-view.c:2318 src/nemo-list-view.c:3866
 #: src/nemo-window-menus.c:1450 src/nemo-file-management-properties.glade:15
 msgid "List View"
 msgstr ""
 
-#: src/nemo-list-view.c:3874
+#: src/nemo-list-view.c:3868
 msgid "_List"
 msgstr ""
 
-#: src/nemo-list-view.c:3875
+#: src/nemo-list-view.c:3869
 msgid "The list view encountered an error."
 msgstr ""
 
-#: src/nemo-list-view.c:3876
+#: src/nemo-list-view.c:3870
 msgid "The list view encountered an error while starting up."
 msgstr ""
 
-#: src/nemo-list-view.c:3877
+#: src/nemo-list-view.c:3871
 msgid "Display this location with the list view."
 msgstr ""
 
@@ -891,8 +891,8 @@ msgid "This link cannot be used, because its target \"%s\" doesn't exist."
 msgstr ""
 
 #: src/nemo-mime-actions.c:656 src/nemo-tree-sidebar.c:1339
-#: src/nemo-view.c:8233 src/nemo-view.c:8351 src/nemo-view.c:9403
-#: src/nemo-view.c:9741
+#: src/nemo-view.c:8241 src/nemo-view.c:8359 src/nemo-view.c:9411
+#: src/nemo-view.c:9749
 msgid "Mo_ve to Trash"
 msgstr ""
 
@@ -979,11 +979,11 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/nemo-mime-actions.c:1649 src/nemo-mime-actions.c:1923
-#: src/nemo-view.c:7351
+#: src/nemo-view.c:7359
 msgid "Unable to mount location"
 msgstr ""
 
-#: src/nemo-mime-actions.c:2002 src/nemo-view.c:7498
+#: src/nemo-mime-actions.c:2002 src/nemo-view.c:7506
 msgid "Unable to start location"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgid_plural "Opening %d items."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-notebook.c:392
+#: src/nemo-notebook.c:371
 msgid "Close tab"
 msgstr ""
 
@@ -1011,227 +1011,227 @@ msgid ""
 "default mimetype handler."
 msgstr ""
 
-#: src/nemo-places-sidebar.c:408
+#: src/nemo-places-sidebar.c:430
 msgid "Devices"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:626 src/nemo-view.c:3127
+#: src/nemo-places-sidebar.c:648 src/nemo-view.c:3127
 #, c-format
 msgid "Free space: %s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:745
+#: src/nemo-places-sidebar.c:767
 msgid "My Computer"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:752
+#: src/nemo-places-sidebar.c:774
 #, c-format
 msgid ""
 "Open your personal folder\n"
 "%s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:756 src/nemo-query-editor.c:1167
+#: src/nemo-places-sidebar.c:778 src/nemo-query-editor.c:1167
 #: src/nemo-tree-sidebar.c:1475 libnemo-private/nemo-bookmark.c:130
 #: libnemo-private/nemo-desktop-link.c:118
 #: libnemo-private/nemo-file-utilities.c:66
 msgid "Home"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:775
+#: src/nemo-places-sidebar.c:797
 msgid "Open the contents of your desktop in a folder"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:825
+#: src/nemo-places-sidebar.c:847
 msgid "Recent"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:827
+#: src/nemo-places-sidebar.c:849
 msgid "Recent files"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:836
+#: src/nemo-places-sidebar.c:858
 #, c-format
 msgid ""
 "Open the contents of the File System\n"
 "%s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:840 src/nemo-tree-sidebar.c:1479
+#: src/nemo-places-sidebar.c:862 src/nemo-tree-sidebar.c:1479
 msgid "File System"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:855 src/nemo-trash-bar.c:202
+#: src/nemo-places-sidebar.c:877 src/nemo-trash-bar.c:202
 #: libnemo-private/nemo-desktop-link.c:135
 msgid "Trash"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:857
+#: src/nemo-places-sidebar.c:879
 msgid "Open the trash"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:862
+#: src/nemo-places-sidebar.c:884
 msgid "Bookmarks"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:979
+#: src/nemo-places-sidebar.c:1001
 #, c-format
 msgid ""
 "%s (%s)\n"
 "%s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:1008
+#: src/nemo-places-sidebar.c:1030
 #, c-format
 msgid "Mount and open %s (%s)"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:1036 src/nemo-places-sidebar.c:1125
+#: src/nemo-places-sidebar.c:1058 src/nemo-places-sidebar.c:1147
 #, c-format
 msgid "Mount and open %s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:1078
+#: src/nemo-places-sidebar.c:1100
 #, c-format
 msgid ""
 "%s\n"
 "%s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:1112 src/nemo-places-sidebar.c:1167
+#: src/nemo-places-sidebar.c:1134 src/nemo-places-sidebar.c:1189
 #: src/nemo-tree-sidebar.c:1483 libnemo-private/nemo-desktop-link.c:147
 msgid "Network"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:1169
+#: src/nemo-places-sidebar.c:1191
 msgid "Browse the contents of the network"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2246 src/nemo-places-sidebar.c:3426
-#: src/nemo-view.c:8279 src/nemo-view.c:8303 src/nemo-view.c:8375
-#: src/nemo-view.c:9026 src/nemo-view.c:9030 src/nemo-view.c:9113
-#: src/nemo-view.c:9117 src/nemo-view.c:9217 src/nemo-view.c:9221
+#: src/nemo-places-sidebar.c:2268 src/nemo-places-sidebar.c:3448
+#: src/nemo-view.c:8287 src/nemo-view.c:8311 src/nemo-view.c:8383
+#: src/nemo-view.c:9034 src/nemo-view.c:9038 src/nemo-view.c:9121
+#: src/nemo-view.c:9125 src/nemo-view.c:9225 src/nemo-view.c:9229
 msgid "_Start"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2247 src/nemo-places-sidebar.c:3433
-#: src/nemo-view.c:8283 src/nemo-view.c:8307 src/nemo-view.c:8379
-#: src/nemo-view.c:9055 src/nemo-view.c:9142 src/nemo-view.c:9246
+#: src/nemo-places-sidebar.c:2269 src/nemo-places-sidebar.c:3455
+#: src/nemo-view.c:8291 src/nemo-view.c:8315 src/nemo-view.c:8387
+#: src/nemo-view.c:9063 src/nemo-view.c:9150 src/nemo-view.c:9254
 #: src/nemo-window-menus.c:1125
 msgid "_Stop"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2252
+#: src/nemo-places-sidebar.c:2274
 msgid "_Power On"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2253 src/nemo-view.c:9059 src/nemo-view.c:9146
-#: src/nemo-view.c:9250
+#: src/nemo-places-sidebar.c:2275 src/nemo-view.c:9067 src/nemo-view.c:9154
+#: src/nemo-view.c:9258
 msgid "_Safely Remove Drive"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2256
+#: src/nemo-places-sidebar.c:2278
 msgid "_Connect Drive"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2257
+#: src/nemo-places-sidebar.c:2279
 msgid "_Disconnect Drive"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2260
+#: src/nemo-places-sidebar.c:2282
 msgid "_Start Multi-disk Device"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2261
+#: src/nemo-places-sidebar.c:2283
 msgid "_Stop Multi-disk Device"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2265 src/nemo-view.c:9129 src/nemo-view.c:9233
+#: src/nemo-places-sidebar.c:2287 src/nemo-view.c:9137 src/nemo-view.c:9241
 msgid "_Unlock Drive"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2266 src/nemo-view.c:9071 src/nemo-view.c:9158
-#: src/nemo-view.c:9262
+#: src/nemo-places-sidebar.c:2288 src/nemo-view.c:9079 src/nemo-view.c:9166
+#: src/nemo-view.c:9270
 msgid "_Lock Drive"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2372 src/nemo-places-sidebar.c:2980
+#: src/nemo-places-sidebar.c:2394 src/nemo-places-sidebar.c:3002
 #, c-format
 msgid "Unable to start %s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2740 src/nemo-places-sidebar.c:2768
-#: src/nemo-places-sidebar.c:2796
+#: src/nemo-places-sidebar.c:2762 src/nemo-places-sidebar.c:2790
+#: src/nemo-places-sidebar.c:2818
 #, c-format
 msgid "Unable to eject %s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:2935
+#: src/nemo-places-sidebar.c:2957
 #, c-format
 msgid "Unable to poll %s for media changes"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3035
+#: src/nemo-places-sidebar.c:3057
 #, c-format
 msgid "Unable to stop %s"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3338 src/nemo-tree-sidebar.c:1250
-#: src/nemo-view.c:8140 src/nemo-view.c:8480 src/nemo-view.c:9650
-#: src/nemo-view.c:9661
+#: src/nemo-places-sidebar.c:3360 src/nemo-tree-sidebar.c:1250
+#: src/nemo-view.c:8148 src/nemo-view.c:8488 src/nemo-view.c:9658
+#: src/nemo-view.c:9669
 msgid "_Open"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3346 src/nemo-tree-sidebar.c:1261
-#: src/nemo-view.c:8152 src/nemo-view.c:8333 src/nemo-view.c:9350
-#: src/nemo-view.c:9718
+#: src/nemo-places-sidebar.c:3368 src/nemo-tree-sidebar.c:1261
+#: src/nemo-view.c:8160 src/nemo-view.c:8341 src/nemo-view.c:9358
+#: src/nemo-view.c:9726
 msgid "Open in New _Tab"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3356 src/nemo-tree-sidebar.c:1275
-#: src/nemo-view.c:9341 src/nemo-view.c:9698
+#: src/nemo-places-sidebar.c:3378 src/nemo-tree-sidebar.c:1275
+#: src/nemo-view.c:9349 src/nemo-view.c:9706
 msgid "Open in New _Window"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3367 src/nemo-window-menus.c:1231
+#: src/nemo-places-sidebar.c:3389 src/nemo-window-menus.c:1231
 msgid "_Add Bookmark"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3373
+#: src/nemo-places-sidebar.c:3395
 msgid "Remove"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3382
+#: src/nemo-places-sidebar.c:3404
 msgid "Rename..."
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3398 src/nemo-view.c:8267 src/nemo-view.c:8291
-#: src/nemo-view.c:8363
+#: src/nemo-places-sidebar.c:3420 src/nemo-view.c:8275 src/nemo-view.c:8299
+#: src/nemo-view.c:8371
 msgid "_Mount"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3405 src/nemo-tree-sidebar.c:1371
-#: src/nemo-view.c:8271 src/nemo-view.c:8295 src/nemo-view.c:8367
+#: src/nemo-places-sidebar.c:3427 src/nemo-tree-sidebar.c:1371
+#: src/nemo-view.c:8279 src/nemo-view.c:8303 src/nemo-view.c:8375
 msgid "_Unmount"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3412 src/nemo-tree-sidebar.c:1380
-#: src/nemo-view.c:8275 src/nemo-view.c:8299 src/nemo-view.c:8371
+#: src/nemo-places-sidebar.c:3434 src/nemo-tree-sidebar.c:1380
+#: src/nemo-view.c:8283 src/nemo-view.c:8307 src/nemo-view.c:8379
 msgid "_Eject"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3419 src/nemo-view.c:8287 src/nemo-view.c:8311
-#: src/nemo-view.c:8383
+#: src/nemo-places-sidebar.c:3441 src/nemo-view.c:8295 src/nemo-view.c:8319
+#: src/nemo-view.c:8391
 msgid "_Detect Media"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3442 src/nemo-trash-bar.c:215
+#: src/nemo-places-sidebar.c:3464 src/nemo-trash-bar.c:215
 #: libnemo-private/nemo-file-operations.c:1506
 #: libnemo-private/nemo-file-operations.c:2382
 msgid "Empty _Trash"
 msgstr ""
 
-#: src/nemo-places-sidebar.c:3454 src/nemo-view.c:8122 src/nemo-view.c:8388
+#: src/nemo-places-sidebar.c:3476 src/nemo-view.c:8130 src/nemo-view.c:8396
 msgid "_Properties"
 msgstr ""
 
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "%s Properties"
 msgstr ""
 
-#: src/nemo-properties-window.c:1119 libnemo-private/nemo-file.c:6385
+#: src/nemo-properties-window.c:1119 libnemo-private/nemo-file.c:6322
 msgid "unknown"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
-#: src/nemo-properties-window.c:3106 libnemo-private/nemo-file.c:7604
+#: src/nemo-properties-window.c:3106 libnemo-private/nemo-file.c:7482
 msgid "Link target:"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: src/nemo-query-editor.c:419 libnemo-private/nemo-file.c:6423
+#: src/nemo-query-editor.c:419 libnemo-private/nemo-file.c:6360
 msgid "Video"
 msgstr ""
 
@@ -1585,11 +1585,11 @@ msgstr ""
 msgid "Illustration"
 msgstr ""
 
-#: src/nemo-query-editor.c:469 libnemo-private/nemo-file.c:6428
+#: src/nemo-query-editor.c:469 libnemo-private/nemo-file.c:6365
 msgid "Spreadsheet"
 msgstr ""
 
-#: src/nemo-query-editor.c:485 libnemo-private/nemo-file.c:6427
+#: src/nemo-query-editor.c:485 libnemo-private/nemo-file.c:6364
 msgid "Presentation"
 msgstr ""
 
@@ -1705,16 +1705,16 @@ msgstr ""
 msgid "There is nothing on the clipboard to paste."
 msgstr ""
 
-#: src/nemo-tree-sidebar.c:1291 src/nemo-view.c:8130
+#: src/nemo-tree-sidebar.c:1291 src/nemo-view.c:8138
 msgid "Create New _Folder"
 msgstr ""
 
-#: src/nemo-tree-sidebar.c:1323 src/nemo-view.c:8199 src/nemo-view.c:8346
+#: src/nemo-tree-sidebar.c:1323 src/nemo-view.c:8207 src/nemo-view.c:8354
 msgid "_Paste Into Folder"
 msgstr ""
 
-#: src/nemo-tree-sidebar.c:1353 src/nemo-view.c:8237 src/nemo-view.c:8355
-#: src/nemo-view.c:9764
+#: src/nemo-tree-sidebar.c:1353 src/nemo-view.c:8245 src/nemo-view.c:8363
+#: src/nemo-view.c:9772
 msgid "_Delete"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr[1] ""
 msgid "%s (%s)"
 msgstr ""
 
-#: src/nemo-view.c:3135 libnemo-private/nemo-file.c:5951
+#: src/nemo-view.c:3135 libnemo-private/nemo-file.c:5888
 #, c-format
 msgid "%'u item"
 msgid_plural "%'u items"
@@ -1902,600 +1902,600 @@ msgstr ""
 msgid "Select Target Folder For Copy"
 msgstr ""
 
-#: src/nemo-view.c:7371
+#: src/nemo-view.c:7379
 msgid "Unable to unmount location"
 msgstr ""
 
-#: src/nemo-view.c:7391
+#: src/nemo-view.c:7399
 msgid "Unable to eject location"
 msgstr ""
 
-#: src/nemo-view.c:7406
+#: src/nemo-view.c:7414
 msgid "Unable to stop drive"
 msgstr ""
 
-#: src/nemo-view.c:7892
+#: src/nemo-view.c:7900
 #, c-format
 msgid "Connect to Server %s"
 msgstr ""
 
-#: src/nemo-view.c:7897 src/nemo-view.c:9034 src/nemo-view.c:9121
-#: src/nemo-view.c:9225
+#: src/nemo-view.c:7905 src/nemo-view.c:9042 src/nemo-view.c:9129
+#: src/nemo-view.c:9233
 msgid "_Connect"
 msgstr ""
 
-#: src/nemo-view.c:7911
+#: src/nemo-view.c:7919
 msgid "Link _name:"
 msgstr ""
 
-#: src/nemo-view.c:8118
+#: src/nemo-view.c:8126
 msgid "Create New _Document"
 msgstr ""
 
-#: src/nemo-view.c:8119
+#: src/nemo-view.c:8127
 msgid "Open Wit_h"
 msgstr ""
 
-#: src/nemo-view.c:8120
+#: src/nemo-view.c:8128
 msgid "Choose a program with which to open the selected item"
 msgstr ""
 
-#: src/nemo-view.c:8123 src/nemo-view.c:9805
+#: src/nemo-view.c:8131 src/nemo-view.c:9813
 msgid "View or modify the properties of each selected item"
 msgstr ""
 
-#: src/nemo-view.c:8131
+#: src/nemo-view.c:8139
 msgid "Create a new empty folder inside this folder"
 msgstr ""
 
-#: src/nemo-view.c:8133
+#: src/nemo-view.c:8141
 msgid "No templates installed"
 msgstr ""
 
-#: src/nemo-view.c:8136
+#: src/nemo-view.c:8144
 msgid "_Empty Document"
 msgstr ""
 
-#: src/nemo-view.c:8137
+#: src/nemo-view.c:8145
 msgid "Create a new empty document inside this folder"
 msgstr ""
 
-#: src/nemo-view.c:8141 src/nemo-view.c:8481
+#: src/nemo-view.c:8149 src/nemo-view.c:8489
 msgid "Open the selected item in this window"
 msgstr ""
 
-#: src/nemo-view.c:8148 src/nemo-view.c:8329
+#: src/nemo-view.c:8156 src/nemo-view.c:8337
 msgid "Open in Navigation Window"
 msgstr ""
 
-#: src/nemo-view.c:8149
+#: src/nemo-view.c:8157
 msgid "Open each selected item in a navigation window"
 msgstr ""
 
-#: src/nemo-view.c:8153
+#: src/nemo-view.c:8161
 msgid "Open each selected item in a new tab"
 msgstr ""
 
-#: src/nemo-view.c:8156 src/nemo-window-menus.c:1427
+#: src/nemo-view.c:8164 src/nemo-window-menus.c:1427
 msgid "Open in Terminal"
 msgstr ""
 
-#: src/nemo-view.c:8157
+#: src/nemo-view.c:8165
 msgid "Open terminal in the selected folder"
 msgstr ""
 
-#: src/nemo-view.c:8160
+#: src/nemo-view.c:8168
 msgid "Open as Root"
 msgstr ""
 
-#: src/nemo-view.c:8161
+#: src/nemo-view.c:8169
 msgid "Open the folder with administration privileges"
 msgstr ""
 
-#: src/nemo-view.c:8165
+#: src/nemo-view.c:8173
 msgid "Follow link to original file"
 msgstr ""
 
-#: src/nemo-view.c:8166
+#: src/nemo-view.c:8174
 msgid "Navigate to the original file that this symbolic link points to"
 msgstr ""
 
-#: src/nemo-view.c:8169
+#: src/nemo-view.c:8177
 msgid "Open containing folder"
 msgstr ""
 
-#: src/nemo-view.c:8170
+#: src/nemo-view.c:8178
 msgid "Navigate to the folder that the selected item is stored in"
 msgstr ""
 
-#: src/nemo-view.c:8173
+#: src/nemo-view.c:8181
 msgid "Other _Application..."
 msgstr ""
 
-#: src/nemo-view.c:8174 src/nemo-view.c:8178
+#: src/nemo-view.c:8182 src/nemo-view.c:8186
 msgid "Choose another application with which to open the selected item"
 msgstr ""
 
-#: src/nemo-view.c:8177
+#: src/nemo-view.c:8185
 msgid "Open With Other _Application..."
 msgstr ""
 
-#: src/nemo-view.c:8186
+#: src/nemo-view.c:8194
 msgid "Prepare the selected files to be moved with a Paste command"
 msgstr ""
 
-#: src/nemo-view.c:8190
+#: src/nemo-view.c:8198
 msgid "Prepare the selected files to be copied with a Paste command"
 msgstr ""
 
-#: src/nemo-view.c:8194
+#: src/nemo-view.c:8202
 msgid "Move or copy files previously selected by a Cut or Copy command"
 msgstr ""
 
-#: src/nemo-view.c:8200
+#: src/nemo-view.c:8208
 msgid ""
 "Move or copy files previously selected by a Cut or Copy command into the "
 "selected folder"
 msgstr ""
 
-#: src/nemo-view.c:8202
+#: src/nemo-view.c:8210
 msgid "Cop_y to"
 msgstr ""
 
-#: src/nemo-view.c:8203
+#: src/nemo-view.c:8211
 msgid "M_ove to"
 msgstr ""
 
-#: src/nemo-view.c:8205 libnemo-private/nemo-clipboard.c:444
+#: src/nemo-view.c:8213 libnemo-private/nemo-clipboard.c:444
 msgid "Select _All"
 msgstr ""
 
-#: src/nemo-view.c:8206
+#: src/nemo-view.c:8214
 msgid "Select all items in this window"
 msgstr ""
 
-#: src/nemo-view.c:8209
+#: src/nemo-view.c:8217
 msgid "Select I_tems Matching..."
 msgstr ""
 
-#: src/nemo-view.c:8210
+#: src/nemo-view.c:8218
 msgid "Select items in this window matching a given pattern"
 msgstr ""
 
-#: src/nemo-view.c:8213
+#: src/nemo-view.c:8221
 msgid "_Invert Selection"
 msgstr ""
 
-#: src/nemo-view.c:8214
+#: src/nemo-view.c:8222
 msgid "Select all and only the items that are not currently selected"
 msgstr ""
 
-#: src/nemo-view.c:8217
+#: src/nemo-view.c:8225
 msgid "D_uplicate"
 msgstr ""
 
-#: src/nemo-view.c:8218
+#: src/nemo-view.c:8226
 msgid "Duplicate each selected item"
 msgstr ""
 
-#: src/nemo-view.c:8221 src/nemo-view.c:9790
+#: src/nemo-view.c:8229 src/nemo-view.c:9798
 msgid "Ma_ke Link"
 msgid_plural "Ma_ke Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8222
+#: src/nemo-view.c:8230
 msgid "Create a symbolic link for each selected item"
 msgstr ""
 
-#: src/nemo-view.c:8225
+#: src/nemo-view.c:8233
 msgid "_Rename..."
 msgstr ""
 
-#: src/nemo-view.c:8226
+#: src/nemo-view.c:8234
 msgid "Rename selected item"
 msgstr ""
 
-#: src/nemo-view.c:8234 src/nemo-view.c:9742
+#: src/nemo-view.c:8242 src/nemo-view.c:9750
 msgid "Move each selected item to the Trash"
 msgstr ""
 
-#: src/nemo-view.c:8238 src/nemo-view.c:9765
+#: src/nemo-view.c:8246 src/nemo-view.c:9773
 msgid "Delete each selected item, without moving to the Trash"
 msgstr ""
 
-#: src/nemo-view.c:8241 src/nemo-view.c:8359
+#: src/nemo-view.c:8249 src/nemo-view.c:8367
 msgid "_Restore"
 msgstr ""
 
-#: src/nemo-view.c:8245 src/nemo-window-menus.c:1114
+#: src/nemo-view.c:8253 src/nemo-window-menus.c:1114
 msgid "_Undo"
 msgstr ""
 
-#: src/nemo-view.c:8246
+#: src/nemo-view.c:8254
 msgid "Undo the last action"
 msgstr ""
 
-#: src/nemo-view.c:8249
+#: src/nemo-view.c:8257
 msgid "_Redo"
 msgstr ""
 
-#: src/nemo-view.c:8250
+#: src/nemo-view.c:8258
 msgid "Redo the last undone action"
 msgstr ""
 
-#: src/nemo-view.c:8259
+#: src/nemo-view.c:8267
 msgid "Reset View to _Defaults"
 msgstr ""
 
-#: src/nemo-view.c:8260
+#: src/nemo-view.c:8268
 msgid "Reset sorting order and zoom level to match preferences for this view"
 msgstr ""
 
-#: src/nemo-view.c:8263
+#: src/nemo-view.c:8271
 msgid "Connect To This Server"
 msgstr ""
 
-#: src/nemo-view.c:8264
+#: src/nemo-view.c:8272
 msgid "Make a permanent connection to this server"
 msgstr ""
 
-#: src/nemo-view.c:8268
+#: src/nemo-view.c:8276
 msgid "Mount the selected volume"
 msgstr ""
 
-#: src/nemo-view.c:8272
+#: src/nemo-view.c:8280
 msgid "Unmount the selected volume"
 msgstr ""
 
-#: src/nemo-view.c:8276
+#: src/nemo-view.c:8284
 msgid "Eject the selected volume"
 msgstr ""
 
-#: src/nemo-view.c:8280
+#: src/nemo-view.c:8288
 msgid "Start the selected volume"
 msgstr ""
 
-#: src/nemo-view.c:8284 src/nemo-view.c:9247
+#: src/nemo-view.c:8292 src/nemo-view.c:9255
 msgid "Stop the selected volume"
 msgstr ""
 
-#: src/nemo-view.c:8288 src/nemo-view.c:8312 src/nemo-view.c:8384
+#: src/nemo-view.c:8296 src/nemo-view.c:8320 src/nemo-view.c:8392
 msgid "Detect media in the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:8292
+#: src/nemo-view.c:8300
 msgid "Mount the volume associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:8296
+#: src/nemo-view.c:8304
 msgid "Unmount the volume associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:8300
+#: src/nemo-view.c:8308
 msgid "Eject the volume associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:8304
+#: src/nemo-view.c:8312
 msgid "Start the volume associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:8308
+#: src/nemo-view.c:8316
 msgid "Stop the volume associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:8315
+#: src/nemo-view.c:8323
 msgid "Open File and Close window"
 msgstr ""
 
-#: src/nemo-view.c:8319
+#: src/nemo-view.c:8327
 msgid "Sa_ve Search"
 msgstr ""
 
-#: src/nemo-view.c:8320
+#: src/nemo-view.c:8328
 msgid "Save the edited search"
 msgstr ""
 
-#: src/nemo-view.c:8323
+#: src/nemo-view.c:8331
 msgid "Sa_ve Search As..."
 msgstr ""
 
-#: src/nemo-view.c:8324
+#: src/nemo-view.c:8332
 msgid "Save the current search as a file"
 msgstr ""
 
-#: src/nemo-view.c:8330
+#: src/nemo-view.c:8338
 msgid "Open this folder in a navigation window"
 msgstr ""
 
-#: src/nemo-view.c:8334
+#: src/nemo-view.c:8342
 msgid "Open this folder in a new tab"
 msgstr ""
 
-#: src/nemo-view.c:8339
+#: src/nemo-view.c:8347
 msgid "Prepare this folder to be moved with a Paste command"
 msgstr ""
 
-#: src/nemo-view.c:8343
+#: src/nemo-view.c:8351
 msgid "Prepare this folder to be copied with a Paste command"
 msgstr ""
 
-#: src/nemo-view.c:8347
+#: src/nemo-view.c:8355
 msgid ""
 "Move or copy files previously selected by a Cut or Copy command into this "
 "folder"
 msgstr ""
 
-#: src/nemo-view.c:8352
+#: src/nemo-view.c:8360
 msgid "Move this folder to the Trash"
 msgstr ""
 
-#: src/nemo-view.c:8356
+#: src/nemo-view.c:8364
 msgid "Delete this folder, without moving to the Trash"
 msgstr ""
 
-#: src/nemo-view.c:8364
+#: src/nemo-view.c:8372
 msgid "Mount the volume associated with this folder"
 msgstr ""
 
-#: src/nemo-view.c:8368
+#: src/nemo-view.c:8376
 msgid "Unmount the volume associated with this folder"
 msgstr ""
 
-#: src/nemo-view.c:8372
+#: src/nemo-view.c:8380
 msgid "Eject the volume associated with this folder"
 msgstr ""
 
-#: src/nemo-view.c:8376
+#: src/nemo-view.c:8384
 msgid "Start the volume associated with this folder"
 msgstr ""
 
-#: src/nemo-view.c:8380
+#: src/nemo-view.c:8388
 msgid "Stop the volume associated with this folder"
 msgstr ""
 
-#: src/nemo-view.c:8389
+#: src/nemo-view.c:8397
 msgid "View or modify the properties of this folder"
 msgstr ""
 
-#: src/nemo-view.c:8392 src/nemo-view.c:8395
+#: src/nemo-view.c:8400 src/nemo-view.c:8403
 msgid "_Other pane"
 msgstr ""
 
-#: src/nemo-view.c:8393
+#: src/nemo-view.c:8401
 msgid "Copy the current selection to the other pane in the window"
 msgstr ""
 
-#: src/nemo-view.c:8396
+#: src/nemo-view.c:8404
 msgid "Move the current selection to the other pane in the window"
 msgstr ""
 
-#: src/nemo-view.c:8399 src/nemo-view.c:8403 src/nemo-window-menus.c:1185
+#: src/nemo-view.c:8407 src/nemo-view.c:8411 src/nemo-window-menus.c:1185
 #: src/nemo-window-menus.c:1377 src/nemo-window-menus.c:1591
 msgid "_Home"
 msgstr ""
 
-#: src/nemo-view.c:8400
+#: src/nemo-view.c:8408
 msgid "Copy the current selection to the home folder"
 msgstr ""
 
-#: src/nemo-view.c:8404
+#: src/nemo-view.c:8412
 msgid "Move the current selection to the home folder"
 msgstr ""
 
-#: src/nemo-view.c:8407 src/nemo-view.c:8411
+#: src/nemo-view.c:8415 src/nemo-view.c:8419
 msgid "_Desktop"
 msgstr ""
 
-#: src/nemo-view.c:8408
+#: src/nemo-view.c:8416
 msgid "Copy the current selection to the desktop"
 msgstr ""
 
-#: src/nemo-view.c:8412
+#: src/nemo-view.c:8420
 msgid "Move the current selection to the desktop"
 msgstr ""
 
-#: src/nemo-view.c:8415 src/nemo-view.c:8419
+#: src/nemo-view.c:8423 src/nemo-view.c:8427
 msgid "Browse…"
 msgstr ""
 
-#: src/nemo-view.c:8416
+#: src/nemo-view.c:8424
 msgid "Browse for a folder to move the selection to"
 msgstr ""
 
-#: src/nemo-view.c:8420
+#: src/nemo-view.c:8428
 msgid "Browse for a folder to copy the selection to"
 msgstr ""
 
-#: src/nemo-view.c:8508
+#: src/nemo-view.c:8516
 msgid "Run scripts"
 msgstr ""
 
-#: src/nemo-view.c:8510
+#: src/nemo-view.c:8518
 msgid "_Scripts"
 msgstr ""
 
-#: src/nemo-view.c:8883
+#: src/nemo-view.c:8891
 #, c-format
 msgid "Move the open folder out of the trash to \"%s\""
 msgstr ""
 
-#: src/nemo-view.c:8886
+#: src/nemo-view.c:8894
 #, c-format
 msgid "Move the selected folder out of the trash to \"%s\""
 msgid_plural "Move the selected folders out of the trash to \"%s\""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8890
+#: src/nemo-view.c:8898
 msgid "Move the selected folder out of the trash"
 msgid_plural "Move the selected folders out of the trash"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8896
+#: src/nemo-view.c:8904
 #, c-format
 msgid "Move the selected file out of the trash to \"%s\""
 msgid_plural "Move the selected files out of the trash to \"%s\""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8900
+#: src/nemo-view.c:8908
 msgid "Move the selected file out of the trash"
 msgid_plural "Move the selected files out of the trash"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8906
+#: src/nemo-view.c:8914
 #, c-format
 msgid "Move the selected item out of the trash to \"%s\""
 msgid_plural "Move the selected items out of the trash to \"%s\""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:8910
+#: src/nemo-view.c:8918
 msgid "Move the selected item out of the trash"
 msgid_plural "Move the selected items out of the trash"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:9027 src/nemo-view.c:9031 src/nemo-view.c:9218
-#: src/nemo-view.c:9222
+#: src/nemo-view.c:9035 src/nemo-view.c:9039 src/nemo-view.c:9226
+#: src/nemo-view.c:9230
 msgid "Start the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9035 src/nemo-view.c:9226
+#: src/nemo-view.c:9043 src/nemo-view.c:9234
 msgid "Connect to the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9038 src/nemo-view.c:9125 src/nemo-view.c:9229
+#: src/nemo-view.c:9046 src/nemo-view.c:9133 src/nemo-view.c:9237
 msgid "_Start Multi-disk Drive"
 msgstr ""
 
-#: src/nemo-view.c:9039 src/nemo-view.c:9230
+#: src/nemo-view.c:9047 src/nemo-view.c:9238
 msgid "Start the selected multi-disk drive"
 msgstr ""
 
-#: src/nemo-view.c:9042
+#: src/nemo-view.c:9050
 msgid "U_nlock Drive"
 msgstr ""
 
-#: src/nemo-view.c:9043 src/nemo-view.c:9234
+#: src/nemo-view.c:9051 src/nemo-view.c:9242
 msgid "Unlock the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9056
+#: src/nemo-view.c:9064
 msgid "Stop the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9060 src/nemo-view.c:9251
+#: src/nemo-view.c:9068 src/nemo-view.c:9259
 msgid "Safely remove the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9063 src/nemo-view.c:9150 src/nemo-view.c:9254
+#: src/nemo-view.c:9071 src/nemo-view.c:9158 src/nemo-view.c:9262
 msgid "_Disconnect"
 msgstr ""
 
-#: src/nemo-view.c:9064 src/nemo-view.c:9255
+#: src/nemo-view.c:9072 src/nemo-view.c:9263
 msgid "Disconnect the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9067 src/nemo-view.c:9154 src/nemo-view.c:9258
+#: src/nemo-view.c:9075 src/nemo-view.c:9162 src/nemo-view.c:9266
 msgid "_Stop Multi-disk Drive"
 msgstr ""
 
-#: src/nemo-view.c:9068 src/nemo-view.c:9259
+#: src/nemo-view.c:9076 src/nemo-view.c:9267
 msgid "Stop the selected multi-disk drive"
 msgstr ""
 
-#: src/nemo-view.c:9072 src/nemo-view.c:9263
+#: src/nemo-view.c:9080 src/nemo-view.c:9271
 msgid "Lock the selected drive"
 msgstr ""
 
-#: src/nemo-view.c:9114 src/nemo-view.c:9118
+#: src/nemo-view.c:9122 src/nemo-view.c:9126
 msgid "Start the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9122
+#: src/nemo-view.c:9130
 msgid "Connect to the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9126
+#: src/nemo-view.c:9134
 msgid "Start the multi-disk drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9130
+#: src/nemo-view.c:9138
 msgid "Unlock the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9143
+#: src/nemo-view.c:9151
 msgid "_Stop the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9147
+#: src/nemo-view.c:9155
 msgid "Safely remove the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9151
+#: src/nemo-view.c:9159
 msgid "Disconnect the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9155
+#: src/nemo-view.c:9163
 msgid "Stop the multi-disk drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9159
+#: src/nemo-view.c:9167
 msgid "Lock the drive associated with the open folder"
 msgstr ""
 
-#: src/nemo-view.c:9399 src/nemo-view.c:9737
+#: src/nemo-view.c:9407 src/nemo-view.c:9745
 msgid "_Delete Permanently"
 msgstr ""
 
-#: src/nemo-view.c:9400
+#: src/nemo-view.c:9408
 msgid "Delete the open folder permanently"
 msgstr ""
 
-#: src/nemo-view.c:9404
+#: src/nemo-view.c:9412
 msgid "Move the open folder to the Trash"
 msgstr ""
 
-#: src/nemo-view.c:9629
+#: src/nemo-view.c:9637
 #, c-format
 msgid "_Open With %s"
 msgstr ""
 
-#: src/nemo-view.c:9700
+#: src/nemo-view.c:9708
 #, c-format
 msgid "Open in %'d New _Window"
 msgid_plural "Open in %'d New _Windows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:9720
+#: src/nemo-view.c:9728
 #, c-format
 msgid "Open in %'d New _Tab"
 msgid_plural "Open in %'d New _Tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/nemo-view.c:9738
+#: src/nemo-view.c:9746
 msgid "Delete all selected items permanently"
 msgstr ""
 
-#: src/nemo-view.c:9761
+#: src/nemo-view.c:9769
 msgid "Remo_ve from Recent"
 msgstr ""
 
-#: src/nemo-view.c:9762
+#: src/nemo-view.c:9770
 msgid "Remove each selected item from the recently used list"
 msgstr ""
 
-#: src/nemo-view.c:9803
+#: src/nemo-view.c:9811
 msgid "View or modify the properties of the open folder"
 msgstr ""
 
-#: src/nemo-view-dnd.c:125 libnemo-private/nemo-file.c:6557
+#: src/nemo-view-dnd.c:125 libnemo-private/nemo-file.c:6494
 #: libnemo-private/nemo-file-operations.c:392
 #, c-format
 msgid "Link to %s"
@@ -2540,12 +2540,12 @@ msgstr ""
 msgid "Go to the location specified by this bookmark"
 msgstr ""
 
-#: src/nemo-window.c:1594
+#: src/nemo-window.c:1555
 #, c-format
 msgid "%s - File Browser"
 msgstr ""
 
-#: src/nemo-window.c:2104 src/nemo-window-menus.c:316
+#: src/nemo-window.c:2065 src/nemo-window-menus.c:316
 msgid "Nemo"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgid "Original location of file before moved to the Trash"
 msgstr ""
 
 #: libnemo-private/nemo-context-menu-menu-item.c:73
-msgid "Show less actions"
+msgid "Show fewer actions"
 msgstr ""
 
 #: libnemo-private/nemo-context-menu-menu-item.c:74
@@ -3279,296 +3279,296 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1228 libnemo-private/nemo-vfs-file.c:405
+#: libnemo-private/nemo-file.c:1227 libnemo-private/nemo-vfs-file.c:405
 msgid "This file cannot be mounted"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1273
+#: libnemo-private/nemo-file.c:1272
 msgid "This file cannot be unmounted"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1307
+#: libnemo-private/nemo-file.c:1306
 msgid "This file cannot be ejected"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1340 libnemo-private/nemo-vfs-file.c:583
+#: libnemo-private/nemo-file.c:1339 libnemo-private/nemo-vfs-file.c:583
 msgid "This file cannot be started"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1392 libnemo-private/nemo-file.c:1423
+#: libnemo-private/nemo-file.c:1391 libnemo-private/nemo-file.c:1422
 msgid "This file cannot be stopped"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1850
+#: libnemo-private/nemo-file.c:1849
 msgid "Slashes are not allowed in filenames"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1868
+#: libnemo-private/nemo-file.c:1867
 msgid "File not found"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1896
+#: libnemo-private/nemo-file.c:1895
 msgid "Toplevel files cannot be renamed"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1919
+#: libnemo-private/nemo-file.c:1918
 msgid "Unable to rename desktop icon"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:1948
+#: libnemo-private/nemo-file.c:1947
 msgid "Unable to rename desktop file"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4493
+#: libnemo-private/nemo-file.c:4467
 msgid "today at 00:00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4496
+#: libnemo-private/nemo-file.c:4470
 msgid "today at 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4497
+#: libnemo-private/nemo-file.c:4471
 msgid "today at %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4499
+#: libnemo-private/nemo-file.c:4473
 msgid "today, 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4500
+#: libnemo-private/nemo-file.c:4474
 msgid "today, %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4502 libnemo-private/nemo-file.c:4503
+#: libnemo-private/nemo-file.c:4476 libnemo-private/nemo-file.c:4477
 msgid "today"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4512
+#: libnemo-private/nemo-file.c:4486
 msgid "yesterday at 00:00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4513
+#: libnemo-private/nemo-file.c:4487
 msgid "yesterday at %-I:%M:%S %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4515
+#: libnemo-private/nemo-file.c:4489
 msgid "yesterday at 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4516
+#: libnemo-private/nemo-file.c:4490
 msgid "yesterday at %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4518
+#: libnemo-private/nemo-file.c:4492
 msgid "yesterday, 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4519
+#: libnemo-private/nemo-file.c:4493
 msgid "yesterday, %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4521 libnemo-private/nemo-file.c:4522
+#: libnemo-private/nemo-file.c:4495 libnemo-private/nemo-file.c:4496
 msgid "yesterday"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4533
+#: libnemo-private/nemo-file.c:4507
 msgid "Wednesday, September 00 0000 at 00:00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4534
+#: libnemo-private/nemo-file.c:4508
 msgid "%A, %B %-d %Y at %-I:%M:%S %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4536
+#: libnemo-private/nemo-file.c:4510
 msgid "Mon, Oct 00 0000 at 00:00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4537
+#: libnemo-private/nemo-file.c:4511
 msgid "%a, %b %-d %Y at %-I:%M:%S %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4539
+#: libnemo-private/nemo-file.c:4513
 msgid "Mon, Oct 00 0000 at 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4540
+#: libnemo-private/nemo-file.c:4514
 msgid "%a, %b %-d %Y at %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4542
+#: libnemo-private/nemo-file.c:4516
 msgid "Oct 00 0000 at 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4543
+#: libnemo-private/nemo-file.c:4517
 msgid "%b %-d %Y at %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4545
+#: libnemo-private/nemo-file.c:4519
 msgid "Oct 00 0000, 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4546
+#: libnemo-private/nemo-file.c:4520
 msgid "%b %-d %Y, %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4548
+#: libnemo-private/nemo-file.c:4522
 msgid "00/00/00, 00:00 PM"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4549
+#: libnemo-private/nemo-file.c:4523
 msgid "%m/%-d/%y, %-I:%M %p"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4551
+#: libnemo-private/nemo-file.c:4525
 msgid "00/00/00"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:4552
+#: libnemo-private/nemo-file.c:4526
 msgid "%m/%d/%y"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5199
+#: libnemo-private/nemo-file.c:5136
 msgid "Not allowed to set permissions"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5494
+#: libnemo-private/nemo-file.c:5431
 msgid "Not allowed to set owner"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5512
+#: libnemo-private/nemo-file.c:5449
 #, c-format
 msgid "Specified owner '%s' doesn't exist"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5776
+#: libnemo-private/nemo-file.c:5713
 msgid "Not allowed to set group"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5794
+#: libnemo-private/nemo-file.c:5731
 #, c-format
 msgid "Specified group '%s' doesn't exist"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:5952
+#: libnemo-private/nemo-file.c:5889
 #, c-format
 msgid "%'u folder"
 msgid_plural "%'u folders"
 msgstr[0] ""
 msgstr[1] ""
 
-#: libnemo-private/nemo-file.c:5953
+#: libnemo-private/nemo-file.c:5890
 #, c-format
 msgid "%'u file"
 msgid_plural "%'u files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: libnemo-private/nemo-file.c:6348 libnemo-private/nemo-file.c:6364
+#: libnemo-private/nemo-file.c:6285 libnemo-private/nemo-file.c:6301
 msgid "? items"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6354
+#: libnemo-private/nemo-file.c:6291
 msgid "? bytes"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6371 libnemo-private/nemo-file.c:6454
-#: libnemo-private/nemo-file.c:6488
+#: libnemo-private/nemo-file.c:6308 libnemo-private/nemo-file.c:6391
+#: libnemo-private/nemo-file.c:6425
 msgid "Unknown"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6414 libnemo-private/nemo-file.c:6422
-#: libnemo-private/nemo-file.c:6514
+#: libnemo-private/nemo-file.c:6351 libnemo-private/nemo-file.c:6359
+#: libnemo-private/nemo-file.c:6451
 msgid "Program"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6415
+#: libnemo-private/nemo-file.c:6352
 msgid "Audio"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6416
+#: libnemo-private/nemo-file.c:6353
 msgid "Font"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6418
+#: libnemo-private/nemo-file.c:6355
 msgid "Archive"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6419
+#: libnemo-private/nemo-file.c:6356
 msgid "Markup"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6420 libnemo-private/nemo-file.c:6421
+#: libnemo-private/nemo-file.c:6357 libnemo-private/nemo-file.c:6358
 #: eel/eel-editable-label.c:311
 msgid "Text"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6424
+#: libnemo-private/nemo-file.c:6361
 msgid "Contacts"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6425
+#: libnemo-private/nemo-file.c:6362
 msgid "Calendar"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6426
+#: libnemo-private/nemo-file.c:6363
 msgid "Document"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6516
+#: libnemo-private/nemo-file.c:6453
 #: src/nemo-file-management-properties.glade:52
 msgid "Binary"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6520
+#: libnemo-private/nemo-file.c:6457
 msgid "Folder"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6551
+#: libnemo-private/nemo-file.c:6488
 msgid "link"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:6573 libnemo-private/nemo-file.c:6587
+#: libnemo-private/nemo-file.c:6510 libnemo-private/nemo-file.c:6524
 msgid "link (broken)"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7544
+#: libnemo-private/nemo-file.c:7421
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7551
+#: libnemo-private/nemo-file.c:7428
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7561
+#: libnemo-private/nemo-file.c:7438
 #, c-format
 msgid "%s item"
 msgid_plural "%s items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: libnemo-private/nemo-file.c:7563
+#: libnemo-private/nemo-file.c:7440
 #, c-format
 msgid "Contains: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7572
+#: libnemo-private/nemo-file.c:7450
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7580
+#: libnemo-private/nemo-file.c:7458
 #, c-format
 msgid "Accessed: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7588
+#: libnemo-private/nemo-file.c:7466
 #, c-format
 msgid "Modified: %s"
 msgstr ""
 
-#: libnemo-private/nemo-file.c:7597
+#: libnemo-private/nemo-file.c:7475
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4730,7 +4730,7 @@ msgstr ""
 msgid "The item cannot be restored from trash"
 msgstr ""
 
-#: libnemo-private/nemo-icon-container.c:2742
+#: libnemo-private/nemo-icon-container.c:2747
 msgid "The selection rectangle"
 msgstr ""
 
@@ -4933,76 +4933,76 @@ msgid " (invalid Unicode)"
 msgstr ""
 
 #: data/action_i18n_strings.py:8
-msgid "Add Desklets"
-msgstr ""
-
-#: data/action_i18n_strings.py:9
-msgid "Add Cinamon desklets"
-msgstr ""
-
-#: data/action_i18n_strings.py:10
 msgid "Set as Wallpaper..."
 msgstr ""
 
-#: data/action_i18n_strings.py:11
+#: data/action_i18n_strings.py:9
 msgid "Set the selected image as your Cinnamon desktop wallpaper"
 msgstr ""
 
-#: data/action_i18n_strings.py:12
-msgid "Change Desktop _Background"
-msgstr ""
-
-#: data/action_i18n_strings.py:13
-msgid "Change the Cinnamon desktop background"
-msgstr ""
-
-#: data/action_i18n_strings.py:14
-msgid "Create a new l_auncher here..."
-msgstr ""
-
-#: data/action_i18n_strings.py:15
-msgid "Create a new launcher in this folder"
-msgstr ""
-
-#: data/action_i18n_strings.py:16
-msgid "Manage workspaces (Expo)"
-msgstr ""
-
-#: data/action_i18n_strings.py:17
-msgid "Open Expo to add, remove, or organize workspaces"
-msgstr ""
-
-#: data/action_i18n_strings.py:18
+#: data/action_i18n_strings.py:10
 msgid "Mount archive"
 msgstr ""
 
-#: data/action_i18n_strings.py:19
+#: data/action_i18n_strings.py:11
 #, python-format
 msgid "Mount %f to browse its contents"
 msgstr ""
 
-#: data/action_i18n_strings.py:20
-msgid "Jump to new workspace"
+#: data/action_i18n_strings.py:12
+msgid "Manage workspaces (Expo)"
 msgstr ""
 
-#: data/action_i18n_strings.py:21
-msgid "Create a new workspace and activate it"
+#: data/action_i18n_strings.py:13
+msgid "Open Expo to add, remove, or organize workspaces"
 msgstr ""
 
-#: data/action_i18n_strings.py:22
-msgid "Desktop _Settings"
-msgstr ""
-
-#: data/action_i18n_strings.py:23
-msgid "Change how your desktop works"
-msgstr ""
-
-#: data/action_i18n_strings.py:24
+#: data/action_i18n_strings.py:14
 msgid "Remove workspace"
 msgstr ""
 
-#: data/action_i18n_strings.py:25
+#: data/action_i18n_strings.py:15
 msgid "Remove the currently active workspace"
+msgstr ""
+
+#: data/action_i18n_strings.py:16
+msgid "Add Desklets"
+msgstr ""
+
+#: data/action_i18n_strings.py:17
+msgid "Add Cinamon desklets"
+msgstr ""
+
+#: data/action_i18n_strings.py:18
+msgid "Desktop _Settings"
+msgstr ""
+
+#: data/action_i18n_strings.py:19
+msgid "Change how your desktop works"
+msgstr ""
+
+#: data/action_i18n_strings.py:20
+msgid "Change Desktop _Background"
+msgstr ""
+
+#: data/action_i18n_strings.py:21
+msgid "Change the Cinnamon desktop background"
+msgstr ""
+
+#: data/action_i18n_strings.py:22
+msgid "Create a new l_auncher here..."
+msgstr ""
+
+#: data/action_i18n_strings.py:23
+msgid "Create a new launcher in this folder"
+msgstr ""
+
+#: data/action_i18n_strings.py:24
+msgid "Jump to new workspace"
+msgstr ""
+
+#: data/action_i18n_strings.py:25
+msgid "Create a new workspace and activate it"
 msgstr ""
 
 #: src/nemo-bookmarks-window.glade:8
@@ -5024,21 +5024,21 @@ msgstr ""
 #: src/nemo-file-management-properties.glade:29
 #: src/nemo-file-management-properties.glade:182
 #: src/nemo-file-management-properties.glade:199
-#: src/nemo-file-management-properties.glade:3154
+#: src/nemo-file-management-properties.glade:3074
 msgid "Always"
 msgstr ""
 
 #: src/nemo-file-management-properties.glade:32
 #: src/nemo-file-management-properties.glade:185
 #: src/nemo-file-management-properties.glade:202
-#: src/nemo-file-management-properties.glade:3157
+#: src/nemo-file-management-properties.glade:3077
 msgid "Local Files Only"
 msgstr ""
 
 #: src/nemo-file-management-properties.glade:35
 #: src/nemo-file-management-properties.glade:188
 #: src/nemo-file-management-properties.glade:205
-#: src/nemo-file-management-properties.glade:3160
+#: src/nemo-file-management-properties.glade:3080
 msgid "Never"
 msgstr ""
 
@@ -5172,365 +5172,361 @@ msgstr ""
 msgid "File Management Preferences"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:370
+#: src/nemo-file-management-properties.glade:365
 msgid "<b>Default View</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:400
+#: src/nemo-file-management-properties.glade:395
 msgid "View _new folders using:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:445
+#: src/nemo-file-management-properties.glade:440
 msgid "_Arrange items:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:482
+#: src/nemo-file-management-properties.glade:478
 msgid "Sort _folders before files"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:535
+#: src/nemo-file-management-properties.glade:530
 msgid "<b>Icon View Defaults</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:565
+#: src/nemo-file-management-properties.glade:560
 msgid "Default _zoom level:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:602
+#: src/nemo-file-management-properties.glade:598
 msgid "_Text beside icons"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:618
+#: src/nemo-file-management-properties.glade:614
 msgid "_Use compact layout"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:671
+#: src/nemo-file-management-properties.glade:666
 msgid "<b>Compact View Defaults</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:701
+#: src/nemo-file-management-properties.glade:696
 msgid "_Default zoom level:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:738
+#: src/nemo-file-management-properties.glade:734
 msgid "A_ll columns have the same width"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:791
+#: src/nemo-file-management-properties.glade:786
 msgid "<b>List View Defaults</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:821
+#: src/nemo-file-management-properties.glade:816
 msgid "D_efault zoom level:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:895
+#: src/nemo-file-management-properties.glade:890
 msgid "<b>Tree View Defaults</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:917
+#: src/nemo-file-management-properties.glade:913
 msgid "Show _only folders"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:954
+#: src/nemo-file-management-properties.glade:950
 msgid "Views"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:982
+#: src/nemo-file-management-properties.glade:977
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1003
+#: src/nemo-file-management-properties.glade:999
 msgid "_Single click to open items"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1020
+#: src/nemo-file-management-properties.glade:1016
 msgid "_Double click to open items"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1038
+#: src/nemo-file-management-properties.glade:1034
 msgid "Click twice with a pause in between to rename items"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1055
+#: src/nemo-file-management-properties.glade:1051
 msgid "Open each _folder in its own window"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1072
+#: src/nemo-file-management-properties.glade:1068
 msgid "Always start in dual-pane view"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1089
+#: src/nemo-file-management-properties.glade:1085
 msgid "Ignore per-folder view preferences"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1106
+#: src/nemo-file-management-properties.glade:1102
 msgid "Disable file operation queueing"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1160
+#: src/nemo-file-management-properties.glade:1119
+msgid "Go to parent folder with double click on blank area"
+msgstr ""
+
+#: src/nemo-file-management-properties.glade:1172
 msgid "<b>Executable Text Files</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1182
+#: src/nemo-file-management-properties.glade:1195
 msgid "_Run executable text files when they are opened"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1199
+#: src/nemo-file-management-properties.glade:1212
 msgid "_View executable text files when they are opened"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1216
+#: src/nemo-file-management-properties.glade:1229
 msgid "_Ask each time"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1270
+#: src/nemo-file-management-properties.glade:1282
 msgid "<b>Trash</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1292
+#: src/nemo-file-management-properties.glade:1305
 msgid "Ask before _emptying the Trash or deleting files"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1308
+#: src/nemo-file-management-properties.glade:1321
 msgid "I_nclude a Delete command that bypasses Trash"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1324
+#: src/nemo-file-management-properties.glade:1337
 msgid "Bypass the Trash when the Delete key is pressed"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1376
+#: src/nemo-file-management-properties.glade:1388
 msgid "<b>Media Handling</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1398
+#: src/nemo-file-management-properties.glade:1411
 msgid "Automatically mount removeable media when inserted and on startup"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1414
+#: src/nemo-file-management-properties.glade:1427
 msgid "Automatically open a folder for automounted media"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1430
+#: src/nemo-file-management-properties.glade:1443
 msgid "Prompt or autorun/autostart programs when media are inserted"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1446
+#: src/nemo-file-management-properties.glade:1459
 msgid ""
 "Automatically close the device's tab, pane, or window when a device is "
 "unmounted or ejected"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1499
+#: src/nemo-file-management-properties.glade:1511
 msgid "<b>Bulk Rename</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1529
+#: src/nemo-file-management-properties.glade:1541
 msgid "Command to invoke when renaming multiple items:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1581
+#: src/nemo-file-management-properties.glade:1594
 msgid "Behavior"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1609
+#: src/nemo-file-management-properties.glade:1622
 msgid "<b>Icon Captions</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1634
+#: src/nemo-file-management-properties.glade:1647
 msgid ""
 "Choose the order of information to appear beneath icon names. More "
 "information will appear when zooming in closer."
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1785
+#: src/nemo-file-management-properties.glade:1798
 msgid "<b>Date</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1808
+#: src/nemo-file-management-properties.glade:1822
 msgid "_Format:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1868
+#: src/nemo-file-management-properties.glade:1881
 msgid "<b>Window and Tab Titles</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1890
+#: src/nemo-file-management-properties.glade:1904
 msgid "Show the full p_ath in the title bar and tab bars"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1943
+#: src/nemo-file-management-properties.glade:1956
 msgid "<b>File Size</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:1966
+#: src/nemo-file-management-properties.glade:1980
 msgid "_Prefixes:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2033
+#: src/nemo-file-management-properties.glade:2046
 msgid "<b>File Properties</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2055
+#: src/nemo-file-management-properties.glade:2069
 msgid "Show advanced permissions in the file property dialog"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2108
+#: src/nemo-file-management-properties.glade:2121
 msgid "<b>Move/Copy To Menu</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2130
+#: src/nemo-file-management-properties.glade:2144
 msgid "List bookmarks in the menu"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2146
+#: src/nemo-file-management-properties.glade:2160
 msgid "List devices and network locations in the menu"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2183
+#: src/nemo-file-management-properties.glade:2197
 msgid "Display"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2212
+#: src/nemo-file-management-properties.glade:2226
 msgid "<b>List Columns</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2237
+#: src/nemo-file-management-properties.glade:2251
 msgid "Choose the order of information to appear in the list view."
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2272
+#: src/nemo-file-management-properties.glade:2287
 msgid "List Columns"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2300
-msgid "<b>Text Files</b>"
+#: src/nemo-file-management-properties.glade:2315
+msgid "<b>Previewable Files</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2330
-msgid "Show te_xt in icons:"
-msgstr ""
-
-#: src/nemo-file-management-properties.glade:2404
-msgid "<b>Other Previewable Files</b>"
-msgstr ""
-
-#: src/nemo-file-management-properties.glade:2434
+#: src/nemo-file-management-properties.glade:2345
 msgid "Show _thumbnails:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2479
+#: src/nemo-file-management-properties.glade:2390
 msgid "_Only for files smaller than:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2553
+#: src/nemo-file-management-properties.glade:2464
 msgid "<b>Folders</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2583
+#: src/nemo-file-management-properties.glade:2494
 msgid "Count _number of items:"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2657
+#: src/nemo-file-management-properties.glade:2568
 msgid "<b>Tooltips</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2679
+#: src/nemo-file-management-properties.glade:2591
 msgid "Show tooltips in icon and compact views"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2696
+#: src/nemo-file-management-properties.glade:2608
 msgid "Show tooltips in list views"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2713
+#: src/nemo-file-management-properties.glade:2625
 msgid "Show tooltips on the desktop"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2733
+#: src/nemo-file-management-properties.glade:2644
 msgid ""
 "<i>By default, a folder tooltip shows the item count, and files display "
 "their size.\n"
 "    Select additional information to display in the tooltip:</i>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2757
+#: src/nemo-file-management-properties.glade:2669
 msgid "Detailed file type"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2772
+#: src/nemo-file-management-properties.glade:2684
 msgid "Accessed date"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2788
+#: src/nemo-file-management-properties.glade:2700
 msgid "Modified date"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2803
+#: src/nemo-file-management-properties.glade:2715
 msgid "File or folder location"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2849
+#: src/nemo-file-management-properties.glade:2761
 msgid "Preview"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2877
+#: src/nemo-file-management-properties.glade:2789
 msgid "<b>Options</b>"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2899
+#: src/nemo-file-management-properties.glade:2812
 msgid "Show previous button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2916
+#: src/nemo-file-management-properties.glade:2829
 msgid "Show next button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2932
+#: src/nemo-file-management-properties.glade:2845
 msgid "Show up button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2948
+#: src/nemo-file-management-properties.glade:2861
 msgid "Show refresh button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2964
+#: src/nemo-file-management-properties.glade:2877
 msgid "Show computer button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2980
+#: src/nemo-file-management-properties.glade:2893
 msgid "Show home button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:2996
+#: src/nemo-file-management-properties.glade:2909
 msgid "Show location entry/breadcrumbs toggle button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3012
+#: src/nemo-file-management-properties.glade:2925
 msgid "Show open in terminal button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3028
+#: src/nemo-file-management-properties.glade:2941
 msgid "Show new folder button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3044
+#: src/nemo-file-management-properties.glade:2957
 msgid "Show search button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3060
+#: src/nemo-file-management-properties.glade:2973
 msgid "Show icon view button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3076
+#: src/nemo-file-management-properties.glade:2989
 msgid "Show list view button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3092
+#: src/nemo-file-management-properties.glade:3005
 msgid "Show compact view button"
 msgstr ""
 
-#: src/nemo-file-management-properties.glade:3129
+#: src/nemo-file-management-properties.glade:3042
 msgid "Toolbar"
 msgstr ""

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -100,6 +100,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_TOOLTIP_FULL_PATH_WIDGET "tt_show_full_path_checkbutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_SKIP_FILE_OP_QUEUE_WIDGET "skip_file_op_queue_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET "click_double_parent_folder_checkbutton"
 
 /* int enums */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_LIMIT_WIDGET "preview_image_size_combobox"
@@ -980,6 +981,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_SKIP_FILE_OP_QUEUE_WIDGET,
                        NEMO_PREFERENCES_NEVER_QUEUE_FILE_OPS);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET,
+                       NEMO_PREFERENCES_CLICK_DOUBLE_PARENT_FOLDER);
 
     setup_tooltip_items (builder);
     connect_tooltip_items (builder);

--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -1114,6 +1114,23 @@
                                             <property name="position">6</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="click_double_parent_folder_checkbutton">
+                                            <property name="label" translatable="yes">Go to parent folder with double click on blank area</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="padding">3</property>
+                                            <property name="position">7</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -2421,11 +2421,23 @@ static gboolean
 button_press_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_data)
 {
     NemoIconView *view = NEMO_ICON_VIEW (user_data);
+    GdkEventButton *event_button = (GdkEventButton *)event;
+    int selection_count;
 
     if (!nemo_view_get_active (NEMO_VIEW (view))) {
         NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
         nemo_window_slot_make_hosting_pane_active (slot);
         return TRUE;
+    }
+
+    /* double left click on blank will go to parent folder */
+    if ((event_button->button == 1) && (event_button->type == GDK_2BUTTON_PRESS)) {
+        selection_count = nemo_view_get_selection_count (view);
+        if (selection_count == 0) {
+            NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
+            nemo_window_slot_go_up (slot, 0);
+            return TRUE;
+        }
     }
 
     return FALSE;

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -2431,7 +2431,8 @@ button_press_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_da
     }
 
     /* double left click on blank will go to parent folder */
-    if ((event_button->button == 1) && (event_button->type == GDK_2BUTTON_PRESS)) {
+    if (g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_CLICK_DOUBLE_PARENT_FOLDER) &&
+        (event_button->button == 1) && (event_button->type == GDK_2BUTTON_PRESS)) {
         selection_count = nemo_view_get_selection_count (view);
         if (selection_count == 0) {
             NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));


### PR DESCRIPTION
I am used to double left click on blank area to go to parent folder on my working computer under MS Windows with QTTabBar (extension of MS Explorer to have tab and useful shortcuts).
So as I started to use Nemo with Cinnamon under ArchLinux, i was expected to found something similar so I propose this patch with an option to not change standard behavior.