### PR TITLE
Fix a crash when attempting to delete an empty selection on the desktop

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -2143,6 +2143,8 @@ nemo_file_operations_trash_or_delete (GList                  *files,
 					  NemoDeleteCallback  done_callback,
 					  gpointer                done_callback_data)
 {
+	g_return_if_fail (files != NULL);
+
 	trash_or_delete_internal (files, parent_window,
 				  TRUE,
 				  done_callback,  done_callback_data);

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -1376,6 +1376,11 @@ trash_or_delete_selected_files (NemoView *view)
 	 */
 	if (!view->details->selection_was_removed) {
 		selection = nemo_view_get_selection_for_file_transfer (view);
+
+        if (selection == NULL) {
+            return;
+        }
+
 		trash_or_delete_files (nemo_view_get_containing_window (view),
 				       selection, TRUE,
 				       view);


### PR DESCRIPTION
Bail out early if there is no selection and and add a bit of extra protection
in case we are inadvertently doing this elsewhere.

Closes: https://github.com/linuxmint/nemo/issues/1415