### PR TITLE
symbolic control icons: Use icon names rather than gicons.

### DIFF
--- a/data/icons/hicolor/places/scalable/nemo-bookmark-not-found-symbolic.svg
+++ b/data/icons/hicolor/places/scalable/nemo-bookmark-not-found-symbolic.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   width="16.031"
+   height="16"
+   version="1.1"
+   viewBox="0 0 16.031 16"
+   sodipodi:docname="nemo-bookmark-not-found-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs89" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
+     id="namedview87"
+     showgrid="true"
+     inkscape:zoom="12.546875"
+     inkscape:cx="2.4858532"
+     inkscape:cy="7.9209877"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid97" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="layer13"
+     transform="translate(-461 -174.99)">
+    <path
+       style="color:#000000;fill:#bebebe;text-decoration-line:none;text-indent:0;text-transform:none"
+       d="M 1.0292969 1 C 1.0292969 1 0.029296875 1 0.029296875 2 L -0.001953125 13.009766 C -0.001933125 13.843096 0.57203685 14.515466 1.0605469 14.759766 C 1.5490569 15.004126 1.9980469 15.009766 1.9980469 15.009766 L 6.0234375 15.009766 A 5 5 0 0 1 4 11 A 5 5 0 0 1 8.7050781 6.0097656 L 2.96875 6.0097656 L 2.5 13.041016 C 2.4836 13.302816 2.23055 13.526126 1.96875 13.509766 C 1.70695 13.493366 1.48364 13.240316 1.5 12.978516 L 2 5.4785156 C 2.01 5.2557056 2.18713 5.0513756 2.40625 5.0097656 C 2.43745 5.0067656 2.4669469 5.0067656 2.4980469 5.0097656 L 13.998047 5.0097656 L 14.029297 4 C 14.029297 3 13.064453 3.0097656 13.064453 3.0097656 L 7.9980469 3.0097656 L 6.0292969 1 L 1.0292969 1 z M 9.1914062 6.0097656 A 5 5 0 0 1 14 11 A 5 5 0 0 1 11.976562 15.009766 L 13.998047 15.009766 C 13.998047 15.009766 14.447037 15.003766 14.935547 14.759766 C 15.424057 14.515506 16.000247 13.843096 15.998047 13.009766 L 15.998047 6.0097656 L 9.1914062 6.0097656 z "
+       transform="translate(461,174.99)"
+       id="path6390-2" />
+  </g>
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 6.8789062 7.4648438 L 5.4648438 8.8789062 L 7.5859375 11 L 5.4648438 13.121094 L 6.8789062 14.535156 L 9 12.414062 L 11.121094 14.535156 L 12.535156 13.121094 L 10.414062 11 L 12.535156 8.8789062 L 11.121094 7.4648438 L 9 9.5859375 L 6.8789062 7.4648438 z "
+     id="rect4619" />
+</svg>

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -26,6 +26,7 @@ publicIcons = [
   'hicolor/actions/scalable/expand-menu-hover-symbolic.svg',
   'hicolor/actions/scalable/collapse-menu-symbolic.svg',
   'hicolor/actions/scalable/collapse-menu-hover-symbolic.svg',
+  'hicolor/places/scalable/nemo-bookmark-not-found-symbolic.svg',
   'hicolor/status/48x48/progress-0.png',
   'hicolor/status/48x48/progress-10.png',
   'hicolor/status/48x48/progress-20.png',

--- a/libnemo-private/nemo-bookmark.c
+++ b/libnemo-private/nemo-bookmark.c
@@ -52,7 +52,7 @@ enum {
 	PROP_NAME = 1,
 	PROP_CUSTOM_NAME,
 	PROP_LOCATION,
-	PROP_ICON,
+	PROP_ICON_NAME,
     PROP_METADATA,
 	NUM_PROPERTIES
 };
@@ -67,7 +67,7 @@ struct NemoBookmarkDetails
 	char *name;
 	gboolean has_custom_name;
 	GFile *location;
-	GIcon *icon;
+    gchar *icon_name;
 	NemoFile *file;
 
 	char *scroll_file;
@@ -94,24 +94,24 @@ nemo_bookmark_set_name_internal (NemoBookmark *bookmark,
 static void
 nemo_bookmark_update_icon (NemoBookmark *bookmark)
 {
-	GIcon *new_icon;
+    gchar *new_icon_name;
 
-	if (bookmark->details->file == NULL) {
-		return;
-	}
+    if (bookmark->details->file == NULL) {
+        return;
+    }
 
-	if (!nemo_file_is_not_yet_confirmed (bookmark->details->file) &&
-	    nemo_file_check_if_ready (bookmark->details->file,
-					  NEMO_FILE_ATTRIBUTES_FOR_ICON)) {
-		DEBUG ("%s: set new icon", nemo_bookmark_get_name (bookmark));
+    if (!nemo_file_is_not_yet_confirmed (bookmark->details->file) &&
+        nemo_file_check_if_ready (bookmark->details->file,
+                                  NEMO_FILE_ATTRIBUTES_FOR_ICON)) {
+        DEBUG ("%s: set new icon", nemo_bookmark_get_name (bookmark));
 
-		new_icon = nemo_file_get_control_icon (bookmark->details->file);
-		g_object_set (bookmark,
-			      "icon", new_icon,
-			      NULL);
+        new_icon_name = nemo_file_get_control_icon_name (bookmark->details->file);
+        g_object_set (bookmark,
+                      "icon-name", new_icon_name,
+                      NULL);
 
-		g_object_unref (new_icon);
-	}
+        g_free (new_icon_name);
+    }
 }
 
 static void
@@ -136,19 +136,19 @@ bookmark_set_name_from_ready_file (NemoBookmark *self,
 	g_free (display_name);
 }
 
-static GIcon *
-get_default_folder_icon (NemoBookmark *bookmark)
+static gchar *
+get_default_folder_icon_name (NemoBookmark *bookmark)
 {
-    GIcon *ret = NULL;
+    gchar *ret = NULL;
 
     if (g_file_is_native (bookmark->details->location)) {
-        ret = g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER);
+        ret = g_strdup (NEMO_ICON_SYMBOLIC_FOLDER);
     } else {
         gchar *uri = g_file_get_uri (bookmark->details->location);
         if (g_str_has_prefix (uri, EEL_SEARCH_URI)) {
-            ret = g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_SAVED_SEARCH);
+            ret = g_strdup (NEMO_ICON_SYMBOLIC_FOLDER_SAVED_SEARCH);
         } else {
-            ret = g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_REMOTE);
+            ret = g_strdup (NEMO_ICON_SYMBOLIC_FOLDER_REMOTE);
         }
         g_free (uri);
     }
@@ -156,80 +156,60 @@ get_default_folder_icon (NemoBookmark *bookmark)
     return ret;
 }
 
-static GIcon *
+static gchar *
 construct_default_icon_from_metadata (NemoBookmark *bookmark)
 {
-    NemoBookmarkMetadata *md = bookmark->details->metadata;
-    GIcon *ret = NULL;
+    return get_default_folder_icon_name (bookmark);
 
-    ret = get_default_folder_icon (bookmark);
+/* TODO: Remove emblem stuff from bookmarks */
+    // if (ret != NULL && md->emblems != NULL) {
+    //     guint i = 0;
 
-    if (ret != NULL && md->emblems != NULL) {
-        guint i = 0;
+    //     GIcon *emb_icon;
+    //     GEmblem *emblem;
 
-        GIcon *emb_icon;
-        GEmblem *emblem;
+    //     emb_icon = g_themed_icon_new (md->emblems[i]);
+    //     emblem = g_emblem_new (emb_icon);
 
-        emb_icon = g_themed_icon_new (md->emblems[i]);
-        emblem = g_emblem_new (emb_icon);
+    //     ret = g_emblemed_icon_new (ret, emblem);
 
-        ret = g_emblemed_icon_new (ret, emblem);
+    //     i++;
 
-        i++;
+    //     while (i < g_strv_length (md->emblems)) {
+    //         emb_icon = g_themed_icon_new (md->emblems[i]);
+    //         emblem = g_emblem_new (emb_icon);
 
-        while (i < g_strv_length (md->emblems)) {
-            emb_icon = g_themed_icon_new (md->emblems[i]);
-            emblem = g_emblem_new (emb_icon);
+    //         g_emblemed_icon_add_emblem (G_EMBLEMED_ICON (ret), emblem);
 
-            g_emblemed_icon_add_emblem (G_EMBLEMED_ICON (ret), emblem);
+    //         i++;
+    //     }
+    // }
 
-            i++;
-        }
-    }
-
-    return ret;
+    // return ret;
 }
 
 static void
 nemo_bookmark_set_icon_to_default (NemoBookmark *bookmark)
 {
-    GIcon *icon, *emblemed_icon;
-    GIcon *folder = NULL;
-    GEmblem *emblem;
+    gchar *icon_name;
 
-    folder = NULL;
-
-    if (bookmark->details->metadata != NULL) {
-        folder = construct_default_icon_from_metadata (bookmark);
-    }
-
-    if (!folder)
-        folder = get_default_folder_icon (bookmark);
+    icon_name = construct_default_icon_from_metadata (bookmark);
 
     if (!nemo_bookmark_uri_get_exists (bookmark)) {
-        DEBUG ("%s: file does not exist, add emblem", nemo_bookmark_get_name (bookmark));
+        DEBUG ("%s: file does not exist, use special icon", nemo_bookmark_get_name (bookmark));
 
-        icon = g_themed_icon_new (GTK_STOCK_DIALOG_WARNING);
-        emblem = g_emblem_new (icon);
+        g_clear_pointer (&icon_name, g_free);
 
-        if (G_IS_EMBLEMED_ICON (folder))
-            g_emblemed_icon_add_emblem (G_EMBLEMED_ICON (folder), emblem);
-        else {
-            emblemed_icon = g_emblemed_icon_new (folder, emblem);
-            folder = emblemed_icon;
-        }
-
-        g_object_unref (emblem);
-        g_object_unref (icon);
+        icon_name = g_strdup (NEMO_ICON_SYMBOLIC_MISSING_BOOKMARK);
     }
 
     DEBUG ("%s: setting icon to default", nemo_bookmark_get_name (bookmark));
 
     g_object_set (bookmark,
-              "icon", G_ICON (folder),
-              NULL);
+                  "icon-name", icon_name,
+                  NULL);
 
-    g_object_unref (folder);
+    g_free (icon_name);
 }
 
 static gboolean
@@ -345,7 +325,7 @@ nemo_bookmark_connect_file (NemoBookmark *bookmark)
 	/* Set icon based on available information. */
 	nemo_bookmark_update_icon (bookmark);
 
-	if (bookmark->details->icon == NULL) {
+	if (bookmark->details->icon_name == NULL) {
 		nemo_bookmark_set_icon_to_default (bookmark);
 	}
 
@@ -368,15 +348,15 @@ nemo_bookmark_set_property (GObject *object,
 				GParamSpec *pspec)
 {
 	NemoBookmark *self = NEMO_BOOKMARK (object);
-	GIcon *new_icon;
+	const gchar *new_icon_name;
 
 	switch (property_id) {
-	case PROP_ICON:
-		new_icon = g_value_get_object (value);
+	case PROP_ICON_NAME:
+		new_icon_name = g_value_get_string (value);
 
-		if (new_icon != NULL && !g_icon_equal (self->details->icon, new_icon)) {
-			g_clear_object (&self->details->icon);
-			self->details->icon = g_object_ref (new_icon);
+		if (new_icon_name != NULL && g_strcmp0 (self->details->icon_name, new_icon_name) != 0) {
+			g_clear_pointer (&self->details->icon_name, g_free);
+			self->details->icon_name = g_strdup (new_icon_name);
 		}
 
 		break;
@@ -413,8 +393,8 @@ nemo_bookmark_get_property (GObject *object,
 	case PROP_NAME:
 		g_value_set_string (value, self->details->name);
 		break;
-	case PROP_ICON:
-		g_value_set_object (value, self->details->icon);
+	case PROP_ICON_NAME:
+		g_value_set_string (value, self->details->icon_name);
 		break;
 	case PROP_LOCATION:
 		g_value_set_object (value, self->details->location);
@@ -443,7 +423,7 @@ nemo_bookmark_finalize (GObject *object)
 	nemo_bookmark_disconnect_file (bookmark);
 
 	g_object_unref (bookmark->details->location);
-	g_clear_object (&bookmark->details->icon);
+	g_clear_pointer (&bookmark->details->icon_name, g_free);
 
     g_clear_pointer (&bookmark->details->metadata, nemo_bookmark_metadata_free);
 
@@ -502,11 +482,11 @@ nemo_bookmark_class_init (NemoBookmarkClass *class)
 				     G_TYPE_FILE,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
-	properties[PROP_ICON] =
-		g_param_spec_object ("icon",
-				     "Bookmark's icon",
-				     "The icon of this bookmark",
-				     G_TYPE_ICON,
+	properties[PROP_ICON_NAME] =
+		g_param_spec_string ("icon-name",
+				     "Bookmark's icon name",
+				     "The icon name for this bookmark",
+				     NULL,
 				     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
     properties[PROP_METADATA] =
@@ -634,21 +614,21 @@ nemo_bookmark_copy (NemoBookmark *bookmark)
     return nemo_bookmark_new (bookmark->details->location,
                               bookmark->details->has_custom_name ?
                                   bookmark->details->name : NULL,
-                              bookmark->details->icon,
+                              bookmark->details->icon_name,
                               bookmark->details->metadata ?
                                   nemo_bookmark_metadata_copy (bookmark->details->metadata) : NULL);
 }
 
-GIcon *
-nemo_bookmark_get_icon (NemoBookmark *bookmark)
+gchar *
+nemo_bookmark_get_icon_name (NemoBookmark *bookmark)
 {
 	g_return_val_if_fail (NEMO_IS_BOOKMARK (bookmark), NULL);
 
 	/* Try to connect a file in case file exists now but didn't earlier. */
 	nemo_bookmark_connect_file (bookmark);
 
-	if (bookmark->details->icon) {
-		return g_object_ref (bookmark->details->icon);
+	if (bookmark->details->icon_name) {
+		return g_strdup (bookmark->details->icon_name);
 	}
 	return NULL;
 }
@@ -684,7 +664,7 @@ nemo_bookmark_get_uri (NemoBookmark *bookmark)
 NemoBookmark *
 nemo_bookmark_new (GFile                *location,
                    const gchar          *custom_name,
-                   GIcon                *icon,
+                   const gchar          *icon_name,
                    NemoBookmarkMetadata *md)
 {
 	NemoBookmark *new_bookmark;
@@ -697,7 +677,7 @@ nemo_bookmark_new (GFile                *location,
 
     new_bookmark = NEMO_BOOKMARK (g_object_new (NEMO_TYPE_BOOKMARK,
 						"location", location,
-						"icon", icon,
+						"icon-name", icon_name,
 						"name", name,
 						"custom-name", custom_name != NULL,
 						"metadata", md,
@@ -710,12 +690,14 @@ nemo_bookmark_new (GFile                *location,
 static GtkWidget *
 create_image_widget_for_bookmark (NemoBookmark *bookmark)
 {
-	GIcon *icon;
-	GtkWidget *widget;
+    GtkWidget *widget;
+    gchar *icon_name;
 
-	icon = nemo_bookmark_get_icon (bookmark);
-        widget = gtk_image_new_from_gicon (icon, GTK_ICON_SIZE_MENU);
-	g_object_unref (icon);
+    icon_name = nemo_bookmark_get_icon_name (bookmark);
+
+    widget = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+
+    g_free (icon_name);
 
 	return widget;
 }

--- a/libnemo-private/nemo-bookmark.h
+++ b/libnemo-private/nemo-bookmark.h
@@ -74,13 +74,13 @@ typedef struct NemoBookmarkClass NemoBookmarkClass;
 GType                 nemo_bookmark_get_type               (void);
 NemoBookmark *    nemo_bookmark_new                    (GFile                *location,
                                                         const char           *custom_name,
-                                                        GIcon                *icon,
+                                                        const char           *icon_name,
                                                         NemoBookmarkMetadata *md);
 NemoBookmark *    nemo_bookmark_copy                   (NemoBookmark      *bookmark);
 const char *          nemo_bookmark_get_name               (NemoBookmark      *bookmark);
 GFile *               nemo_bookmark_get_location           (NemoBookmark      *bookmark);
 char *                nemo_bookmark_get_uri                (NemoBookmark      *bookmark);
-GIcon *               nemo_bookmark_get_icon               (NemoBookmark      *bookmark);
+gchar *               nemo_bookmark_get_icon_name          (NemoBookmark      *bookmark);
 gboolean	      nemo_bookmark_get_has_custom_name    (NemoBookmark      *bookmark);		
 void                  nemo_bookmark_set_custom_name        (NemoBookmark      *bookmark,
 								const char            *new_name);		

--- a/libnemo-private/nemo-file-utilities.c
+++ b/libnemo-private/nemo-file-utilities.c
@@ -1467,17 +1467,68 @@ nemo_get_cached_x_content_types_for_mount (GMount *mount)
 	return NULL;
 }
 
-GIcon *nemo_get_mount_gicon (GMount *mount)
+gchar *nemo_get_mount_icon_name (GMount *mount)
 {
-    GIcon *icon;
+    GIcon *gicon;
+    gchar *icon_name;
 
     g_return_val_if_fail (mount != NULL, NULL);
 
     if (g_mount_can_eject (mount)) {
-        return g_themed_icon_new ("media-removable-symbolic");
+        return g_strdup ("media-removable-symbolic");
     }
 
-    return g_mount_get_symbolic_icon (mount);
+    gicon = g_mount_get_symbolic_icon (mount);
+
+    if (G_IS_THEMED_ICON (gicon)) {
+        icon_name = g_strdup (g_themed_icon_get_names (G_THEMED_ICON (gicon))[0]);
+    } else {
+        icon_name = g_strdup ("folder-symbolic"); // any theme will have at least this?...
+    }
+
+    g_object_unref (gicon);
+
+    return icon_name;
+}
+
+gchar *nemo_get_volume_icon_name (GVolume *volume)
+{
+    GIcon *gicon;
+    gchar *icon_name;
+
+    g_return_val_if_fail (volume != NULL, NULL);
+
+    gicon = g_volume_get_symbolic_icon (volume);
+
+    if (G_IS_THEMED_ICON (gicon)) {
+        icon_name = g_strdup (g_themed_icon_get_names (G_THEMED_ICON (gicon))[0]);
+    } else {
+        icon_name = g_strdup ("folder-symbolic"); // any theme will have at least this?...
+    }
+
+    g_object_unref (gicon);
+
+    return icon_name;
+}
+
+gchar *nemo_get_drive_icon_name (GDrive *drive)
+{
+    GIcon *gicon;
+    gchar *icon_name;
+
+    g_return_val_if_fail (drive != NULL, NULL);
+
+    gicon = g_drive_get_symbolic_icon (drive);
+
+    if (G_IS_THEMED_ICON (gicon)) {
+        icon_name = g_strdup (g_themed_icon_get_names (G_THEMED_ICON (gicon))[0]);
+    } else {
+        icon_name = g_strdup ("folder-symbolic"); // any theme will have at least this?...
+    }
+
+    g_object_unref (gicon);
+
+    return icon_name;
 }
 
 #if !defined (NEMO_OMIT_SELF_CHECK)

--- a/libnemo-private/nemo-file-utilities.h
+++ b/libnemo-private/nemo-file-utilities.h
@@ -106,5 +106,7 @@ void nemo_get_x_content_types_for_mount_async (GMount *mount,
 						   GCancellable *cancellable,
 						   gpointer user_data);
 
-GIcon *nemo_get_mount_gicon (GMount *mount);
+gchar *nemo_get_mount_icon_name (GMount *mount);
+gchar *nemo_get_volume_icon_name (GVolume *volume);
+gchar *nemo_get_drive_icon_name (GDrive *drive);
 #endif /* NEMO_FILE_UTILITIES_H */

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4351,79 +4351,97 @@ nemo_file_get_gicon (NemoFile *file,
 }
 
 
-GIcon *
-get_symbolic_icon_for_file (NemoFile *file)
+static const gchar *
+get_symbolic_icon_name_for_file (NemoFile *file)
 {
     if (nemo_file_is_home (file)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_HOME);
+        return NEMO_ICON_SYMBOLIC_HOME;
     }
 
     // Special folders (XDG)
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_DESKTOP)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_DESKTOP);
+        return NEMO_ICON_SYMBOLIC_DESKTOP;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_DOCUMENTS)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_DOCUMENTS);
+        return NEMO_ICON_SYMBOLIC_FOLDER_DOCUMENTS;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_DOWNLOAD)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_DOWNLOAD);
+        return NEMO_ICON_SYMBOLIC_FOLDER_DOWNLOAD;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_MUSIC)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_MUSIC);
+        return NEMO_ICON_SYMBOLIC_FOLDER_MUSIC;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_PICTURES)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_PICTURES);
+        return NEMO_ICON_SYMBOLIC_FOLDER_PICTURES;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_PUBLIC_SHARE)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_PUBLIC_SHARE);
+        return NEMO_ICON_SYMBOLIC_FOLDER_PUBLIC_SHARE;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_TEMPLATES)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_TEMPLATES);
+        return NEMO_ICON_SYMBOLIC_FOLDER_TEMPLATES;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_VIDEOS)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_VIDEOS);
+        return NEMO_ICON_SYMBOLIC_FOLDER_VIDEOS;
     }
 
     if (nemo_file_is_user_special_directory (file, G_USER_DIRECTORY_TEMPLATES)) {
-        return g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_TEMPLATES);
+        return NEMO_ICON_SYMBOLIC_FOLDER_TEMPLATES;
     }
 
-    if (file->details->mime_type != NULL) {
-        return g_content_type_get_symbolic_icon (file->details->mime_type);
-    } else {
-        return NULL;
-    }
+    return NULL;
 }
 
-GIcon *
-nemo_file_get_control_icon (NemoFile *file)
+gchar *
+nemo_file_get_control_icon_name (NemoFile *file)
 {
-    GIcon *gicon;
+    gchar *icon_name;
 
-    if (file->details->symbolic_icon != NULL) {
-        gicon = g_object_ref (file->details->symbolic_icon);
+    icon_name = NULL;
+
+    if (file->details->symbolic_icon != NULL &&
+        G_IS_THEMED_ICON (file->details->symbolic_icon)) {
+            icon_name = g_strdup (g_themed_icon_get_names (G_THEMED_ICON (file->details->symbolic_icon))[0]);
     } else {
         gchar *uri;
 
         uri = nemo_file_get_uri (file);
 
         if (eel_uri_is_search (uri)) {
-            gicon = g_themed_icon_new (NEMO_ICON_SYMBOLIC_FOLDER_SAVED_SEARCH);
+            icon_name = g_strdup (NEMO_ICON_SYMBOLIC_FOLDER_SAVED_SEARCH);
         } else {
-            gicon = get_symbolic_icon_for_file (file);
+            const gchar *static_name;
+
+            static_name = get_symbolic_icon_name_for_file (file);
+            g_printerr ("what %s\n", static_name);
+            if (static_name != NULL) {
+                icon_name = g_strdup (static_name);
+            } else {
+                if (file->details->mime_type != NULL) {
+                    GIcon *gicon;
+
+                    gicon = g_content_type_get_symbolic_icon (file->details->mime_type);
+                    icon_name = g_icon_to_string (gicon);
+
+                    g_object_unref (gicon);
+                }
+            }
         }
 
         g_free (uri);
     }
 
-    return gicon;
+    if (icon_name == NULL) {
+        icon_name = g_strdup ("text-x-generic");
+    }
+
+    return icon_name;
 }
 
 static gint

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -450,7 +450,7 @@ char *                  nemo_file_get_drop_target_uri               (NemoFile   
 
 GIcon *                 nemo_file_get_gicon                         (NemoFile                   *file,
                                                                      NemoFileIconFlags           flags);
-GIcon *                 nemo_file_get_control_icon                  (NemoFile                   *file);
+gchar *                 nemo_file_get_control_icon_name             (NemoFile                   *file);
 
 NemoIconInfo *      nemo_file_get_icon                          (NemoFile                   *file,
 									 int                             size,

--- a/libnemo-private/nemo-icon-names.h
+++ b/libnemo-private/nemo-icon-names.h
@@ -51,7 +51,7 @@
 #define NEMO_ICON_SYMBOLIC_FOLDER_VIDEOS     "folder-videos-symbolic"
 #define NEMO_ICON_SYMBOLIC_FOLDER_SAVED_SEARCH "folder-saved-search-symbolic"
 
-
+#define NEMO_ICON_SYMBOLIC_MISSING_BOOKMARK "nemo-bookmark-not-found-symbolic"
 
 
 

--- a/libnemo-private/nemo-trash-monitor.c
+++ b/libnemo-private/nemo-trash-monitor.c
@@ -37,7 +37,7 @@
 struct NemoTrashMonitorDetails {
 	gboolean empty;
 	GIcon *icon;
-    GIcon *symbolic_icon;
+    const gchar *symbolic_icon_name;
 	GFileMonitor *file_monitor;
 };
 
@@ -61,9 +61,7 @@ nemo_trash_monitor_finalize (GObject *object)
 	if (trash_monitor->details->icon) {
 		g_object_unref (trash_monitor->details->icon);
 	}
-    if (trash_monitor->details->symbolic_icon) {
-        g_object_unref (trash_monitor->details->symbolic_icon);
-    }
+
 	if (trash_monitor->details->file_monitor) {
 		g_object_unref (trash_monitor->details->file_monitor);
 	}
@@ -100,10 +98,10 @@ update_icon (NemoTrashMonitor *trash_monitor)
 
 	if (trash_monitor->details->empty) {
 		trash_monitor->details->icon = g_themed_icon_new (NEMO_ICON_TRASH);
-        trash_monitor->details->symbolic_icon = g_themed_icon_new (NEMO_ICON_SYMBOLIC_TRASH);
+        trash_monitor->details->symbolic_icon_name = NEMO_ICON_SYMBOLIC_TRASH;
 	} else {
 		trash_monitor->details->icon = g_themed_icon_new (NEMO_ICON_TRASH_FULL);
-        trash_monitor->details->symbolic_icon = g_themed_icon_new (NEMO_ICON_SYMBOLIC_TRASH_FULL);
+        trash_monitor->details->symbolic_icon_name = NEMO_ICON_SYMBOLIC_TRASH_FULL;
 	}
 }
 
@@ -249,14 +247,14 @@ nemo_trash_monitor_get_icon (void)
 	return NULL;
 }
 
-GIcon *
-nemo_trash_monitor_get_symbolic_icon (void)
+gchar *
+nemo_trash_monitor_get_symbolic_icon_name (void)
 {
     NemoTrashMonitor *monitor;
 
     monitor = nemo_trash_monitor_get ();
-    if (monitor->details->symbolic_icon) {
-        return g_object_ref (monitor->details->symbolic_icon);
+    if (monitor->details->symbolic_icon_name) {
+        return g_strdup (monitor->details->symbolic_icon_name);
     }
     return NULL;
 }

--- a/libnemo-private/nemo-trash-monitor.h
+++ b/libnemo-private/nemo-trash-monitor.h
@@ -62,7 +62,7 @@ GType			nemo_trash_monitor_get_type				(void);
 NemoTrashMonitor   *nemo_trash_monitor_get 				(void);
 gboolean		nemo_trash_monitor_is_empty 			(void);
 GIcon                  *nemo_trash_monitor_get_icon                         (void);
-GIcon                  *nemo_trash_monitor_get_symbolic_icon                (void);
+gchar                  *nemo_trash_monitor_get_symbolic_icon_name           (void);
 
 void		        nemo_trash_monitor_add_new_trash_directories        (void);
 

--- a/src/nemo-bookmark-list.c
+++ b/src/nemo-bookmark-list.c
@@ -360,7 +360,7 @@ connect_bookmark_signals (NemoBookmark     *bookmark,
                  G_CALLBACK (bookmark_location_mounted_callback), bookmarks, 0);
     g_signal_connect_object (bookmark, "contents-changed",
                  G_CALLBACK (bookmark_in_list_changed_callback), bookmarks, 0);
-    g_signal_connect_object (bookmark, "notify::icon",
+    g_signal_connect_object (bookmark, "notify::icon-name",
                  G_CALLBACK (bookmark_in_list_notify), bookmarks, 0);
     g_signal_connect_object (bookmark, "notify::name",
                  G_CALLBACK (bookmark_in_list_notify), bookmarks, 0);

--- a/src/nemo-bookmarks-window.c
+++ b/src/nemo-bookmarks-window.c
@@ -178,7 +178,7 @@ static GtkListStore *
 create_bookmark_store (void)
 {
 	return gtk_list_store_new (BOOKMARK_LIST_COLUMN_COUNT,
-				   G_TYPE_ICON,
+				   G_TYPE_STRING,
 				   G_TYPE_STRING,
 				   G_TYPE_OBJECT,
 				   PANGO_TYPE_STYLE);
@@ -290,7 +290,7 @@ create_bookmarks_window (NemoBookmarkList *list, GObject *undo_manager_source)
 	rend = gtk_cell_renderer_pixbuf_new ();
 	col = gtk_tree_view_column_new_with_attributes ("Icon", 
 							rend,
-							"gicon", 
+							"icon-name", 
 							BOOKMARK_LIST_COLUMN_ICON,
 							NULL);
 	gtk_tree_view_append_column (bookmark_list_widget,
@@ -810,7 +810,7 @@ update_bookmark_from_text (void)
 	if (text_changed) {
 		NemoBookmark *bookmark, *bookmark_in_list;
 		const char *name;
-		GIcon *icon;
+		gchar *icon_name;
 		guint selected_row;
 		GtkTreeIter iter;
 		GFile *location;
@@ -855,17 +855,17 @@ update_bookmark_from_text (void)
 								   selected_row);
 
 		name = nemo_bookmark_get_name (bookmark_in_list);
-		icon = nemo_bookmark_get_icon (bookmark_in_list);
+		icon_name = nemo_bookmark_get_icon_name (bookmark_in_list);
 
 		gtk_list_store_set (bookmark_list_store, &iter,
 				    BOOKMARK_LIST_COLUMN_BOOKMARK, bookmark_in_list,
 				    BOOKMARK_LIST_COLUMN_NAME, name,
-				    BOOKMARK_LIST_COLUMN_ICON, icon,
+				    BOOKMARK_LIST_COLUMN_ICON, icon_name,
 				    -1);
 		g_signal_handler_unblock (bookmark_list_store,
 					  row_changed_signal_id);
 
-		g_object_unref (icon);
+		g_free (icon_name);
 	}
 }
 
@@ -990,12 +990,12 @@ repopulate (void)
 	for (index = 0; index < nemo_bookmark_list_length (bookmarks); ++index) {
 		NemoBookmark *bookmark;
 		const char       *bookmark_name;
-		GIcon            *bookmark_icon;
+		gchar            *bookmark_icon;
 		GtkTreeIter       iter;
 
 		bookmark = nemo_bookmark_list_item_at (bookmarks, index);
 		bookmark_name = nemo_bookmark_get_name (bookmark);
-		bookmark_icon = nemo_bookmark_get_icon (bookmark);
+		bookmark_icon = nemo_bookmark_get_icon_name (bookmark);
 
 		gtk_list_store_append (store, &iter);
 		gtk_list_store_set (store, &iter, 
@@ -1014,7 +1014,7 @@ repopulate (void)
 			gtk_tree_path_free (pth);
 		}
 
-		g_object_unref (bookmark_icon);
+		g_free (bookmark_icon);
 	}
 
 	g_signal_handler_unblock (store, row_changed_signal_id);

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -388,7 +388,7 @@ add_place (NemoPlacesSidebar *sidebar,
 	   PlaceType place_type,
 	   SectionType section_type,
 	   const char *name,
-	   GIcon *icon,
+	   const char *icon,
 	   const char *uri,
 	   GDrive *drive,
 	   GVolume *volume,
@@ -649,12 +649,12 @@ recent_is_supported (void)
     return FALSE;
 }
 
-static GIcon *
-get_gicon (const gchar *uri)
+static gchar *
+get_icon_name (const gchar *uri)
 {
     NemoFile *file = nemo_file_get_by_uri (uri);
 
-    return nemo_file_get_control_icon (file);
+    return nemo_file_get_control_icon_name (file);
 }
 
 static void
@@ -674,7 +674,7 @@ update_places (NemoPlacesSidebar *sidebar)
 	int bookmark_count, bookmark_index;
 	char *location, *mount_uri, *name, *desktop_path, *last_uri, *identifier;
 	const gchar *bookmark_name;
-	GIcon *icon;
+	gchar *icon;
 	GFile *root;
 	NemoWindowSlot *slot;
 	char *tooltip;
@@ -712,7 +712,7 @@ update_places (NemoPlacesSidebar *sidebar)
 
     /* home folder */
     mount_uri = nemo_get_home_directory_uri ();
-    icon = get_gicon (mount_uri);
+    icon = get_icon_name (mount_uri);
     full = get_disk_full (g_file_new_for_uri (mount_uri), &tooltip_info);
     tooltip = g_strdup_printf (_("Open your personal folder\n%s"), tooltip_info);
     g_free (tooltip_info);
@@ -723,7 +723,7 @@ update_places (NemoPlacesSidebar *sidebar)
                            tooltip,
                            full, home_on_different_fs (mount_uri),
                            cat_iter);
-    g_object_unref (icon);
+    g_free (icon);
     sidebar->top_bookend_uri = g_strdup (mount_uri);
     g_free (mount_uri);
     g_free (tooltip);
@@ -732,14 +732,14 @@ update_places (NemoPlacesSidebar *sidebar)
         /* desktop */
         desktop_path = nemo_get_desktop_directory ();
         mount_uri = g_filename_to_uri (desktop_path, NULL, NULL);
-        icon = get_gicon (mount_uri);
+        icon = get_icon_name (mount_uri);
         cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                                SECTION_COMPUTER,
                                _("Desktop"), icon,
                                mount_uri, NULL, NULL, NULL, 0,
                                _("Open the contents of your desktop in a folder"), 0, FALSE,
                                cat_iter);
-        g_object_unref (icon);
+        g_free (icon);
         g_free (sidebar->top_bookend_uri);
         sidebar->top_bookend_uri = g_strdup (mount_uri);
         g_free (mount_uri);
@@ -766,7 +766,7 @@ update_places (NemoPlacesSidebar *sidebar)
         root = nemo_bookmark_get_location (bookmark);
 
         bookmark_name = nemo_bookmark_get_name (bookmark);
-        icon = nemo_bookmark_get_icon (bookmark);
+        icon = nemo_bookmark_get_icon_name (bookmark);
         mount_uri = nemo_bookmark_get_uri (bookmark);
         tooltip = g_file_get_parse_name (root);
 
@@ -777,26 +777,25 @@ update_places (NemoPlacesSidebar *sidebar)
                                tooltip, 0, FALSE,
                                cat_iter);
         g_object_unref (root);
-        g_object_unref (icon);
+        g_free (icon);
         g_free (mount_uri);
         g_free (tooltip);
     }
 
     if (recent_is_supported ()) {
         mount_uri = (char *)"recent:///"; /* No need to strdup */
-        icon = g_themed_icon_new ("document-open-recent-symbolic");
+        icon = "document-open-recent-symbolic";
         cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                               SECTION_COMPUTER,
                               _("Recent"), icon, mount_uri,
                               NULL, NULL, NULL, 0,
                               _("Recent files"), 0, FALSE, cat_iter);
-        g_object_unref (icon);
         sidebar->bottom_bookend_uri = g_strdup (mount_uri);
     }
 
     /* file system root */
     mount_uri = (char *)"file:///"; /* No need to strdup */
-    icon = g_themed_icon_new (NEMO_ICON_SYMBOLIC_FILESYSTEM);
+    icon = NEMO_ICON_SYMBOLIC_FILESYSTEM;
     full = get_disk_full (g_file_new_for_uri (mount_uri), &tooltip_info);
     tooltip = g_strdup_printf (_("Open the contents of the File System\n%s"), tooltip_info);
     g_free (tooltip_info);
@@ -807,21 +806,20 @@ update_places (NemoPlacesSidebar *sidebar)
                            tooltip,
                            full, TRUE,
                            cat_iter);
-    g_object_unref (icon);
     g_free (tooltip);
 
     if (!recent_is_supported())
         sidebar->bottom_bookend_uri = g_strdup (mount_uri);
 
     mount_uri = (char *)"trash:///"; /* No need to strdup */
-    icon = nemo_trash_monitor_get_symbolic_icon ();
+    icon = nemo_trash_monitor_get_symbolic_icon_name ();
     cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                            SECTION_COMPUTER,
                            _("Trash"), icon, mount_uri,
                            NULL, NULL, NULL, 0,
                            _("Open the trash"), 0, FALSE,
                            cat_iter);
-    g_object_unref (icon);
+    g_free (icon);
 
     cat_iter = add_heading (sidebar, SECTION_BOOKMARKS,
                                     _("Bookmarks"));
@@ -832,7 +830,7 @@ update_places (NemoPlacesSidebar *sidebar)
             root = nemo_bookmark_get_location (bookmark);
 
             bookmark_name = nemo_bookmark_get_name (bookmark);
-            icon = nemo_bookmark_get_icon (bookmark);
+            icon = nemo_bookmark_get_icon_name (bookmark);
             mount_uri = nemo_bookmark_get_uri (bookmark);
             tooltip = g_file_get_parse_name (root);
 
@@ -843,7 +841,7 @@ update_places (NemoPlacesSidebar *sidebar)
                                    tooltip, 0, FALSE,
                                    cat_iter);
             g_object_unref (root);
-            g_object_unref (icon);
+            g_free (icon);
             g_free (mount_uri);
             g_free (tooltip);
         }
@@ -894,7 +892,7 @@ update_places (NemoPlacesSidebar *sidebar)
             }
         }
 
-        icon = nemo_get_mount_gicon (mount);
+        icon = nemo_get_mount_icon_name (mount);
         mount_uri = g_file_get_uri (root);
         name = g_mount_get_name (mount);
         tooltip = g_file_get_parse_name (root);
@@ -905,7 +903,7 @@ update_places (NemoPlacesSidebar *sidebar)
                                cat_iter);
         g_object_unref (root);
         g_object_unref (mount);
-        g_object_unref (icon);
+        g_free (icon);
         g_free (name);
         g_free (mount_uri);
         g_free (tooltip);
@@ -935,7 +933,7 @@ update_places (NemoPlacesSidebar *sidebar)
                 mount = g_volume_get_mount (volume);
                 if (mount != NULL) {
                     /* Show mounted volume in the sidebar */
-                    icon = nemo_get_mount_gicon (mount);
+                    icon = nemo_get_mount_icon_name (mount);
                     root = g_mount_get_default_location (mount);
                     mount_uri = g_file_get_uri (root);
                     name = g_mount_get_name (mount);
@@ -954,7 +952,7 @@ update_places (NemoPlacesSidebar *sidebar)
                                            cat_iter);
                     g_object_unref (root);
                     g_object_unref (mount);
-                    g_object_unref (icon);
+                    g_free (icon);
                     g_free (tooltip);
                     g_free (name);
                     g_free (mount_uri);
@@ -967,7 +965,7 @@ update_places (NemoPlacesSidebar *sidebar)
                      * cue that the user should remember to yank out the media if
                      * he just unmounted it.
                      */
-                    icon = g_volume_get_symbolic_icon (volume);
+                    icon = nemo_get_volume_icon_name (volume);
                     name = g_volume_get_name (volume);
                     tooltip = g_strdup_printf (_("Mount and open %s (%s)"), name,
                                                g_volume_get_identifier (volume,
@@ -978,7 +976,7 @@ update_places (NemoPlacesSidebar *sidebar)
                                            name, icon, NULL,
                                            drive, volume, NULL, 0, tooltip, 0, FALSE,
                                            cat_iter);
-                    g_object_unref (icon);
+                    g_free (icon);
                     g_free (name);
                     g_free (tooltip);
                 }
@@ -995,7 +993,7 @@ update_places (NemoPlacesSidebar *sidebar)
                  * work.. but it's also for human beings who like to turn off media detection
                  * in the OS to save battery juice.
                  */
-                icon = g_drive_get_symbolic_icon (drive);
+                icon = nemo_get_drive_icon_name (drive);
                 name = g_drive_get_name (drive);
                 tooltip = g_strdup_printf (_("Mount and open %s"), name);
 
@@ -1004,7 +1002,7 @@ update_places (NemoPlacesSidebar *sidebar)
                                        name, icon, NULL,
                                        drive, NULL, NULL, 0, tooltip, 0, FALSE,
                                        cat_iter);
-                g_object_unref (icon);
+                g_free (icon);
                 g_free (tooltip);
                 g_free (name);
             }
@@ -1035,7 +1033,7 @@ update_places (NemoPlacesSidebar *sidebar)
 
         mount = g_volume_get_mount (volume);
         if (mount != NULL) {
-            icon = nemo_get_mount_gicon (mount);
+            icon = nemo_get_mount_icon_name (mount);
             root = g_mount_get_default_location (mount);
             mount_uri = g_file_get_uri (root);
             full = get_disk_full (g_file_new_for_uri (mount_uri), &tooltip_info);
@@ -1051,20 +1049,20 @@ update_places (NemoPlacesSidebar *sidebar)
                                    NULL, volume, mount, 0, tooltip, full, TRUE,
                                    cat_iter);
             g_object_unref (mount);
-            g_object_unref (icon);
+            g_free (icon);
             g_free (name);
             g_free (tooltip);
             g_free (mount_uri);
         } else {
             /* see comment above in why we add an icon for an unmounted mountable volume */
-            icon = g_volume_get_symbolic_icon (volume);
+            icon = nemo_get_volume_icon_name (volume);
             name = g_volume_get_name (volume);
             cat_iter = add_place (sidebar, PLACES_MOUNTED_VOLUME,
                                    SECTION_DEVICES,
                                    name, icon, NULL,
                                    NULL, volume, NULL, 0, name, 0, FALSE,
                                    cat_iter);
-            g_object_unref (icon);
+            g_free (icon);
             g_free (name);
         }
         g_object_unref (volume);
@@ -1084,7 +1082,7 @@ update_places (NemoPlacesSidebar *sidebar)
 			network_mounts = g_list_prepend (network_mounts, mount);
 			continue;
 		} else {
-			icon = g_volume_get_symbolic_icon (volume);
+			icon = nemo_get_volume_icon_name (volume);
 			name = g_volume_get_name (volume);
 			tooltip = g_strdup_printf (_("Mount and open %s"), name);
 
@@ -1093,7 +1091,7 @@ update_places (NemoPlacesSidebar *sidebar)
                 				   name, icon, NULL,
                 				   NULL, volume, NULL, 0, tooltip, 0, FALSE,
                                    cat_iter);
-			g_object_unref (icon);
+			g_free (icon);
 			g_free (name);
 			g_free (tooltip);
 		}
@@ -1105,7 +1103,7 @@ update_places (NemoPlacesSidebar *sidebar)
 	for (l = network_mounts; l != NULL; l = l->next) {
 		mount = l->data;
 		root = g_mount_get_default_location (mount);
-		icon = nemo_get_mount_gicon (mount);
+		icon = nemo_get_mount_icon_name (mount);
 		mount_uri = g_file_get_uri (root);
 		name = g_mount_get_name (mount);
 		tooltip = g_file_get_parse_name (root);
@@ -1115,7 +1113,7 @@ update_places (NemoPlacesSidebar *sidebar)
                 			   NULL, NULL, mount, 0, tooltip, 0, FALSE,
                                cat_iter);
 		g_object_unref (root);
-		g_object_unref (icon);
+		g_free (icon);
 		g_free (name);
 		g_free (mount_uri);
 		g_free (tooltip);
@@ -1125,14 +1123,13 @@ update_places (NemoPlacesSidebar *sidebar)
 
 	/* network:// */
  	mount_uri = (char *)"network:///"; /* No need to strdup */
-	icon = g_themed_icon_new (NEMO_ICON_SYMBOLIC_NETWORK);
+	icon = NEMO_ICON_SYMBOLIC_NETWORK;
 	cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                 		   SECTION_NETWORK,
                 		   _("Network"), icon,
                 		   mount_uri, NULL, NULL, NULL, 0,
                 		   _("Browse the contents of the network"), 0, FALSE,
                            cat_iter);
-	g_object_unref (icon);
 
 	/* restore selection */
     restore_expand_state (sidebar);
@@ -3920,7 +3917,7 @@ nemo_places_sidebar_init (NemoPlacesSidebar *sidebar)
                   NULL);
 	gtk_tree_view_column_pack_start (col, cell, FALSE);
 	gtk_tree_view_column_set_attributes (col, cell,
-					     "gicon", PLACES_SIDEBAR_COLUMN_ICON,
+					     "icon-name", PLACES_SIDEBAR_COLUMN_ICON,
 					     NULL);
 	gtk_tree_view_column_set_cell_data_func (col, cell,
 						 icon_cell_renderer_func,
@@ -4349,7 +4346,7 @@ nemo_shortcuts_model_new (NemoPlacesSidebar *sidebar)
 		G_TYPE_VOLUME,
 		G_TYPE_MOUNT,
 		G_TYPE_STRING,
-		G_TYPE_ICON,
+		G_TYPE_STRING,
 		G_TYPE_INT,
 		G_TYPE_BOOLEAN,
 		G_TYPE_BOOLEAN,

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -5005,7 +5005,7 @@ action_copy_bookmark_callback (GtkAction *action, gpointer callback_data)
 static void
 setup_bookmark_action(      char *action_name,
                       const char *bookmark_name,
-                           GIcon *icon,
+                      const char *icon_name,
                             char *mount_uri,
                     GtkUIManager *ui_manager,
                          gboolean move,
@@ -5020,7 +5020,7 @@ setup_bookmark_action(      char *action_name,
              bookmark_name,
              NULL,
              NULL);
-    gtk_action_set_gicon (action, icon);
+    gtk_action_set_icon_name (action, icon_name);
 
     if (move) {
         g_signal_connect_data (action, "activate",
@@ -5048,14 +5048,14 @@ setup_bookmark_action(      char *action_name,
 }
 
 static void
-add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon, gchar *mount_uri, gint index)
+add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, const gchar *icon_name, gchar *mount_uri, gint index)
 {
     GtkUIManager *ui_manager;
     ui_manager = nemo_window_get_ui_manager (view->details->window);
 
     setup_bookmark_action(g_strdup_printf ("BM_MOVETO_POPUP_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             TRUE,
@@ -5066,7 +5066,7 @@ add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon,
 
     setup_bookmark_action(g_strdup_printf ("BM_COPYTO_POPUP_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             FALSE,
@@ -5077,7 +5077,7 @@ add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon,
 
     setup_bookmark_action(g_strdup_printf ("BM_MOVETO_MENU_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             TRUE,
@@ -5088,7 +5088,7 @@ add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon,
 
     setup_bookmark_action(g_strdup_printf ("BM_COPYTO_MENU_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             FALSE,
@@ -5099,14 +5099,14 @@ add_bookmark_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon,
 }
 
 static void
-add_place_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon, gchar *mount_uri, gint index)
+add_place_to_action (NemoView *view, const gchar *bookmark_name, const gchar *icon_name, gchar *mount_uri, gint index)
 {
     GtkUIManager *ui_manager;
     ui_manager = nemo_window_get_ui_manager (view->details->window);
 
     setup_bookmark_action(g_strdup_printf ("PLACE_MOVETO_POPUP_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             TRUE,
@@ -5117,7 +5117,7 @@ add_place_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon, gc
 
     setup_bookmark_action(g_strdup_printf ("PLACE_COPYTO_POPUP_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             FALSE,
@@ -5128,7 +5128,7 @@ add_place_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon, gc
 
     setup_bookmark_action(g_strdup_printf ("PLACE_MOVETO_MENU_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             TRUE,
@@ -5139,7 +5139,7 @@ add_place_to_action (NemoView *view, const gchar *bookmark_name, GIcon *icon, gc
 
     setup_bookmark_action(g_strdup_printf ("PLACE_COPYTO_MENU_%d", index),
                                             bookmark_name,
-                                            icon,
+                                            icon_name,
                                             mount_uri,
                                             ui_manager,
                                             FALSE,
@@ -5158,7 +5158,7 @@ reset_move_copy_to_menu (NemoView *view)
     GtkUIManager *ui_manager;
     GFile *root;
     const gchar *bookmark_name;
-    GIcon *icon;
+    gchar *icon_name;
     char *mount_uri;
 
     ui_manager = nemo_window_get_ui_manager (view->details->window);
@@ -5183,21 +5183,30 @@ reset_move_copy_to_menu (NemoView *view)
     file = nemo_file_get_by_uri (mount_uri);
     g_free (mount_uri);
 
-    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_COPY_TO_HOME);
-    gtk_action_set_gicon (action, nemo_file_get_control_icon (file));
-    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_MOVE_TO_HOME);
-    gtk_action_set_gicon (action, nemo_file_get_control_icon (file));
+    icon_name = nemo_file_get_control_icon_name (file);
 
+    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_COPY_TO_HOME);
+    gtk_action_set_icon_name (action, icon_name);
+
+    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_MOVE_TO_HOME);
+    gtk_action_set_icon_name (action, icon_name);
+
+    g_clear_pointer (&icon_name, g_free);
     g_object_unref (file);
+
     mount_uri = nemo_get_desktop_directory_uri ();
     file = nemo_file_get_by_uri (mount_uri);
     g_free (mount_uri);
 
-    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_COPY_TO_DESKTOP);
-    gtk_action_set_gicon (action, nemo_file_get_control_icon (file));
-    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_MOVE_TO_DESKTOP);
-    gtk_action_set_gicon (action, nemo_file_get_control_icon (file));
+    icon_name = nemo_file_get_control_icon_name (file);
 
+    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_COPY_TO_DESKTOP);
+    gtk_action_set_icon_name (action, icon_name);
+
+    action = gtk_action_group_get_action (view->details->dir_action_group, NEMO_ACTION_MOVE_TO_DESKTOP);
+    gtk_action_set_icon_name (action, icon_name);
+
+    g_clear_pointer (&icon_name, g_free);
     g_object_unref (file);
 
     if (view->details->showing_bookmarks_in_to_menus) {
@@ -5218,17 +5227,17 @@ reset_move_copy_to_menu (NemoView *view)
             nemo_file_unref (file);
 
             bookmark_name = nemo_bookmark_get_name (bookmark);
-            icon = nemo_bookmark_get_icon (bookmark);
+            icon_name = nemo_bookmark_get_icon_name (bookmark);
             mount_uri = nemo_bookmark_get_uri (bookmark);
 
             add_bookmark_to_action (view,
                                     bookmark_name,
-                                    icon,
+                                    icon_name,
                                     mount_uri,
                                     index);
 
             g_object_unref (root);
-            g_object_unref (icon);
+            g_free (icon_name);
             g_free (mount_uri);
         }
     }
@@ -5291,19 +5300,19 @@ reset_move_copy_to_menu (NemoView *view)
                 }
             }
 
-            icon = nemo_get_mount_gicon (mount);
+            icon_name = nemo_get_mount_icon_name (mount);
             mount_uri = g_file_get_uri (root);
             name = g_mount_get_name (mount);
 
             add_place_to_action (view,
                                  name,
-                                 icon,
+                                 icon_name,
                                  mount_uri,
                                  index);
 
             g_object_unref (root);
             g_object_unref (mount);
-            g_object_unref (icon);
+            g_free (icon_name);
             g_free (name);
             g_free (mount_uri);
 
@@ -5333,20 +5342,20 @@ reset_move_copy_to_menu (NemoView *view)
                     mount = g_volume_get_mount (volume);
                     if (mount != NULL) {
                         /* Show mounted volume in the sidebar */
-                        icon = nemo_get_mount_gicon (mount);
+                        icon_name = nemo_get_mount_icon_name (mount);
                         root = g_mount_get_default_location (mount);
                         mount_uri = g_file_get_uri (root);
                         name = g_mount_get_name (mount);
 
                         add_place_to_action (view,
                                              name,
-                                             icon,
+                                             icon_name,
                                              mount_uri,
                                              index);
 
                         g_object_unref (root);
                         g_object_unref (mount);
-                        g_object_unref (icon);
+                        g_free (icon_name);
                         g_free (name);
                         g_free (mount_uri);
                         index++;
@@ -5381,7 +5390,7 @@ reset_move_copy_to_menu (NemoView *view)
 
             mount = g_volume_get_mount (volume);
             if (mount != NULL) {
-                icon = nemo_get_mount_gicon (mount);
+                icon_name = nemo_get_mount_icon_name (mount);
                 root = g_mount_get_default_location (mount);
                 mount_uri = g_file_get_uri (root);
 
@@ -5390,12 +5399,12 @@ reset_move_copy_to_menu (NemoView *view)
 
                 add_place_to_action (view,
                                      name,
-                                     icon,
+                                     icon_name,
                                      mount_uri,
                                      index);
 
                 g_object_unref (mount);
-                g_object_unref (icon);
+                g_free (icon_name);
                 g_free (name);
                 g_free (mount_uri);
                 index++;
@@ -5422,18 +5431,18 @@ reset_move_copy_to_menu (NemoView *view)
         for (l = network_mounts; l != NULL; l = l->next) {
             mount = l->data;
             root = g_mount_get_default_location (mount);
-            icon = nemo_get_mount_gicon (mount);
+            icon_name = nemo_get_mount_icon_name (mount);
             mount_uri = g_file_get_uri (root);
             name = g_mount_get_name (mount);
 
             add_place_to_action (view,
                                  name,
-                                 icon,
+                                 icon_name,
                                  mount_uri,
                                  index);
 
             g_object_unref (root);
-            g_object_unref (icon);
+            g_free (icon_name);
             g_free (name);
             g_free (mount_uri);
             index++;

--- a/src/nemo-window-bookmarks.c
+++ b/src/nemo-window-bookmarks.c
@@ -191,7 +191,7 @@ connect_proxy_cb (GtkActionGroup *action_group,
                   gpointer dummy)
 {
 	GtkLabel *label;
-	GIcon *icon;
+	const gchar *icon_name;
 
 	if (!GTK_IS_MENU_ITEM (proxy))
 		return;
@@ -202,11 +202,11 @@ connect_proxy_cb (GtkActionGroup *action_group,
 	gtk_label_set_ellipsize (label, PANGO_ELLIPSIZE_END);
 	gtk_label_set_max_width_chars (label, MENU_ITEM_MAX_WIDTH_CHARS);
 
-	icon = g_object_get_data (G_OBJECT (action), "menu-icon");
+	icon_name = g_object_get_data (G_OBJECT (action), "menu-icon-name");
 
-	if (icon != NULL) {
+	if (icon_name != NULL) {
 		gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (proxy),
-					       gtk_image_new_from_gicon (icon, GTK_ICON_SIZE_MENU));
+					       gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU));
 	}
 }
 
@@ -290,7 +290,7 @@ nemo_menus_append_bookmark_to_menu (NemoWindow *window,
 	char action_name[128];
 	const char *name;
 	char *path;
-	GIcon *icon;
+	gchar *icon_name;
 	GtkAction *action;
 	GtkWidget *menuitem;
 
@@ -301,7 +301,7 @@ nemo_menus_append_bookmark_to_menu (NemoWindow *window,
 	name = nemo_bookmark_get_name (bookmark);
 
 	/* Create menu item with pixbuf */
-	icon = nemo_bookmark_get_icon (bookmark);
+	icon_name = nemo_bookmark_get_icon_name (bookmark);
 
 	g_snprintf (action_name, sizeof (action_name), "%s%d", parent_id, index_in_parent);
 
@@ -310,9 +310,9 @@ nemo_menus_append_bookmark_to_menu (NemoWindow *window,
 				 _("Go to the location specified by this bookmark"),
 				 NULL);
 	
-	g_object_set_data_full (G_OBJECT (action), "menu-icon",
-				icon,
-				g_object_unref);
+	g_object_set_data_full (G_OBJECT (action), "menu-icon-name",
+				icon_name,
+				g_free);
 
 	g_signal_connect_data (action, "activate",
 			       G_CALLBACK (activate_bookmark_in_menu_item),

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -455,17 +455,17 @@ trash_state_changed_cb (NemoTrashMonitor *monitor,
 {
 	GtkActionGroup *action_group;
 	GtkAction *action;
-	GIcon *gicon;
+    gchar *icon_name;
 
 	action_group = nemo_window_get_main_action_group (window);
 	action = gtk_action_group_get_action (action_group, "Go to Trash");
 
-	gicon = nemo_trash_monitor_get_symbolic_icon ();
+    icon_name = nemo_trash_monitor_get_symbolic_icon_name ();
 
-	if (gicon) {
-		g_object_set (action, "gicon", gicon, NULL);
-		g_object_unref (gicon);
-	}
+    if (icon_name) {
+        g_object_set (action, "icon-name", icon_name, NULL);
+        g_clear_pointer (&icon_name, g_free);
+    }
 }
 
 static void


### PR DESCRIPTION
The gicon api does not support inherited icon themes.


