### PR TITLE
desktop/extension config: remove incorrect tooltips

### DIFF
--- a/gresources/nemo-desktop-overlay.glade
+++ b/gresources/nemo-desktop-overlay.glade
@@ -693,7 +693,6 @@
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
                                                     <property name="receives_default">True</property>
-                                                    <property name="uri">http://glade.gnome.org</property>
                                                     <signal name="activate-link" handler="on_view_prefs_link_button_activate_link" swapped="no"/>
                                                     <signal name="clicked" handler="on_view_prefs_link_button_clicked" swapped="no"/>
                                                   </object>
@@ -885,7 +884,6 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="relief">none</property>
-                        <property name="uri">http://null</property>
                         <signal name="activate-link" handler="on_disabled_view_link_button_activate_link" swapped="no"/>
                         <signal name="clicked" handler="on_disabled_view_link_button_clicked" swapped="no"/>
                       </object>

--- a/src/nemo-desktop-overlay.c
+++ b/src/nemo-desktop-overlay.c
@@ -454,8 +454,9 @@ nemo_desktop_overlay_init (NemoDesktopOverlay *overlay)
         widget = GTK_WIDGET (nemo_desktop_preferences_new ());
         gtk_box_pack_start (GTK_BOX (prefs_box), widget, TRUE, TRUE, 0);
 
-        widget = gtk_link_button_new_with_label ("http://null",
+        widget = gtk_link_button_new_with_label ("",
                                                _("Current Monitor Preferences"));
+        gtk_widget_set_tooltip_text (widget, "");
 
         g_signal_connect (widget,
                           "clicked",

--- a/src/nemo-extension-config-widget.c
+++ b/src/nemo-extension-config-widget.c
@@ -281,7 +281,7 @@ refresh_widget (NemoExtensionConfigWidget *widget)
             gtk_box_pack_start (GTK_BOX (box), w, FALSE, FALSE, 6);
 
             if (proxy->config_exec != NULL) {
-                button = gtk_link_button_new_with_label ("uri://dummy", _("Configure"));
+                button = gtk_link_button_new_with_label ("", _("Configure"));
                 g_signal_connect (button, "activate-link", G_CALLBACK (on_config_clicked), proxy);
 
                 gtk_box_pack_end (GTK_BOX (box), button, FALSE, FALSE, 2);


### PR DESCRIPTION
It was showing a URL for the desktop settings link's tooltip, and
we're not actually using any URLs for these.

![screenshot from 2018-11-13 16-15-59](https://user-images.githubusercontent.com/11601860/48457486-c52d3980-e777-11e8-89c4-4393584d8ddf.png)
