### PR TITLE
nemo-properties-window: Stop using stock buttons

### DIFF
--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -4903,8 +4903,8 @@ create_properties_window (StartupData *startup_data)
 	append_extension_pages (window);
 
 	gtk_dialog_add_buttons (GTK_DIALOG (window),
-				GTK_STOCK_HELP, GTK_RESPONSE_HELP,
-				GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
+				_("Help"), GTK_RESPONSE_HELP,
+				_("Close"), GTK_RESPONSE_CLOSE,
 				NULL);
 
 	/* FIXME - HIGificiation, should be done inside GTK+ */
@@ -5409,9 +5409,9 @@ select_image_button_callback (GtkWidget *widget,
 	if (dialog == NULL) {
 		dialog = gtk_file_chooser_dialog_new (_("Select Custom Icon"), GTK_WINDOW (window),
 						      GTK_FILE_CHOOSER_ACTION_OPEN,
-						      GTK_STOCK_REVERT_TO_SAVED, GTK_RESPONSE_NO,
-						      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-						      GTK_STOCK_OPEN, GTK_RESPONSE_OK,
+						      _("Revert"), GTK_RESPONSE_NO,
+						      _("Cancel"), GTK_RESPONSE_CANCEL,
+						      _("Open"), GTK_RESPONSE_OK,
 						      NULL);
 		gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (dialog), "/usr/share/pixmaps", NULL);
         gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (dialog), "/usr/share/icons", NULL);


### PR DESCRIPTION
These are long deprecated and leave you with some ugly icons on the buttons.