### PR TITLE
When activating files on desktop (only), deselect them after activating them

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -1177,6 +1177,10 @@ nemo_view_activate_files (NemoView *view,
 				      flags,
 				      confirm_multiple);
 
+	if (get_is_desktop_view(view)) {
+		nemo_view_set_selection(view, NULL);
+	}
+
 	g_free (path);
 }
 
@@ -1193,6 +1197,10 @@ nemo_view_activate_file (NemoView *view,
 				     file,
 				     path,
 				     flags);
+
+	if (get_is_desktop_view(view)) {
+		nemo_view_set_selection(view, NULL);
+	}
 
 	g_free (path);
 }


### PR DESCRIPTION
I found it annoying that after I double-clicked a desktop icon to launch a program, it stayed highlighted.  This change fixes that for files on the desktop only.  Files in nemo windows will still stay selected after activation.  This mirrors the behavior on MS Windows 10 (and possibly earlier versions, but I don't have them right now to test with).