### PR TITLE
 Make the libExecPath usable 

### DIFF
--- a/debian/nemo.install
+++ b/debian/nemo.install
@@ -1,6 +1,6 @@
 usr/bin
-usr/lib/*/nemo/nemo-convert-metadata
-usr/lib/*/nemo/nemo-extensions-list
+usr/lib/nemo/nemo-convert-metadata
+usr/lib/nemo/nemo-extensions-list
 usr/share/applications
 usr/share/dbus-1
 usr/share/man

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 
 CONFIGURE_EXTRA_FLAGS = \
 	--prefix=/usr \
+	--libexecdir=/usr/lib/nemo \
 	-D deprecated_warnings=false \
 	-D gtk_doc=true \
 	-D selinux=false

--- a/meson.build
+++ b/meson.build
@@ -144,7 +144,7 @@ configure_file(
 
 rootInclude = include_directories('.')
 nemoDataPath      = join_paths(get_option('prefix'), get_option('datadir'), 'nemo')
-libExecPath       = join_paths(get_option('prefix'), get_option('libdir'), 'nemo')
+libExecPath       = join_paths(get_option('prefix'), get_option('libexecdir'))
 # Keep this constant, in case some extensions are behind in being updated...
 nemoExtensionPath = join_paths(get_option('prefix'), 'lib', 'nemo', 'extensions-3.0')
 


### PR DESCRIPTION
--libexecdir=/usr/libexec option isn't respected and installs files to  /usr/lib64/nemo/

```
   /usr/lib64/nemo/nemo-convert-metadata
   /usr/lib64/nemo/nemo-extensions-list
```


libexecdir isn't the same as libdir and hard coding nemo isn't acceptable as I want to install in

```
   /usr/libexec/nemo-convert-metadata
   /usr/libexec/nemo-extensions-list
```