### PR TITLE
file-operations: don't automatically trust executable .desktop files

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -4052,10 +4052,8 @@ is_trusted_desktop_file (GFile *file,
 	res = FALSE;
 	
 	/* Weird file => not trusted,
-	   Already executable => no need to mark trusted */
+	   File in system directory => no need to mark trusted */
 	if (g_file_info_get_file_type (info) == G_FILE_TYPE_REGULAR &&
-	    !g_file_info_get_attribute_boolean (info,
-						G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE) &&
 	    nemo_is_in_system_dir (file)) {
 		res = TRUE;
 	}


### PR DESCRIPTION
This is a security improvement, to not automatically trust executable .desktop files in non-system directories. Nemo uses the name and icon as configured in trusted .desktop files instead of their true filename and generic icon as Nemo uses for untrusted .desktop files. When opening a trusted .desktop file its Exec command is immediately run while for untrusted .desktop files Nemo first asks the user whether to trust the "Untrusted application launcher". This means an archive with a .desktop file in it can be created where the executable .desktop file appears as something else to the user, like an image, and when opening it the user would run an undesirable command. As demonstrated on https://www.reddit.com/r/linux/comments/5r6va0/how_to_easily_trick_file_manager_users_to_execute/

This patch makes it so Nemo doesn't automatically trust executable .desktop files in non-system directories. They are treated the same as non-executable .desktop files. It is up to the user to decide whether to trust any not-yet-trusted .desktop file in non-system directories when opening them.