### PR TITLE
Revert license tweak done by db6414a

### DIFF
--- a/src/nemo-query-editor.c
+++ b/src/nemo-query-editor.c
@@ -10,7 +10,7 @@
  * Nemo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more priv.
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
  * License along with this program; see the file COPYING.  If not,


### PR DESCRIPTION
It seems that details was replaced with priv all over the file, including the license paragraph.