### PR TITLE
Force X11 backend

### DIFF
--- a/src/nemo-main.c
+++ b/src/nemo-main.c
@@ -89,6 +89,8 @@ main (int argc, char *argv[])
 
 	g_set_prgname ("nemo");
 
+	gdk_set_allowed_backends ("x11");
+
 #ifdef HAVE_EXEMPI
 	xmp_init();
 #endif


### PR DESCRIPTION
based on 94dcf03e5bc9cd1db83cf3016289e305e13694d4

From 94dcf03e5bc9cd1db83cf3016289e305e13694d4 Mon Sep 17 00:00:00 2001
From: Florian <fmuellner@gnome.org>
Date: Wed, 7 Dec 2016 17:11:56 +0100
Subject: desktop: Force X11 backend

At least for the time being, desktop icons are not supported on
wayland. This may or may not change, but in the meantime we can
still meet user expectations by forcing the supported backend
instead of failing with an unsupported one.

https://bugzilla.gnome.org/show_bug.cgi?id=748347

Fixes https://github.com/linuxmint/nemo/issues/1343