### PR TITLE
Make libselinux dependency controllable by configure switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,18 +149,19 @@ dnl ==========================================================================
 dnl ****************************
 dnl *** Check for libselinux ***
 dnl ****************************
-    
-SELINUX_LIBS=
+
 msg_selinux=no
-AC_CHECK_LIB(selinux, is_selinux_enabled,
-   [AC_CHECK_HEADERS(selinux/selinux.h,
-     [AC_SEARCH_LIBS(selinux_raw_to_trans_context, selinux, 
-       [AC_DEFINE(HAVE_SELINUX, 1, [Define to 1 if libselinux is available])
-        SELINUX_LIBS="-lselinux"
-        msg_selinux=yes])
-     ])
-   ])
-AC_SUBST(SELINUX_LIBS)
+
+AC_ARG_ENABLE([selinux],
+              [AS_HELP_STRING([--enable-selinux],
+                              [Enable selinux support])])
+AS_IF([test "$enable_selinux" != "no"],
+      [PKG_CHECK_MODULES([SELINUX], [libselinux >= 2.0],
+                         [
+                           AC_DEFINE([HAVE_SELINUX], [1], [Define to 1 if libselinux is available])
+                           msg_selinux=yes
+                         ])
+      ])
 
 
 AC_ARG_ENABLE(empty_view,


### PR DESCRIPTION
Based on https://git.gnome.org/browse/nautilus/patch/configure.ac?id=450bf6bc9371d246f3084757efaef1a663d9f416

