### PR TITLE
Better format for the Modified coloumn + Today bugfix 

### DIFF
--- a/libnemo-private/nemo-column-utilities.c
+++ b/libnemo-private/nemo-column-utilities.c
@@ -136,6 +136,14 @@ get_builtin_columns (void)
 					       "label", _("Location"),
 					       "description", _("The location of the file."),
 					       NULL));
+	columns = g_list_append (columns,
+				 g_object_new (NEMO_TYPE_COLUMN,
+					       "name", "date_modified_with_time",
+					       "attribute", "date_modified_with_time",
+					       "label", _("Modified - Time"),
+					       "description", _("The date the file was modified."),
+					       "xalign", 1.0,
+					       NULL));
 
 	return columns;
 }

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4545,28 +4545,28 @@ nemo_file_get_date_as_string (NemoFile       *file,
 		if (days_ago < 1) {
 			if (use_24) {
 				/* Translators: Time in 24h format */
-				format = N_("%H:%M");
+				format = _("%H:%M");
 			} else {
 				/* Translators: Time in 12h format */
-				format = N_("%l:%M %p");
+				format = _("%l:%M %p");
 			}
 		}
 		// Show the word "Yesterday" and time if date is on yesterday
 		else if (days_ago < 2) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				// xgettext:no-c-format
-				format = N_("Yesterday");
+				format = _("Yesterday");
 			} else {
 				if (use_24) {
 					/* Translators: this is the word Yesterday followed by
 					 * a time in 24h format. i.e. "Yesterday 23:04" */
 					// xgettext:no-c-format
-					format = N_("Yesterday %H:%M");
+					format = _("Yesterday %H:%M");
 				} else {
 					/* Translators: this is the word Yesterday followed by
 					 * a time in 12h format. i.e. "Yesterday 9:04 PM" */
 					// xgettext:no-c-format
-					format = N_("Yesterday %l:%M %p");
+					format = _("Yesterday %l:%M %p");
 				}
 			}
 		}
@@ -4574,18 +4574,18 @@ nemo_file_get_date_as_string (NemoFile       *file,
 		else if (days_ago < 7) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				// xgettext:no-c-format
-				format = N_("%a");
+				format = _("%a");
 			} else {
 				if (use_24) {
 					/* Translators: this is the name of the week day followed by
 					 * a time in 24h format. i.e. "Monday 23:04" */
 					// xgettext:no-c-format
-					format = N_("%a %H:%M");
+					format = _("%a %H:%M");
 				} else {
 					/* Translators: this is the week day name followed by
 					 * a time in 12h format. i.e. "Monday 9:04 PM" */
 					// xgettext:no-c-format
-					format = N_("%a %l:%M %p");
+					format = _("%a %l:%M %p");
 				}
 			}
 		} else if (g_date_time_get_year (file_date) == g_date_time_get_year (now)) {
@@ -4593,20 +4593,20 @@ nemo_file_get_date_as_string (NemoFile       *file,
 				/* Translators: this is the day of the month followed
 				 * by the abbreviated month name i.e. "3 Feb" */
 				// xgettext:no-c-format
-				format = N_("%-e %b");
+				format = _("%-e %b");
 			} else {
 				if (use_24) {
 					/* Translators: this is the day of the month followed
 					 * by the abbreviated month name followed by a time in
 					 * 24h format i.e. "3 Feb 23:04" */
 					// xgettext:no-c-format
-					format = N_("%-e %b %H:%M");
+					format = _("%-e %b %H:%M");
 				} else {
 					/* Translators: this is the day of the month followed
 					 * by the abbreviated month name followed by a time in
 					 * 12h format i.e. "3 Feb 9:04" */
 					// xgettext:no-c-format
-					format = N_("%-e %b %l:%M %p");
+					format = _("%-e %b %l:%M %p");
 				}
 			}
 		} else {
@@ -4614,20 +4614,20 @@ nemo_file_get_date_as_string (NemoFile       *file,
 				/* Translators: this is the day of the month followed by the abbreviated
 				 * month name followed by the year i.e. "3 Feb 2015" */
 				// xgettext:no-c-format
-				format = N_("%-e %b %Y");
+				format = _("%-e %b %Y");
 			} else {
 				if (use_24) {
 					/* Translators: this is the day number followed
 					 * by the abbreviated month name followed by the year followed
 					 * by a time in 24h format i.e. "3 Feb 2015 23:04" */
 					// xgettext:no-c-format
-					format = N_("%-e %b %Y %H:%M");
+					format = _("%-e %b %Y %H:%M");
 				} else {
 					/* Translators: this is the day number followed
 					 * by the abbreviated month name followed by the year followed
 					 * by a time in 12h format i.e. "3 Feb 2015 9:04 PM" */
 					// xgettext:no-c-format
-					format = N_("%-e %b %Y %l:%M %p");
+					format = _("%-e %b %Y %l:%M %p");
 				}
 			}
 		}
@@ -4636,7 +4636,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 		g_date_time_unref (today_midnight);
 	} else {
 		// xgettext:no-c-format
-		format = N_("%c");
+		format = _("%c");
 	}
 
 	result = g_date_time_format (file_date, format);

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4507,6 +4507,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 {
 	time_t file_time_raw;
   	GDateTime *file_date, *now;
+        GDateTime *today_midnight;
 	gint days_ago;
 	gboolean use_24;
 	const gchar *format;
@@ -4531,8 +4532,13 @@ nemo_file_get_date_as_string (NemoFile       *file,
   	file_date = g_date_time_new_from_unix_local (file_time_raw);
 	if (date_format != NEMO_DATE_FORMAT_FULL) {
 		now = g_date_time_new_now_local ();
+                today_midnight = g_date_time_new_local (g_date_time_get_year (now),
+                                                        g_date_time_get_month (now),
+                                                        g_date_time_get_day_of_month (now),
+                                                        0, 1, 0);
 
-		days_ago = g_date_time_difference (now, file_date) / (24 * 60 * 60 * 1000 * 1000L);
+		days_ago = g_date_time_difference (today_midnight, file_date) /
+                           (24 * 60 * 60 * 1000 * 1000L);
 
 		use_24 = g_settings_get_boolean (cinnamon_interface_preferences, "clock-use-24h");
 
@@ -4628,6 +4634,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 		}
 
 		g_date_time_unref (now);
+		g_date_time_unref (today_midnight);
 	} else {
 		// xgettext:no-c-format
 		format = N_("%c");

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4509,7 +4509,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
   	GDateTime *file_date, *now;
 	gint days_ago;
 	gboolean use_24;
-	gchar *format;
+	const gchar *format;
 	gchar *result;
 	gchar *result_with_ratio;
     int date_format_pref;

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4495,11 +4495,13 @@ nemo_file_get_trash_original_file_parent_as_string (NemoFile *file)
  * off zero padding, and putting a "_" there will use
  * space padding instead of zero padding.
  */
+#define TODAY_TIME_FORMAT_24 N_("%R")
 #define TODAY_TIME_FORMAT N_("%-I:%M %P")
 #define THIS_MONTH_TIME_FORMAT N_("%b %-e")
 #define THIS_YEAR_TIME_FORMAT N_("%b %-e")
 #define ANYTIME_TIME_FORMAT N_("%b %-d %Y")
-#define FULL_FORMAT N_("%a, %b %e %Y %H:%M:%S %p")
+#define FULL_FORMAT N_("%a, %b %e %Y %I:%M:%S %p")
+#define FULL_FORMAT_24 N_("%a, %b %e %Y %T")
 
 /**
  * nemo_file_get_date_as_string:
@@ -4521,6 +4523,7 @@ nemo_file_get_date_as_string (NemoFile *file, NemoDateType date_type, gboolean c
 	GDateTime *date_time, *today;
 	int y, m, d;
 	int y_now, m_now, d_now;
+	gboolean use_24;
 
 	if (!nemo_file_get_date (file, date_type, &file_time_raw)) {
 		return NULL;
@@ -4544,10 +4547,12 @@ nemo_file_get_date_as_string (NemoFile *file, NemoDateType date_type, gboolean c
 	g_date_time_get_ymd (today, &y_now, &m_now, &d_now);
 	g_date_time_unref (today);
 
+	use_24 = g_settings_get_boolean (cinnamon_interface_preferences, "clock-use-24h");
+
 	if (!compact) {
-		format = FULL_FORMAT;
+		format = use_24 ? FULL_FORMAT_24 : FULL_FORMAT;
 	} else if (y == y_now && m == m_now && d == d_now) {
-		format = TODAY_TIME_FORMAT;
+		format = use_24 ? TODAY_TIME_FORMAT_24 : TODAY_TIME_FORMAT;
 	} else if (y == y_now && m == m_now) {
 		format = THIS_MONTH_TIME_FORMAT;
 	} else if (y == y_now) {

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4581,39 +4581,39 @@ nemo_file_get_date_as_string (NemoFile       *file,
 		else if (days_ago < 7) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				// xgettext:no-c-format
-				format = _("%a");
+				format = _("%A");
 			} else {
 				if (use_24) {
 					/* Translators: this is the name of the week day followed by
 					 * a time in 24h format. i.e. "Monday 23:04" */
 					// xgettext:no-c-format
-					format = _("%a %H:%M");
+					format = _("%A %H:%M");
 				} else {
 					/* Translators: this is the week day name followed by
 					 * a time in 12h format. i.e. "Monday 9:04 PM" */
 					// xgettext:no-c-format
-					format = _("%a %l:%M %p");
+					format = _("%A %l:%M %p");
 				}
 			}
 		} else if (g_date_time_get_year (file_date) == g_date_time_get_year (now)) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				/* Translators: this is the day of the month followed
-				 * by the abbreviated month name i.e. "3 Feb" */
+				 * by the abbreviated month name i.e. "3 February" */
 				// xgettext:no-c-format
-				format = _("%-e %b");
+				format = _("%-e %B");
 			} else {
 				if (use_24) {
 					/* Translators: this is the day of the month followed
 					 * by the abbreviated month name followed by a time in
-					 * 24h format i.e. "3 Feb 23:04" */
+					 * 24h format i.e. "3 February 23:04" */
 					// xgettext:no-c-format
-					format = _("%-e %b %H:%M");
+					format = _("%-e %B %H:%M");
 				} else {
 					/* Translators: this is the day of the month followed
 					 * by the abbreviated month name followed by a time in
-					 * 12h format i.e. "3 Feb 9:04" */
+					 * 12h format i.e. "3 February 9:04" */
 					// xgettext:no-c-format
-					format = _("%-e %b %l:%M %p");
+					format = _("%-e %B %l:%M %p");
 				}
 			}
 		} else {

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4585,41 +4585,41 @@ nemo_file_get_date_as_string (NemoFile       *file,
 			}
 		} else if (g_date_time_get_year (file_date) == g_date_time_get_year (now)) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
-				/* Translators: this is the day of the month plus the short
-				 * month name i.e. "3 Feb" */
+				/* Translators: this is the day of the month followed
+				 * by the abbreviated month name i.e. "3 Feb" */
 				// xgettext:no-c-format
 				format = N_("%-e %b");
 			} else {
 				if (use_24) {
 					/* Translators: this is the day of the month followed
-					 * by the day number followed by a time in
+					 * by the abbreviated month name followed by a time in
 					 * 24h format i.e. "3 Feb 23:04" */
 					// xgettext:no-c-format
 					format = N_("%-e %b %H:%M");
 				} else {
 					/* Translators: this is the day of the month followed
-					 * by the day number followed by a time in
-					 * 12h format i.e. "3 Feb 9:04 PM" */
+					 * by the abbreviated month name followed by a time in
+					 * 12h format i.e. "3 Feb 9:04" */
 					// xgettext:no-c-format
 					format = N_("%-e %b %l:%M %p");
 				}
 			}
 		} else {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
-				/* Translators: this is the day of the month followed by the short
+				/* Translators: this is the day of the month followed by the abbreviated
 				 * month name followed by the year i.e. "3 Feb 2015" */
 				// xgettext:no-c-format
 				format = N_("%-e %b %Y");
 			} else {
 				if (use_24) {
 					/* Translators: this is the day number followed
-					 * by the month name followed by the year followed
+					 * by the abbreviated month name followed by the year followed
 					 * by a time in 24h format i.e. "3 Feb 2015 23:04" */
 					// xgettext:no-c-format
 					format = N_("%-e %b %Y %H:%M");
 				} else {
 					/* Translators: this is the day number followed
-					 * by the month name followed by the year followed
+					 * by the abbreviated month name followed by the year followed
 					 * by a time in 12h format i.e. "3 Feb 2015 9:04 PM" */
 					// xgettext:no-c-format
 					format = N_("%-e %b %Y %l:%M %p");

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4626,6 +4626,8 @@ nemo_file_get_date_as_string (NemoFile       *file,
 				}
 			}
 		}
+
+		g_date_time_unref (now);
 	} else {
 		format = N_("%c");
 	}

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -106,6 +106,12 @@ typedef enum {
 	SHOW_HIDDEN = 1 << 0,
 } FilterOptions;
 
+typedef enum {
+	NEMO_DATE_FORMAT_REGULAR = 0,
+	NEMO_DATE_FORMAT_REGULAR_WITH_TIME = 1,
+	NEMO_DATE_FORMAT_FULL = 2,
+} NemoDateCompactFormat;
+
 typedef void (* ModifyListFunction) (GList **list, NemoFile *file);
 
 enum {
@@ -125,6 +131,7 @@ static GQuark attribute_name_q,
 	attribute_modification_date_q,
 	attribute_date_modified_q,
 	attribute_date_modified_full_q,
+	attribute_date_modified_with_time_q,
 	attribute_accessed_date_q,
 	attribute_date_accessed_q,
 	attribute_date_accessed_full_q,
@@ -3291,7 +3298,7 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
                                NEMO_FILE_SORT_BY_DETAILED_TYPE,
                                directories_first,
                                reversed); 
-    } else if (attribute == attribute_modification_date_q || attribute == attribute_date_modified_q  || attribute == attribute_date_modified_full_q) {
+	} else if (attribute == attribute_modification_date_q || attribute == attribute_date_modified_q || attribute == attribute_date_modified_with_time_q || attribute == attribute_date_modified_full_q) {
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_MTIME,
 						       directories_first,
@@ -4494,9 +4501,9 @@ nemo_file_get_trash_original_file_parent_as_string (NemoFile *file)
  * 
  **/
 static char *
-nemo_file_get_date_as_string (NemoFile     *file,
-                              NemoDateType  date_type,
-                              gboolean      full_date)
+nemo_file_get_date_as_string (NemoFile       *file,
+                              NemoDateType    date_type,
+                              NemoDateCompactFormat  date_format)
 {
 	time_t file_time_raw;
   	GDateTime *file_date, *now;
@@ -4522,7 +4529,7 @@ nemo_file_get_date_as_string (NemoFile     *file,
 		goto out;
 	}
   	file_date = g_date_time_new_from_unix_local (file_time_raw);
-	if (!full_date) {
+	if (date_format != NEMO_DATE_FORMAT_FULL) {
 		now = g_date_time_new_now_local ();
 
 		daysAgo = g_date_time_difference (now, file_date) / (24 * 60 * 60 * 1000 * 1000L);
@@ -4541,23 +4548,83 @@ nemo_file_get_date_as_string (NemoFile     *file,
 		}
 		// Show the word "Yesterday" and time if date is on yesterday
 		else if (daysAgo < 2) {
-			// xgettext:no-c-format
-			format = N_("Yesterday");
+			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
+				// xgettext:no-c-format
+				format = N_("Yesterday");
+			} else {
+				if (use_24) {
+					/* Translators: this is the word Yesterday followed by
+					 * a time in 24h format. i.e. "Yesterday 23:04" */
+					// xgettext:no-c-format
+					format = N_("Yesterday %H:%M");
+				} else {
+					/* Translators: this is the word Yesterday followed by
+					 * a time in 12h format. i.e. "Yesterday 9:04 PM" */
+					// xgettext:no-c-format
+					format = N_("Yesterday %l:%M %p");
+				}
+			}
 		}
 		// Show a week day and time if date is in the last week
 		else if (daysAgo < 7) {
-			// xgettext:no-c-format
-			format = N_("%a");
+			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
+				// xgettext:no-c-format
+				format = N_("%a");
+			} else {
+				if (use_24) {
+					/* Translators: this is the name of the week day followed by
+					 * a time in 24h format. i.e. "Monday 23:04" */
+					// xgettext:no-c-format
+					format = N_("%a %H:%M");
+				} else {
+					/* Translators: this is the week day name followed by
+					 * a time in 12h format. i.e. "Monday 9:04 PM" */
+					// xgettext:no-c-format
+					format = N_("%a %l:%M %p");
+				}
+			}
 		} else if (g_date_time_get_year (file_date) == g_date_time_get_year (now)) {
-			/* Translators: this is the day of the month plus the short
-			 * month name i.e. "3 Feb" */
-			// xgettext:no-c-format
-			format = N_("%-e %b");
+			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
+				/* Translators: this is the day of the month plus the short
+				 * month name i.e. "3 Feb" */
+				// xgettext:no-c-format
+				format = N_("%-e %b");
+			} else {
+				if (use_24) {
+					/* Translators: this is the day of the month followed
+					 * by the day number followed by a time in
+					 * 24h format i.e. "3 Feb 23:04" */
+					// xgettext:no-c-format
+					format = N_("%-e %b %H:%M");
+				} else {
+					/* Translators: this is the day of the month followed
+					 * by the day number followed by a time in
+					 * 12h format i.e. "3 Feb 9:04 PM" */
+					// xgettext:no-c-format
+					format = N_("%-e %b %l:%M %p");
+				}
+			}
 		} else {
-			/* Translators: this is the day of the month followed by the short
-			 * month name followed by the year i.e. "3 Feb 2015" */
-			// xgettext:no-c-format
-			format = N_("%-e %b %Y");
+			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
+				/* Translators: this is the day of the month followed by the short
+				 * month name followed by the year i.e. "3 Feb 2015" */
+				// xgettext:no-c-format
+				format = N_("%-e %b %Y");
+			} else {
+				if (use_24) {
+					/* Translators: this is the day number followed
+					 * by the month name followed by the year followed
+					 * by a time in 24h format i.e. "3 Feb 2015 23:04" */
+					// xgettext:no-c-format
+					format = N_("%-e %b %Y %H:%M");
+				} else {
+					/* Translators: this is the day number followed
+					 * by the month name followed by the year followed
+					 * by a time in 12h format i.e. "3 Feb 2015 9:04 PM" */
+					// xgettext:no-c-format
+					format = N_("%-e %b %Y %l:%M %p");
+				}
+			}
 		}
 	} else {
 		format = N_("%c");
@@ -6045,52 +6112,57 @@ nemo_file_get_string_attribute_q (NemoFile *file, GQuark attribute_q)
 	if (attribute_q == attribute_date_modified_q) {
 		return nemo_file_get_date_as_string (file, 
 							 NEMO_DATE_TYPE_MODIFIED,
-							 FALSE);
+							 NEMO_DATE_FORMAT_REGULAR);
 	}
 	if (attribute_q == attribute_date_modified_full_q) {
 		return nemo_file_get_date_as_string (file, 
 							 NEMO_DATE_TYPE_MODIFIED,
-							 TRUE);
+							 NEMO_DATE_FORMAT_FULL);
+	}
+	if (attribute_q == attribute_date_modified_with_time_q) {
+		return nemo_file_get_date_as_string (file,
+							 NEMO_DATE_TYPE_MODIFIED,
+		                     NEMO_DATE_FORMAT_REGULAR_WITH_TIME);
 	}
 	if (attribute_q == attribute_date_changed_q) {
 		return nemo_file_get_date_as_string (file, 
 							 NEMO_DATE_TYPE_CHANGED,
-							 FALSE);
+							 NEMO_DATE_FORMAT_REGULAR);
 	}
 	if (attribute_q == attribute_date_changed_full_q) {
 		return nemo_file_get_date_as_string (file, 
 							 NEMO_DATE_TYPE_CHANGED,
-							 TRUE);
+							 NEMO_DATE_FORMAT_FULL);
 	}
 	if (attribute_q == attribute_date_accessed_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_ACCESSED,
-							 FALSE);
+							 NEMO_DATE_FORMAT_REGULAR);
 	}
 	if (attribute_q == attribute_date_accessed_full_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_ACCESSED,
-							 TRUE);
+							 NEMO_DATE_FORMAT_FULL);
 	}
 	if (attribute_q == attribute_trashed_on_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_TRASHED,
-							 TRUE);
+							 NEMO_DATE_FORMAT_FULL);
 	}
 	if (attribute_q == attribute_trashed_on_full_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_TRASHED,
-							 FALSE);
+							 NEMO_DATE_FORMAT_REGULAR);
 	}
 	if (attribute_q == attribute_date_permissions_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_PERMISSIONS_CHANGED,
-							 TRUE);
+							 NEMO_DATE_FORMAT_FULL);
 	}
 	if (attribute_q == attribute_date_permissions_full_q) {
 		return nemo_file_get_date_as_string (file,
 							 NEMO_DATE_TYPE_PERMISSIONS_CHANGED,
-							 FALSE);
+							 NEMO_DATE_FORMAT_REGULAR);
 	}
 	if (attribute_q == attribute_permissions_q) {
 		return nemo_file_get_permissions_as_string (file);
@@ -6239,6 +6311,7 @@ nemo_file_is_date_sort_attribute_q (GQuark attribute_q)
 	if (attribute_q == attribute_modification_date_q ||
 	    attribute_q == attribute_date_modified_q ||
 	    attribute_q == attribute_date_modified_full_q ||
+	    attribute_q == attribute_date_modified_with_time_q ||
 	    attribute_q == attribute_accessed_date_q ||
 	    attribute_q == attribute_date_accessed_q ||
 	    attribute_q == attribute_date_accessed_full_q ||
@@ -8054,6 +8127,7 @@ nemo_file_class_init (NemoFileClass *class)
 	attribute_modification_date_q = g_quark_from_static_string ("modification_date");
 	attribute_date_modified_q = g_quark_from_static_string ("date_modified");
 	attribute_date_modified_full_q = g_quark_from_static_string ("date_modified_full");
+	attribute_date_modified_with_time_q = g_quark_from_static_string ("date_modified_with_time");
 	attribute_accessed_date_q = g_quark_from_static_string ("accessed_date");
 	attribute_date_accessed_q = g_quark_from_static_string ("date_accessed");
 	attribute_date_accessed_full_q = g_quark_from_static_string ("date_accessed_full");

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4507,7 +4507,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 {
 	time_t file_time_raw;
   	GDateTime *file_date, *now;
-	gint daysAgo;
+	gint days_ago;
 	gboolean use_24;
 	gchar *format;
 	gchar *result;
@@ -4532,12 +4532,12 @@ nemo_file_get_date_as_string (NemoFile       *file,
 	if (date_format != NEMO_DATE_FORMAT_FULL) {
 		now = g_date_time_new_now_local ();
 
-		daysAgo = g_date_time_difference (now, file_date) / (24 * 60 * 60 * 1000 * 1000L);
+		days_ago = g_date_time_difference (now, file_date) / (24 * 60 * 60 * 1000 * 1000L);
 
 		use_24 = g_settings_get_boolean (cinnamon_interface_preferences, "clock-use-24h");
 
 		// Show only the time if date is on today
-		if (daysAgo < 1) {
+		if (days_ago < 1) {
 			if (use_24) {
 				/* Translators: Time in 24h format */
 				format = N_("%H:%M");
@@ -4547,7 +4547,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 			}
 		}
 		// Show the word "Yesterday" and time if date is on yesterday
-		else if (daysAgo < 2) {
+		else if (days_ago < 2) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				// xgettext:no-c-format
 				format = N_("Yesterday");
@@ -4566,7 +4566,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 			}
 		}
 		// Show a week day and time if date is in the last week
-		else if (daysAgo < 7) {
+		else if (days_ago < 7) {
 			if (date_format == NEMO_DATE_FORMAT_REGULAR) {
 				// xgettext:no-c-format
 				format = N_("%a");

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4561,7 +4561,7 @@ nemo_file_get_date_as_string (NemoFile *file, NemoDateType date_type, gboolean c
 		format = ANYTIME_TIME_FORMAT;
 	}
 
-	result = g_date_time_format (date_time, format);
+	result = g_date_time_format (date_time, _(format));
 
  out:
 	g_date_time_unref (date_time);

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4537,8 +4537,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
                                                         g_date_time_get_day_of_month (now),
                                                         0, 1, 0);
 
-		days_ago = g_date_time_difference (today_midnight, file_date) /
-                           (24 * 60 * 60 * 1000 * 1000L);
+		days_ago = g_date_time_difference (today_midnight, file_date) / G_TIME_SPAN_DAY;
 
 		use_24 = g_settings_get_boolean (cinnamon_interface_preferences, "clock-use-24h");
 

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4629,6 +4629,7 @@ nemo_file_get_date_as_string (NemoFile       *file,
 
 		g_date_time_unref (now);
 	} else {
+		// xgettext:no-c-format
 		format = N_("%c");
 	}
 

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -389,11 +389,6 @@ char *                  nemo_file_get_string_attribute_with_default (NemoFile   
 									 const char                     *attribute_name);
 char *                  nemo_file_get_string_attribute_with_default_q (NemoFile                  *file,
 									 GQuark                          attribute_q);
-char *			nemo_file_fit_modified_date_as_string	(NemoFile 			*file,
-									 int				 width,
-									 NemoWidthMeasureCallback    measure_callback,
-									 NemoTruncateCallback	 truncate_callback,
-									 void				*measure_truncate_context);
 
 /* Matching with another URI. */
 gboolean                nemo_file_matches_uri                       (NemoFile                   *file,
@@ -493,8 +488,6 @@ char *   nemo_file_get_owner_as_string            (NemoFile          *file,
                                                           gboolean           include_real_name);
 char *   nemo_file_get_type_as_string             (NemoFile          *file);
 char *   nemo_file_get_detailed_type_as_string    (NemoFile          *file);
-
-char *   nemo_file_get_date_as_string             (NemoFile *file, NemoDateType date_type);
 
 gchar *  nemo_file_construct_tooltip              (NemoFile *file, NemoFileTooltipFlags flags);
 

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -131,6 +131,7 @@ nemo_global_preferences_init (void)
 	gnome_media_handling_preferences = g_settings_new("org.cinnamon.desktop.media-handling");
 	gnome_terminal_preferences = g_settings_new("org.cinnamon.desktop.default-applications.terminal");
     cinnamon_privacy_preferences = g_settings_new("org.cinnamon.desktop.privacy");
+	cinnamon_interface_preferences = g_settings_new ("org.cinnamon.desktop.interface");
 
     ignore_view_metadata = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_IGNORE_VIEW_METADATA);
 

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -274,6 +274,7 @@ GSettings *gnome_background_preferences;
 GSettings *gnome_media_handling_preferences;
 GSettings *gnome_terminal_preferences;
 GSettings *cinnamon_privacy_preferences;
+GSettings *cinnamon_interface_preferences;
 
 gint64 nemo_startup_time;
 

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -460,9 +460,7 @@ create_date_format_menu (GtkBuilder *builder)
 	gtk_combo_box_text_append_text (combo_box, date_string);
 	g_free (date_string);
 
-	date_string = g_date_time_format (now, _("today at %-I:%M:%S %p"));
-	gtk_combo_box_text_append_text (combo_box, date_string);
-	g_free (date_string);
+	gtk_combo_box_text_append_text (combo_box, _("Yesterday"));
 
 	g_date_time_unref (now);
 }

--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -3141,11 +3141,11 @@ create_basic_page (NemoPropertiesWindow *window)
 		append_blank_row (grid);
 
 		append_title_value_pair (window, grid, _("Accessed:"), 
-					 "date_accessed",
+					 "date_accessed_full",
 					 INCONSISTENT_STATE_STRING,
 					 FALSE);
 		append_title_value_pair (window, grid, _("Modified:"), 
-					 "date_modified",
+					 "date_modified_full",
 					 INCONSISTENT_STATE_STRING,
 					 FALSE);
 	}


### PR DESCRIPTION
This is a rebase of the recent changes of the Modified column from Nautilus. 

It replaces the broken width dependent formating with a compact and human readable format. 
Depending on the age of the file, it displays: 

- 14:58 
- Yesterday
- Monday
- 2 February
- 10 Aug 2016

For photo folders or similar, there is a new right aligned "Modified - Time"  column available, which adds always the time to the above formats. 

The time format follows the org.cinnamon.desktop.interface settings. 

Unlike in Nautilus, the alternative preference option for full date and iso date is kept. 

This PR fixes also a Bug in the calculation of "today", which was introduced by 
744f164af91ccb85a5af2289634303884223fea3
reported here https://github.com/daschuer/nemo/issues/1



   


