### PR TITLE
Add option to show filenames for executable .desktop files

### DIFF
--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -3342,12 +3342,14 @@ link_info_done (NemoDirectory *directory,
 		gboolean is_foreign)
 {
 	gboolean is_trusted;
+	gboolean show_filename;
 	
 	file->details->link_info_is_up_to_date = TRUE;
 
 	is_trusted = is_link_trusted (file, is_launcher);
+	show_filename = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_LINK_FILENAME);
 
-	if (is_trusted) {
+	if (is_trusted && !show_filename) {
 		nemo_file_set_display_name (file, name, name, TRUE);
 	} else {
 		nemo_file_set_display_name (file, NULL, NULL, TRUE);

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -92,6 +92,7 @@ typedef enum
 #define NEMO_PREFERENCES_SHOW_ICON_VIEW_ICON_TOOLBAR   "show-icon-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_LIST_VIEW_ICON_TOOLBAR   "show-list-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR   "show-compact-view-icon-toolbar"
+#define NEMO_PREFERENCES_SHOW_LINK_FILENAME   "show-link-filename"
 
 /* Which views should be displayed for new windows */
 #define NEMO_WINDOW_STATE_START_WITH_STATUS_BAR		"start-with-status-bar"

--- a/libnemo-private/org.nemo.gschema.xml.in
+++ b/libnemo-private/org.nemo.gschema.xml.in
@@ -160,6 +160,11 @@
       <summary>Show Compact View button in nemo toolbar</summary>
       <description>If set to true, then Nemo browser windows will show the button.</description>
     </key>
+    <key type="b" name="show-link-filename">
+      <default>false</default>
+      <summary>Show filename of trusted desktop files</summary>
+      <description>If set to true, then Nemo will show the filename of desktop files instread of the target name.</description>
+    </key>
     <key name="confirm-trash" type="b">
       <default>true</default>
       <_summary>Whether to ask for confirmation when deleting files, or emptying Trash</_summary>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -84,6 +84,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTOOPEN_MEDIA_WIDGET "media_autoopen_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTORUN_MEDIA_WIDGET "media_autorun_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ADVANCED_PERMISSIONS_WIDGET "show_advanced_permissions_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LINK_FILENAME "show_link_filename"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET "start_with_dual_pane_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
@@ -929,6 +930,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ADVANCED_PERMISSIONS_WIDGET,
                        NEMO_PREFERENCES_SHOW_ADVANCED_PERMISSIONS);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LINK_FILENAME,
+                       NEMO_PREFERENCES_SHOW_LINK_FILENAME);
 
     bind_builder_string_entry (builder, nemo_preferences,
                          NEMO_FILE_MANAGEMENT_PROPERTIES_BULK_RENAME_WIDGET,

--- a/src/nemo-file-management-properties.glade
+++ b/src/nemo-file-management-properties.glade
@@ -2080,6 +2080,22 @@
                                             <property name="position">0</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="show_link_filename">
+                                            <property name="label" translatable="yes">Show filename of trusted desktop files</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>


### PR DESCRIPTION
Adds an option to show the filenames for executable .desktop files (default false).

This is motivated both by the security hole hiding filenames causes (see #1404) and by my personal preference.