### PR TITLE
Fix left pane in dual pane mode reverting to minimum width

### DIFF
--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1589,13 +1589,12 @@ window_set_search_action_text (NemoWindow *window,
 static gboolean
 reposition_paned (GtkPaned *paned)
 {
+	g_return_val_if_fail (GTK_IS_PANED (paned), FALSE);
+
 	/* Make the paned think it's been manually resized, otherwise
 	   things like the trash bar will force unwanted resizes */
-	int w;
 	int current_position;
 	current_position = gtk_paned_get_position (paned);
-	w = gtk_widget_get_allocated_width (GTK_WIDGET (paned)) / 2;
-	gtk_paned_set_position (paned, w);
 	gtk_paned_set_position (paned, current_position);
 	return FALSE;
 }


### PR DESCRIPTION
This also fixes the trash bar resizing the left pane. I used printf to check the value of the `w` variable, and it was always logging 0 in `create_extra_pane`. Deferring the repositioning seems to correct this.

Closes #1180 