### PR TITLE
Add toggle for thumbnails per directory

### DIFF
--- a/gresources/nemo-directory-view-ui.xml
+++ b/gresources/nemo-directory-view-ui.xml
@@ -101,6 +101,7 @@
 		<placeholder name="View Preferences Placeholder">
 			<menuitem name="Reset to Defaults" action="Reset to Defaults"/>
 			<menuitem name="Show Hidden Files" action="Show Hidden Files"/>
+			<menuitem name="Show Thumbnails" action="Show Thumbnails"/>
 		</placeholder>
 	</menu>
 </menubar>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -28,6 +28,11 @@
     <property name="can_focus">False</property>
     <property name="icon_name">view-compact-symbolic</property>
   </object>
+  <object class="GtkImage" id="image14">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">xapp-prefs-preview-symbolic</property>
+  </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -313,6 +318,9 @@
       </row>
       <row>
         <col id="0" translatable="yes">Local Files Only</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Per Folder</col>
       </row>
       <row>
         <col id="0" translatable="yes">Never</col>
@@ -3143,7 +3151,41 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <placeholder/>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkToggleButton" id="show_show_thumbnails_icon_toolbar_togglebutton">
+                                            <property name="name">show_show_thumbnails_icon_toolbar_togglebutton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">True</property>
+                                            <property name="image">image14</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Show Thumbnails</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">6</property>
+                                      </packing>
                                     </child>
                                   </object>
                                   <packing>

--- a/libnemo-private/nemo-directory.c
+++ b/libnemo-private/nemo-directory.c
@@ -1733,6 +1733,17 @@ nemo_directory_is_desktop_directory (NemoDirectory   *directory)
 	return nemo_is_desktop_directory (directory->details->location);
 }
 
+void
+nemo_directory_set_show_thumbnails (NemoDirectory         *directory,
+                                    gboolean show_thumbnails)
+{
+  NemoFile *file;
+  
+  file = nemo_file_get(directory->details->location);
+  nemo_file_set_boolean_metadata (file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, FALSE, show_thumbnails);
+  emit_change_signals_for_all_files(directory);
+}
+
 #if !defined (NEMO_OMIT_SELF_CHECK)
 
 #include <eel/eel-debug.h>

--- a/libnemo-private/nemo-directory.h
+++ b/libnemo-private/nemo-directory.h
@@ -237,5 +237,7 @@ gboolean           nemo_directory_is_desktop_directory     (NemoDirectory       
 
 gboolean           nemo_directory_is_editable              (NemoDirectory         *directory);
 
+void               nemo_directory_set_show_thumbnails      (NemoDirectory         *directory,
+                                gboolean show_thumbnails);
 
 #endif /* NEMO_DIRECTORY_H */

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4167,8 +4167,19 @@ gboolean
 nemo_file_should_show_thumbnail (NemoFile *file)
 {
 	GFilesystemPreviewType use_preview;
+    gboolean show_dir_thumbnails;
+    NemoFile *dir;
+
+    if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
+        return FALSE;
+    }
 
 	use_preview = nemo_file_get_filesystem_use_preview (file);
+    dir = nemo_file_is_directory(file) ? file : nemo_file_get_parent(file);
+    
+    show_dir_thumbnails = nemo_file_get_boolean_metadata (dir,
+                                                          NEMO_METADATA_KEY_SHOW_THUMBNAILS,
+                                                          FALSE);
 
 	/* If the thumbnail has already been created, don't care about the size
 	 * of the original file.
@@ -4187,8 +4198,8 @@ nemo_file_should_show_thumbnail (NemoFile *file)
 		} else {
 			return TRUE;
 		}
-	} else if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
-		return FALSE;
+	} else if (show_image_thumbs == NEMO_SPEED_TRADEOFF_PER_FOLDER) {
+		return show_dir_thumbnails;
 	} else {
 		if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_NEVER) {
 			/* file system says to never thumbnail anything */

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -92,6 +92,7 @@ typedef enum
 #define NEMO_PREFERENCES_SHOW_LIST_VIEW_ICON_TOOLBAR   "show-list-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR   "show-compact-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_ROOT_WARNING                "show-root-warning"
+#define NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR     "show-show-thumbnails-toolbar"
 
 /* Which views should be displayed for new windows */
 #define NEMO_WINDOW_STATE_START_WITH_STATUS_BAR		"start-with-status-bar"
@@ -186,7 +187,8 @@ typedef enum
 {
 	NEMO_SPEED_TRADEOFF_ALWAYS,
 	NEMO_SPEED_TRADEOFF_LOCAL_ONLY,
-	NEMO_SPEED_TRADEOFF_NEVER
+    NEMO_SPEED_TRADEOFF_NEVER,
+    NEMO_SPEED_TRADEOFF_PER_FOLDER
 } NemoSpeedTradeoffValue;
 
 #define NEMO_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS "show-directory-item-counts"

--- a/libnemo-private/nemo-metadata.c
+++ b/libnemo-private/nemo-metadata.c
@@ -58,6 +58,7 @@ static char *used_metadata_names[] = {
   (char *)NEMO_METADATA_KEY_EMBLEMS,
   (char *)NEMO_METADATA_KEY_MONITOR,
   (char *)NEMO_METADATA_KEY_DESKTOP_GRID_HORIZONTAL,
+  (char *)NEMO_METADATA_KEY_SHOW_THUMBNAILS,
   NULL
 };
 

--- a/libnemo-private/nemo-metadata.h
+++ b/libnemo-private/nemo-metadata.h
@@ -74,6 +74,7 @@
 #define NEMO_METADATA_KEY_EMBLEMS				"emblems"
 #define NEMO_METADATA_KEY_MONITOR               "monitor"
 #define NEMO_METADATA_KEY_DESKTOP_GRID_HORIZONTAL  "desktop-horizontal"
+#define NEMO_METADATA_KEY_SHOW_THUMBNAILS "show-thumbnails"
 
 guint nemo_metadata_get_id (const char *metadata);
 

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -3,6 +3,7 @@
     <value nick="always" value="0"/>
     <value nick="local-only" value="1"/>
     <value nick="never" value="2"/>
+    <value nick="per-folder" value="3"/>
   </enum>
 
   <enum id="org.nemo.ClickPolicy">
@@ -158,6 +159,11 @@
     <key type="b" name="show-compact-view-icon-toolbar">
       <default>true</default>
       <summary>Show Compact View button in nemo toolbar</summary>
+      <description>If set to true, then Nemo browser windows will show the button.</description>
+    </key>
+    <key type="b" name="show-show-thumbnails-toolbar">
+      <default>true</default>
+      <summary>Show Thumbnails button in nemo toolbar</summary>
       <description>If set to true, then Nemo browser windows will show the button.</description>
     </key>
     <key type="b" name="show-root-warning">

--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -148,4 +148,6 @@
 
 #define NEMO_ACTION_PLUGIN_MANAGER "NemoPluginManager"
 
+#define NEMO_ACTION_SHOW_THUMBNAILS "Show Thumbnails"
+
 #endif /* NEMO_ACTIONS_H */

--- a/src/nemo-convert-metadata.c
+++ b/src/nemo-convert-metadata.c
@@ -119,6 +119,7 @@ static struct {
 	{"icon_scale", "metadata::" NEMO_METADATA_KEY_ICON_SCALE},
 	{"custom_icon", "metadata::" NEMO_METADATA_KEY_CUSTOM_ICON},
 	{"keyword", "metadata::" NEMO_METADATA_KEY_EMBLEMS},
+  {"show_thumbnails", "metadata::" NEMO_METADATA_KEY_SHOW_THUMBNAILS},
 };
 
 static const char *

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -79,6 +79,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ICON_VIEW_ICON_TOOLBAR_WIDGET "show_icon_view_icon_toolbar_togglebutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LIST_VIEW_ICON_TOOLBAR_WIDGET "show_list_view_icon_toolbar_togglebutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_COMPACT_VIEW_ICON_TOOLBAR_WIDGET "show_compact_view_icon_toolbar_togglebutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SHOW_THUMBNAILS_ICON_TOOLBAR_WIDGET "show_show_thumbnails_icon_toolbar_togglebutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_FULL_PATH_IN_TITLE_BARS_WIDGET "show_full_path_in_title_bars_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_CLOSE_DEVICE_VIEW_ON_EJECT_WIDGET "close_device_view_on_eject_checkbutton"
@@ -148,7 +149,15 @@ static const char * const date_format_values[] = {
 	NULL
 };
 
-static const char * const preview_values[] = {
+static const char * const preview_image_values[] = {
+    "always",
+    "local-only",
+    "per-folder",
+    "never",
+    NULL
+};
+
+static const char * const preview_folder_values[] = {
 	"always",
 	"local-only",
 	"never",
@@ -829,6 +838,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_COMPACT_VIEW_ICON_TOOLBAR_WIDGET,
 			   NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR);
+    bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SHOW_THUMBNAILS_ICON_TOOLBAR_WIDGET,
+			   NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR);
 
 	/* setup preferences */
 	bind_builder_bool (builder, nemo_icon_view_preferences,
@@ -885,11 +897,11 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_IMAGE_WIDGET,
 			   NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
-			   (const char **) preview_values);
+			   (const char **) preview_image_values);
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_FOLDER_WIDGET,
 			   NEMO_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS,
-			   (const char **) preview_values);
+			   (const char **) preview_folder_values);
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_SIZE_PREFIXES_WIDGET,
 			   NEMO_PREFERENCES_SIZE_PREFIXES,

--- a/src/nemo-toolbar.c
+++ b/src/nemo-toolbar.c
@@ -54,6 +54,7 @@ struct _NemoToolbarPriv {
     GtkWidget *icon_view_button;
     GtkWidget *list_view_button;
     GtkWidget *compact_view_button;
+    GtkWidget *show_thumbnails_button;
 
     GtkToolItem *navigation_box;
     GtkToolItem *refresh_box;
@@ -183,6 +184,13 @@ toolbar_update_appearance (NemoToolbar *self)
     icon_toolbar = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR);
     if ( icon_toolbar == FALSE ) { gtk_widget_hide (widgetitem); }
     else {gtk_widget_show (GTK_WIDGET(widgetitem));}
+    
+    widgetitem = self->priv->show_thumbnails_button;
+    icon_toolbar = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR) &&
+                   (g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS) ==
+                    NEMO_SPEED_TRADEOFF_PER_FOLDER);
+    if ( icon_toolbar == FALSE ) { gtk_widget_hide (widgetitem); }
+    else {gtk_widget_show (GTK_WIDGET(widgetitem));}
 
     if (gtk_widget_get_visible(self->priv->previous_button) == FALSE &&
         gtk_widget_get_visible(self->priv->next_button) == FALSE &&
@@ -211,7 +219,8 @@ toolbar_update_appearance (NemoToolbar *self)
     if (gtk_widget_get_visible(self->priv->search_button) == FALSE &&
         gtk_widget_get_visible(self->priv->new_folder_button) == FALSE && 
         gtk_widget_get_visible(self->priv->open_terminal_button) == FALSE &&
-        gtk_widget_get_visible(self->priv->toggle_location_button) == FALSE)
+        gtk_widget_get_visible(self->priv->toggle_location_button) == FALSE &&
+        gtk_widget_get_visible(self->priv->show_thumbnails_button) == FALSE)
     {
         gtk_widget_hide(GTK_WIDGET (self->priv->tools_box));
     } else {
@@ -391,6 +400,9 @@ nemo_toolbar_constructed (GObject *obj)
 
     self->priv->search_button = toolbar_create_toolbutton (self, TRUE, NEMO_ACTION_SEARCH);
     gtk_container_add (GTK_CONTAINER (box), self->priv->search_button);
+    
+    self->priv->show_thumbnails_button = toolbar_create_toolbutton (self, TRUE, NEMO_ACTION_SHOW_THUMBNAILS);
+    gtk_container_add (GTK_CONTAINER (box), self->priv->show_thumbnails_button);
 
     gtk_style_context_add_class (gtk_widget_get_style_context (box), GTK_STYLE_CLASS_RAISED);
     gtk_style_context_add_class (gtk_widget_get_style_context (box), GTK_STYLE_CLASS_LINKED);
@@ -464,6 +476,12 @@ nemo_toolbar_constructed (GObject *obj)
                   G_CALLBACK (toolbar_update_appearance), self);
     g_signal_connect_swapped (nemo_preferences,
                   "changed::" NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR,
+                  G_CALLBACK (toolbar_update_appearance), self);
+    g_signal_connect_swapped (nemo_preferences,
+                  "changed::" NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR,
+                  G_CALLBACK (toolbar_update_appearance), self);
+    g_signal_connect_swapped (nemo_preferences,
+                  "changed::" NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
                   G_CALLBACK (toolbar_update_appearance), self);
 
 	toolbar_update_appearance (self);

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -39,6 +39,7 @@
 #include "nemo-previewer.h"
 #include "nemo-properties-window.h"
 #include "nemo-bookmark-list.h"
+#include "nemo-directory-private.h"
 
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -503,6 +504,7 @@ nemo_view_reveal_selection (NemoView *view)
 static void
 nemo_view_reset_to_defaults (NemoView *view)
 {
+    NemoFile *file;
     g_return_if_fail (NEMO_IS_VIEW (view));
 
     NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->reset_to_defaults (view);
@@ -514,6 +516,10 @@ nemo_view_reset_to_defaults (NemoView *view)
     } else {
         nemo_window_set_hidden_files_mode (view->details->window, NEMO_WINDOW_SHOW_HIDDEN_FILES_DISABLE);
     }
+
+    file = view->details->slot->viewed_file;
+    nemo_file_set_metadata(file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, NULL, NULL);
+    emit_change_signals_for_all_files_in_all_directories ();
 }
 
 static gboolean

--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -1473,6 +1473,7 @@ update_for_new_location (NemoWindowSlot *slot)
 		nemo_window_sync_zoom_widgets (window);
         nemo_window_sync_bookmark_action (window);
         nemo_window_sync_view_type (window);
+        nemo_window_sync_thumbnail_action(window);
 
 		/* Load menus from nemo extensions for this location */
 		nemo_window_load_extension_menus (window);

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -885,6 +885,27 @@ action_menu_edit_location_callback (GtkAction *action,
 }
 
 static void
+action_show_thumbnails_callback (GtkAction * action,
+                                 gpointer user_data)
+{
+    NemoWindowSlot *slot;
+    NemoWindowPane *pane;
+    NemoWindow *window;
+    gboolean value;
+
+    window = NEMO_WINDOW (user_data);
+
+    slot = nemo_window_get_active_slot (window);
+    pane = nemo_window_get_active_pane(window);
+
+    value = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    nemo_window_slot_set_show_thumbnails(slot, value);
+
+    toolbar_set_show_thumbnails_button (value, pane);
+    menu_set_show_thumbnails_action(value, window);
+}
+
+static void
 set_content_view_type(NemoWindow *window,
                       const gchar *view_id)
 {
@@ -1025,6 +1046,60 @@ toolbar_set_view_button (guint action_id, NemoWindowPane *pane)
                            action_compact_view_callback,
                            NULL);
 
+}
+
+void
+toolbar_set_show_thumbnails_button (gboolean value, NemoWindowPane *pane)
+{
+    GtkAction *action;
+    GtkActionGroup *action_group;
+
+    action_group = nemo_window_pane_get_toolbar_action_group (pane);
+
+
+    action = gtk_action_group_get_action(action_group,
+                                         NEMO_ACTION_SHOW_THUMBNAILS);
+
+    g_signal_handlers_block_matched (action,
+                         G_SIGNAL_MATCH_FUNC,
+                         0, 0,
+                         NULL,
+                         action_show_thumbnails_callback,
+                         NULL);
+
+    gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), value);
+
+    g_signal_handlers_unblock_matched (action,
+                           G_SIGNAL_MATCH_FUNC,
+                           0, 0,
+                           NULL,
+                           action_show_thumbnails_callback,
+                           NULL);
+}
+
+void
+menu_set_show_thumbnails_action (gboolean value, NemoWindow *window)
+{
+    GtkAction *action;
+
+    action = gtk_action_group_get_action (window->details->main_action_group,
+                                          NEMO_ACTION_SHOW_THUMBNAILS);
+
+    g_signal_handlers_block_matched (action,
+                         G_SIGNAL_MATCH_FUNC,
+                         0, 0,
+                         NULL,
+                         action_show_thumbnails_callback,
+                         NULL);
+
+    gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), value);
+
+    g_signal_handlers_unblock_matched (action,
+                           G_SIGNAL_MATCH_FUNC,
+                           0, 0,
+                           NULL,
+                           action_show_thumbnails_callback,
+                           NULL);
 }
 
 void
@@ -1354,6 +1429,11 @@ static const GtkToggleActionEntry main_toggle_entries[] = {
   /* tooltip */              N_("Open an extra folder view side-by-side"),
                              G_CALLBACK (action_split_view_callback),
   /* is_active */            FALSE },
+    /* name, stock id */         { NEMO_ACTION_SHOW_THUMBNAILS, NULL,
+  /* label, accelerator */       N_("Show _Thumbnails"), NULL,
+  /* tooltip */                  N_("Toggle the display of thumbnails in the current directory"),
+  /* callback */                 G_CALLBACK (action_show_thumbnails_callback),
+  /* default */                  FALSE },
 };
 
 static const GtkRadioActionEntry sidebar_radio_entries[] = {
@@ -1558,6 +1638,18 @@ nemo_window_create_toolbar_action_group (NemoWindow *window)
     gtk_action_set_icon_name (GTK_ACTION (action), "edit-find-symbolic");
 
   	g_object_unref (action);
+    
+    action = GTK_ACTION (gtk_toggle_action_new (NEMO_ACTION_SHOW_THUMBNAILS,
+                         _("Show Thumbnails"),
+                         _("Show Thumbnails"),
+                         NULL));
+   	g_signal_connect (action, "activate",
+                      G_CALLBACK (action_show_thumbnails_callback),
+                      window);
+   	gtk_action_group_add_action (action_group, action);
+    gtk_action_set_icon_name (GTK_ACTION (action), "xapp-prefs-preview-symbolic");
+
+   	g_object_unref (action);
 
 	navigation_state = nemo_window_get_navigation_state (window);
 	nemo_navigation_state_add_group (navigation_state, action_group);

--- a/src/nemo-window-menus.h
+++ b/src/nemo-window-menus.h
@@ -31,6 +31,8 @@
 
 guint           action_for_view_id  (const char *view_id                           );
 void            toolbar_set_view_button     (guint action_id,      NemoWindowPane *pane);
+void            toolbar_set_show_thumbnails_button (gboolean value, NemoWindowPane *pane);
+void            menu_set_show_thumbnails_action (gboolean value, NemoWindow *window);
 void            menu_set_view_selection (guint       action_id,
                                          NemoWindow *window);
 #endif /* NEMO_WINDOW_PANE_H */

--- a/src/nemo-window-private.h
+++ b/src/nemo-window-private.h
@@ -160,6 +160,7 @@ void nemo_window_sync_zoom_widgets     (NemoWindow *window);
 void nemo_window_sync_up_button        (NemoWindow *window);
 void nemo_window_sync_menu_bar         (NemoWindow *window);
 void nemo_window_sync_bookmark_action  (NemoWindow *window);
+void nemo_window_sync_thumbnail_action (NemoWindow *window);
 
 /* window menus */
 GtkActionGroup *nemo_window_create_toolbar_action_group (NemoWindow *window);

--- a/src/nemo-window-slot.c
+++ b/src/nemo-window-slot.c
@@ -239,6 +239,7 @@ real_active (NemoWindowSlot *slot)
     nemo_window_sync_bookmark_action (window);
 	nemo_window_pane_sync_location_widgets (slot->pane);
 	nemo_window_pane_sync_search_widgets (slot->pane);
+	nemo_window_sync_thumbnail_action(window);
 
 	if (slot->viewed_file != NULL) {
 		nemo_window_sync_view_type (window);
@@ -549,6 +550,16 @@ nemo_window_slot_update_icon (NemoWindowSlot *slot)
 
         nemo_icon_info_unref (info);
 	}
+}
+
+void
+nemo_window_slot_set_show_thumbnails (NemoWindowSlot *slot,
+                                      gboolean show_thumbnails)
+{
+  NemoDirectory *directory;
+  
+  directory = nemo_directory_get (slot->location);
+  nemo_directory_set_show_thumbnails(directory, show_thumbnails);
 }
 
 void

--- a/src/nemo-window-slot.h
+++ b/src/nemo-window-slot.h
@@ -188,4 +188,6 @@ void nemo_window_slot_clear_back_list    (NemoWindowSlot *slot);
 
 void nemo_window_slot_check_bad_cache_bar (NemoWindowSlot *slot);
 
+void nemo_window_slot_set_show_thumbnails (NemoWindowSlot *slot,
+                                           gboolean show_thumbnails);
 #endif /* NEMO_WINDOW_SLOT_H */


### PR DESCRIPTION
This adds the ability to toggle thumbnails for a specific folder, not only globally.
If it's set for the current folder, this setting takes precedence over the global setting.
It gets reset on "reset view to defaults".