### PR TITLE
autogen.sh: don't run aclocal

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,8 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
     echo "" >&2
 fi
 
-aclocal --install || exit 1
+mkdir -p m4
+
 glib-gettextize --force --copy || exit 1
 gtkdocize --copy || exit 1
 intltoolize --force --copy --automake || exit 1


### PR DESCRIPTION
Based on https://git.gnome.org/browse/nautilus/commit/autogen.sh?id=753e9d812cc33b5477418152abaa03795b9059c8


autoreconf takes care of running aclocal and other commands in the right order.


