### PR TITLE
Fix meson warnings by increasing required meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 
 # https://github.com/linuxmint/nemo
 project('nemo', 'c', version: '3.9.0',
-  meson_version: '>=0.37.0'
+  meson_version: '>=0.41.0'
 )
 
 # 1. If the library code has changed at all since last release, then increment revision.


### PR DESCRIPTION
WARNING: Project targetting '>=0.37.0' but tried to use feature introduced in '0.41.0': variables arg in pkgconfig.generate
WARNING: Project targetting '>=0.37.0' but tried to use feature introduced in '0.41.0': custom pkgconfig variables
Native dependency glib-2.0 found: YES 2.56.1
Message: 
        nemo-3.8.4
    prefix:                 /usr
    source code location:   /builddir/build/BUILD/nemo-3.8.4
    compiler:           gcc
    debugging support:  plain
    libexif support:    true
    exempi  support:    true
    Tracker support:    false
    nemo-extension documentation: false
    nemo-extension introspection: true
Build targets in project: 26
WARNING: Project specifies a minimum meson_version '>=0.37.0' which conflicts with:
 * 0.41.0: {'variables arg in pkgconfig.generate', 'custom pkgconfig variables'}