### PR TITLE
Updated pkexec support

### DIFF
--- a/makepot
+++ b/makepot
@@ -2,3 +2,4 @@
 data/extract_action_strings data
 xgettext --from-code=UTF-8 --keyword=_ --keyword=N_ --output=nemo.pot src/*.c libnemo-extension/*.c libnemo-private/*.c eel/*.c data/action_i18n_strings.py
 xgettext --join-existing  -L Glade src/*.glade --output=nemo.pot
+xgettext --join-existing --its=polkit.its -L PolkitPolicy share/polkit/*.policy.in --output=nemo.pot

--- a/polkit.its
+++ b/polkit.its
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           version="2.0">
+  <its:translateRule selector="/action/description |
+                               /action/message"
+                     translate="yes"/>
+</its:rules>

--- a/polkit.loc
+++ b/polkit.loc
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<locatingRules>
+  <locatingRule name="PolkitPolicy" pattern="*.policy">
+    <documentRule localName="policyconfig" target="polkit.its"/>
+  </locatingRule>
+</locatingRules>

--- a/src/org.nemo.root.policy.in
+++ b/src/org.nemo.root.policy.in
@@ -5,16 +5,16 @@
 
 <policyconfig>
 
- <vendor>Linux Mint</vendor>
- <vendor_url>http://linuxmint.com/</vendor_url>
+ <vendor>Nemo Project</vendor>
+ <vendor_url>https://github.com/linuxmint/nemo</vendor_url>
 
  <action id="org.nemo.root">
    <description>Run Nemo with elevated privileges</description>
-   <message>Authentication is required to run Nemo as root</message>
+   <message>Please enter your password to run Nemo as root</message>
    <icon_name>gksu-root-terminal</icon_name>
    <defaults>
-     <allow_any>auth_admin_keep</allow_any>
-     <allow_inactive>auth_admin_keep</allow_inactive>
+     <allow_any>no</allow_any>
+     <allow_inactive>no</allow_inactive>
      <allow_active>auth_admin_keep</allow_active>
    </defaults>
    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/nemo</annotate>


### PR DESCRIPTION
See https://github.com/linuxmint/mintsources/issues/75

I changed the `<vendor>` from "Linux Mint" to "Nemo Project" because Nemo isn't specific to the Linux Mint distros.  