### PR TITLE
meson: don't install libnemo-private.a

### DIFF
--- a/libnemo-private/meson.build
+++ b/libnemo-private/meson.build
@@ -100,7 +100,6 @@ nemo_private_lib = static_library('nemo-private',
   nemo_private_sources,
   dependencies: nemo_private_deps,
   include_directories: [ rootInclude, ],
-  install: true,
   c_args: nemo_definitions,
 )
 


### PR DESCRIPTION
This is not meant for public use, hence why it is a static-only library
linked directly into nemo. During the meson port it was accidentally set
to be installed, where the autotools build marked it as noinst.