### PR TITLE
[RFC] nemo-file-operations.c: add additional note to translators

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -6093,7 +6093,10 @@ create_job (GIOSchedulerJob *io_job,
 		} else {
 			if (job->src != NULL) {
 				basename = g_file_get_basename (job->src);
-				/* localizers: the initial name of a new template document */
+				/* localizers: the initial name of a new template document
+				 * the %s placeholder MUST be at the end of the string for
+				 * this to work properly.
+				 */
 				filename = g_strdup_printf (_("Untitled %s"), basename);
 
 				g_free (basename);


### PR DESCRIPTION
The new template document string placeholder '%s' is replaced with the
filename, including the extension. If the placeholder is not at the end of
the string then we will get filenames like "Empty text document.txt Untitled"

See #1278

Edit: either this, or import this patch from nautilus https://github.com/GNOME/nautilus/commit/9d28b3263dbce896bf017438a0059a2da4e32f2c

Let me know.