### PR TITLE
nemo-properties-window: use gdk_pixbuf_scale_simple ()

### DIFF
--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -236,7 +236,7 @@ static gboolean
 is_multi_file_window (NemoPropertiesWindow *window)
 {
 	GList *l;
-	int count;
+	guint count;
 
 	count = 0;
 
@@ -5371,10 +5371,10 @@ update_preview_callback (GtkFileChooser *icon_chooser,
 			scale = (double)gdk_pixbuf_get_height (pixbuf) /
 				gdk_pixbuf_get_width (pixbuf);
 
-			scaled_pixbuf = gnome_desktop_thumbnail_scale_down_pixbuf
-				(pixbuf,
-				 PREVIEW_IMAGE_WIDTH,
-				 scale * PREVIEW_IMAGE_WIDTH);
+			scaled_pixbuf = gdk_pixbuf_scale_simple (pixbuf,
+                                                     PREVIEW_IMAGE_WIDTH,
+                                                     scale * PREVIEW_IMAGE_WIDTH,
+                                                     GDK_INTERP_BILINEAR);
 			g_object_unref (pixbuf);
 			pixbuf = scaled_pixbuf;
 		}


### PR DESCRIPTION
It appears to be a bit faster.  https://github.com/GNOME/nautilus/commit/2b6ca358c5187c3ef741ce29dc134db1b395f4fd