### PR TITLE
Prefer XDS Protocol Type over _NETSCAPE_URL to make DnD work in Firefox.

### DIFF
--- a/libnemo-private/nemo-icon-dnd.c
+++ b/libnemo-private/nemo-icon-dnd.c
@@ -70,10 +70,11 @@ static const GtkTargetEntry drag_types [] = {
 
 static const GtkTargetEntry drop_types [] = {
 	{ (char *)NEMO_ICON_DND_GNOME_ICON_LIST_TYPE, 0, NEMO_ICON_DND_GNOME_ICON_LIST },
+	/* prefer XDS Protocol Type over "_NETSCAPE_URL" to make DnD work in Firefox. */
+	{ (char *)NEMO_ICON_DND_XDNDDIRECTSAVE_TYPE, 0, NEMO_ICON_DND_XDNDDIRECTSAVE },
 	/* prefer "_NETSCAPE_URL" over "text/uri-list" to satisfy web browsers. */
 	{ (char *)NEMO_ICON_DND_NETSCAPE_URL_TYPE, 0, NEMO_ICON_DND_NETSCAPE_URL },
 	{ (char *)NEMO_ICON_DND_URI_LIST_TYPE, 0, NEMO_ICON_DND_URI_LIST },
-	{ (char *)NEMO_ICON_DND_XDNDDIRECTSAVE_TYPE, 0, NEMO_ICON_DND_XDNDDIRECTSAVE }, /* XDS Protocol Type */
 	{ (char *)NEMO_ICON_DND_RAW_TYPE, 0, NEMO_ICON_DND_RAW },
 	/* Must be last: */
 	{ (char *)NEMO_ICON_DND_ROOTWINDOW_DROP_TYPE,  0, NEMO_ICON_DND_ROOTWINDOW_DROP }

--- a/libnemo-private/nemo-tree-view-drag-dest.c
+++ b/libnemo-private/nemo-tree-view-drag-dest.c
@@ -87,10 +87,11 @@ G_DEFINE_TYPE (NemoTreeViewDragDest, nemo_tree_view_drag_dest,
 
 static const GtkTargetEntry drag_types [] = {
 	{ (char *)NEMO_ICON_DND_GNOME_ICON_LIST_TYPE, 0, NEMO_ICON_DND_GNOME_ICON_LIST },
+	/* prefer XDS Protocol Type over "_NETSCAPE_URL" to make DnD work in Firefox. */
+	{ (char *)NEMO_ICON_DND_XDNDDIRECTSAVE_TYPE, 0, NEMO_ICON_DND_XDNDDIRECTSAVE },
 	/* prefer "_NETSCAPE_URL" over "text/uri-list" to satisfy web browsers. */
 	{ (char *)NEMO_ICON_DND_NETSCAPE_URL_TYPE, 0, NEMO_ICON_DND_NETSCAPE_URL },
 	{ (char *)NEMO_ICON_DND_URI_LIST_TYPE, 0, NEMO_ICON_DND_URI_LIST },
-	{ (char *)NEMO_ICON_DND_XDNDDIRECTSAVE_TYPE, 0, NEMO_ICON_DND_XDNDDIRECTSAVE }, /* XDS Protocol Type */
 	{ (char *)NEMO_ICON_DND_RAW_TYPE, 0, NEMO_ICON_DND_RAW }
 };
 


### PR DESCRIPTION
This fixes #407. I verified that this enables dragging images from Firefox Nightly to this build of nemo.