### PR TITLE
location-bar: use a GFile in location-changed signal

### DIFF
--- a/src/nemo-location-bar.c
+++ b/src/nemo-location-bar.c
@@ -60,7 +60,6 @@ struct NemoLocationBarDetails {
 };
 
 enum {
-	NEMO_DND_MC_DESKTOP_ICON,
 	NEMO_DND_URI_LIST,
 	NEMO_DND_TEXT_PLAIN,
 	NEMO_DND_NTARGETS
@@ -96,39 +95,29 @@ nemo_location_bar_get_window (GtkWidget *bar)
 /**
  * nemo_location_bar_get_location
  *
- * Get the "URI" represented by the text in the location bar.
- *
- * @bar: A NemoLocationBar.
- *
- * returns a newly allocated "string" containing the mangled
- * (by g_file_parse_name) text that the user typed in...maybe a URI 
- * but not guaranteed.
- *
+ * Get the GFile represented by the text in the location bar.
  **/
-static char *
+static GFile *
 nemo_location_bar_get_location (NemoLocationBar *bar) 
 {
-	char *user_location, *uri;
+	char *user_location;
 	GFile *location;
 	
 	user_location = gtk_editable_get_chars (GTK_EDITABLE (bar->details->entry), 0, -1);
 	location = g_file_parse_name (user_location);
 	g_free (user_location);
-	uri = g_file_get_uri (location);
-	g_object_unref (location);
-	return uri;
+
+	return location;
 }
 
 static void
 emit_location_changed (NemoLocationBar *bar)
 {
-	char *location;
+	GFile *location;
 
 	location = nemo_location_bar_get_location (bar);
-	g_signal_emit (bar,
-		       signals[LOCATION_CHANGED], 0,
-		       location);
-	g_free (location);
+	g_signal_emit (bar, signals[LOCATION_CHANGED], 0, location);
+	g_object_unref (location);
 }
 
 static void
@@ -232,25 +221,28 @@ drag_data_get_callback (GtkWidget *widget,
 			gpointer callback_data)
 {
 	NemoLocationBar *self;
-	char *entry_text;
+	GFile *location;
+	gchar *uri;
 
 	g_assert (selection_data != NULL);
 	self = callback_data;
 
-	entry_text = nemo_location_bar_get_location (self);
+	location = nemo_location_bar_get_location (self);
+	uri = g_file_get_uri (location);
 
 	switch (info) {
 	case NEMO_DND_URI_LIST:
 	case NEMO_DND_TEXT_PLAIN:
 		gtk_selection_data_set (selection_data,
 					gtk_selection_data_get_target (selection_data),
-					8, (guchar *) entry_text,
-					strlen (entry_text));
+					8, (guchar *) uri,
+					strlen (uri));
 		break;
 	default:
 		g_assert_not_reached ();
 	}
-	g_free (entry_text);
+	g_free (uri);
+	g_object_unref (location);
 }
 
 static gboolean
@@ -401,8 +393,8 @@ nemo_location_bar_class_init (NemoLocationBarClass *klass)
 		 G_TYPE_FROM_CLASS (klass),
 		 G_SIGNAL_RUN_LAST, 0,
 		 NULL, NULL,
-		 g_cclosure_marshal_VOID__STRING,
-		 G_TYPE_NONE, 1, G_TYPE_STRING);
+		 g_cclosure_marshal_generic,
+		 G_TYPE_NONE, 1, G_TYPE_OBJECT);
 
 	binding_set = gtk_binding_set_by_class (klass);
 	gtk_binding_entry_add_signal (binding_set, GDK_KEY_Escape, 0, "cancel", 0);

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -229,18 +229,14 @@ navigation_bar_cancel_callback (GtkWidget *widget,
 
 static void
 navigation_bar_location_changed_callback (GtkWidget *widget,
-                                        const gchar *uri,
-                                     NemoWindowPane *pane)
+                                          GFile *location,
+                                          NemoWindowPane *pane)
 {
-    GFile *location;
-
     nemo_window_pane_hide_temporary_bars (pane);
 
     restore_focus_widget (pane);
 
-    location = g_file_new_for_uri (uri);
     nemo_window_slot_open_location (pane->active_slot, location, 0);
-    g_object_unref (location);
 }
 
 static gboolean


### PR DESCRIPTION
Avoids GFile->URI->GFile roundtrips

This is adopted nautilus patch: 
ce16451d1d7f384ca296ca7ce824938606b21af0