### PR TITLE
Use exec-arg when "open in terminal"

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -234,6 +234,7 @@ typedef enum
 
 /* Terminal */
 #define GNOME_DESKTOP_TERMINAL_EXEC        "exec"
+#define GNOME_DESKTOP_TERMINAL_EXEC_ARG    "exec-arg"
 
 /* Tooltips */
 #define NEMO_PREFERENCES_TOOLTIPS_DESKTOP              "tooltips-on-desktop"

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7125,10 +7125,12 @@ open_as_root (const gchar *path)
 static void
 open_in_terminal (const gchar *path)
 {	
-    gchar *argv[2];
+    gchar *argv[3];
     argv[0] = g_settings_get_string (gnome_terminal_preferences,
 				     GNOME_DESKTOP_TERMINAL_EXEC);
-    argv[1] = NULL;
+    argv[1] = g_settings_get_string (gnome_terminal_preferences,
+				     GNOME_DESKTOP_TERMINAL_EXEC_ARG);
+    argv[2] = NULL;
     g_spawn_async(path, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }
 

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1091,9 +1091,10 @@ action_new_folder_callback (GtkAction *action,
 static void
 open_in_terminal_other (const gchar *path)
 {
-    gchar *argv[2];
+    gchar *argv[3];
     argv[0] = g_settings_get_string (gnome_terminal_preferences, GNOME_DESKTOP_TERMINAL_EXEC);
-    argv[1] = NULL;
+    argv[1] = g_settings_get_string (gnome_terminal_preferences, GNOME_DESKTOP_TERMINAL_EXEC_ARG);
+    argv[2] = NULL;
     g_spawn_async(path, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }
 


### PR DESCRIPTION
Just a small fix.

Nemo ignores exec-arg in org.cinnamon.desktop.default-applications.terminal the using "open in terminal".

I fixed this because i thought i could stop using a wrapper script to open a new tab in guake. Sadly didn't fix my problem.

But as i put a litle effort into the patch, i wanted to share it :)

Hopefully someone have a use for it.