### PR TITLE
Nemo modify desktop icon order

### DIFF
--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -453,16 +453,16 @@ nemo_icon_view_container_get_icon_text (NemoIconContainer *container,
  *   1) home link
  *   2) network link
  *   3) mount links
- *   4) other
- *   5) trash link
+ *   4) trash link
+ *   5) other
  */
 typedef enum {
 	SORT_COMPUTER_LINK,
 	SORT_HOME_LINK,
 	SORT_NETWORK_LINK,
 	SORT_MOUNT_LINK,
-	SORT_OTHER,
-	SORT_TRASH_LINK
+	SORT_TRASH_LINK,
+	SORT_OTHER
 } SortCategory;
 
 static SortCategory

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -376,8 +376,8 @@ typedef enum {
 	SORT_HOME_LINK,
 	SORT_NETWORK_LINK,
 	SORT_MOUNT_LINK,
-	SORT_OTHER,
-	SORT_TRASH_LINK
+	SORT_TRASH_LINK,
+	SORT_OTHER
 } SortCategory;
 
 static SortCategory

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -368,8 +368,8 @@ nemo_icon_view_grid_container_get_icon_text (NemoIconContainer *container,
  *   1) home link
  *   2) network link
  *   3) mount links
- *   4) other
- *   5) trash link
+ *   4) trash link
+ *   5) other
  */
 typedef enum {
 	SORT_COMPUTER_LINK,


### PR DESCRIPTION
Update grid auto arrange icon order. More user friendly due to rubbish bin remaining in the same position, and mirrors the behaviour of other popular OS such as Windows