### PR TITLE
Disable selinux for Debian rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@ TYPELIBDIR=$(shell pkg-config gobject-introspection-1.0 --variable libdir | sed 
 CONFIGURE_EXTRA_FLAGS = --libexecdir=/usr/lib/nemo \
                         --disable-update-mimedb \
 			--enable-gtk-doc \
+			--enable-selinux=no \
 			--enable-compile-warnings=yes
 
 export LDFLAGS+=-Wl,-z,defs -Wl,-O1 -Wl,--as-needed


### PR DESCRIPTION
Disable selinux for Debian rules or you could add libselinux-dev to the build deps.