### PR TITLE
file-operations: don't recurse for trash operations

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -2793,7 +2793,10 @@ scan_file (GFile *file,
 	if (info) {
 		count_file (info, job, source_info);
 
-		if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY) {
+    		/* trashing operation doesn't recurse */
+    		if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY &&
+        		source_info->op != OP_KIND_TRASH)
+     		{
 			g_queue_push_head (dirs, g_object_ref (file));
 		}
 		


### PR DESCRIPTION
Based on https://git.gnome.org/browse/nautilus/commit/?id=d4a4f7915ccad4fbe9bb726dd9f876738c7960d4


From d4a4f7915ccad4fbe9bb726dd9f876738c7960d4 Mon Sep 17 00:00:00 2001
From: Carlos Soriano <csoriano@gnome.org>
Date: Thu, 24 Nov 2016 13:32:02 +0100
Subject: file-operations: don't recurse for trash operations

We were scanning the sources as we do for copy and move operations,
and to count the files we were recursing inside directories.

However, the trash operation doesn't recurse at all, so the operation
progress was wrong.

Instead of that, don't recurse for counting the number of files, so the
trash progress is correct. Although is not coherent with the rest of the
operations, recursing for just showing all the files in the progress
would be extremely counterproductive.

https://bugzilla.gnome.org/show_bug.cgi?id=775094