### PR TITLE
eel_g_list_str_copy: replace contents with g_list_copy_deep

### DIFF
--- a/eel/eel-glib-extensions.c
+++ b/eel/eel-glib-extensions.c
@@ -65,14 +65,7 @@ eel_g_str_list_equal (GList *list_a, GList *list_b)
 GList *
 eel_g_str_list_copy (GList *list)
 {
-	GList *node, *result;
-
-	result = NULL;
-	
-	for (node = g_list_last (list); node != NULL; node = node->prev) {
-		result = g_list_prepend (result, g_strdup (node->data));
-	}
-	return result;
+	return g_list_copy_deep (list, (GCopyFunc) g_strdup, NULL);
 }
 
 gboolean


### PR DESCRIPTION
May improve performance somewhat for very high volume file copies
though I have no way to test with the volumes reported here https://bugs.launchpad.net/linuxmint/+bug/1663186