### PR TITLE
nemo-file-operations.c: use only template filename for new files

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -6094,7 +6094,7 @@ create_job (GIOSchedulerJob *io_job,
 			if (job->src != NULL) {
 				basename = g_file_get_basename (job->src);
 				/* localizers: the initial name of a new template document */
-				filename = g_strdup_printf (_("Untitled %s"), basename);
+				filename = g_strdup_printf ("%s", basename);
 
 				g_free (basename);
 			}


### PR DESCRIPTION
The current string format causes problems when localized to certain languages
that need to rearrange the structure. Since a placeholder name is not strictly
necessary with template files, just remove it.

Fixes #1278