### PR TITLE
nemo-dbus-manager.c: Add MoveURIs method

### DIFF
--- a/data/dbus-interfaces.xml
+++ b/data/dbus-interfaces.xml
@@ -29,6 +29,10 @@
       <arg type='as' name='SourceFilesURIList' direction='in'/>
       <arg type='s' name='DestinationDirectoryURI' direction='in'/>
     </method>
+    <method name='MoveURIs'>
+      <arg type='as' name='SourceFilesURIList' direction='in'/>
+      <arg type='s' name='DestinationDirectoryURI' direction='in'/>
+    </method>
     <method name='EmptyTrash'>
     </method>"
     <method name='CopyFile'>


### PR DESCRIPTION
Add MoveURIs, which has the same signature as the existing CopyURIs
method.

Motivation: Better integration with other applications.

<img src="http://i.imgur.com/bE8tnQA.png" width="484">

Why should a launcher/command shell integrate with nemo? The user gets a more consistent experience, progress, conflict resolution and error handling are all handled by nemo in a familiar interface. The nemo plugin in kupfer is available in its latest version. It can already handle other neat operations that nemo provides:

<img src="http://i.imgur.com/tKu9Q9l.png" width="332">