### PR TITLE
fix desktop file error

### DIFF
--- a/data/nemo.desktop.in.in
+++ b/data/nemo.desktop.in.in
@@ -111,7 +111,6 @@ Name[vi_VN]=Nhà
 Name[zh_CN]=主目录
 Name[zh_HK]=家
 Name[zh_TW]=家
-Comment=None
 Exec=nemo %U
 
 [Desktop Action open-computer]
@@ -210,7 +209,6 @@ Name[vi_VN]=Máy tính
 Name[zh_CN]=计算机
 Name[zh_HK]=電腦
 Name[zh_TW]=電腦
-Comment=None
 Exec=nemo computer:///
 
 [Desktop Action open-trash]
@@ -320,5 +318,4 @@ Name[vi_VN]=Thùng rác
 Name[zh_CN]=回收站
 Name[zh_HK]=垃圾桶
 Name[zh_TW]=回收筒
-Comment=None
 Exec=nemo trash:///


### PR DESCRIPTION
```
+ desktop-file-validate /home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo-autorun-software.desktop /home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo-autostart.desktop /home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo.desktop
/home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo.desktop: error: file contains key "Comment" in group "Desktop Action open-home", but keys extending the format should start with "X-"
/home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo.desktop: error: file contains key "Comment" in group "Desktop Action open-computer", but keys extending the format should start with "X-"
/home/leigh/development/rpmbuild/BUILDROOT/nemo-3.4.0-0.0.20170426git5a50a78.fc26.x86_64/usr/share/applications/nemo.desktop: error: file contains key "Comment" in group "Desktop Action open-trash", but keys extending the format should start with "X-"
```