### PR TITLE
Add Move to Trash confirmation option

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1240,6 +1240,22 @@
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">6</property>
                                         <child>
+                                          <object class="GtkCheckButton" id="trash_confirm_move_checkbutton">
+                                            <property name="label" translatable="yes">Ask before moving files to the Trash</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="trash_confirm_checkbutton">
                                             <property name="label" translatable="yes">Ask before _emptying the Trash or deleting files</property>
                                             <property name="visible">True</property>
@@ -1252,7 +1268,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">0</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1268,7 +1284,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1283,7 +1299,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">2</property>
+                                            <property name="position">3</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -31,6 +31,7 @@
 G_BEGIN_DECLS
 
 /* Trash options */
+#define NEMO_PREFERENCES_CONFIRM_MOVE_TO_TRASH	"confirm-move-to-trash"
 #define NEMO_PREFERENCES_CONFIRM_TRASH			"confirm-trash"
 #define NEMO_PREFERENCES_ENABLE_DELETE			"enable-delete"
 #define NEMO_PREFERENCES_SWAP_TRASH_DELETE      "swap-trash-delete"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -171,6 +171,11 @@
       <summary>Show warning when opening as root</summary>
       <description>If set to true, then Nemo show warning message when run Nemo as root user.</description>
     </key>
+    <key name="confirm-move-to-trash" type="b">
+      <default>false</default>
+      <summary>Whether to ask for confirmation when moving files to Trash</summary>
+      <description>If set to true, then Nemo will ask for confirmation when  you attempt to move files to the Trash.</description>
+    </key>
     <key name="confirm-trash" type="b">
       <default>true</default>
       <summary>Whether to ask for confirmation when deleting files, or emptying Trash</summary>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -60,6 +60,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LABELS_BESIDE_ICONS_WIDGET "labels_beside_icons_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_ALL_COLUMNS_SAME_WIDTH "all_columns_same_width_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_BROWSER_WIDGET "always_use_browser_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_MOVE_WIDGET "trash_confirm_move_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_WIDGET "trash_confirm_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_DELETE_WIDGET "trash_delete_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SWAP_TRASH_DELETE "swap_trash_binding_checkbutton"
@@ -863,6 +864,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 	bind_builder_bool_inverted (builder, nemo_preferences,
 				    NEMO_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_BROWSER_WIDGET,
 				    NEMO_PREFERENCES_ALWAYS_USE_BROWSER);
+	bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_MOVE_WIDGET,
+			   NEMO_PREFERENCES_CONFIRM_MOVE_TO_TRASH);
 	bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_WIDGET,
 			   NEMO_PREFERENCES_CONFIRM_TRASH);


### PR DESCRIPTION
First of all, thanks for the Linux Mint 19.1/Nemo 4.0.6 release.
I just switched over from Win10 to Mint Cinnamon, and find that I also missed the "Move to Trash" confirmation (like the others did in #1135).
#### 1. "Move to Trash confirmation" option
So this is my attempt to implement the Move to Trash confirmation dialog: 
![move-to-trash-confirm](https://user-images.githubusercontent.com/10971704/50547401-e38dbc80-0c73-11e9-8df7-18af34d8f2fd.png)
(which is largely a replicate of the confirm delete dialog)

It's configurable with the first option under Trash in Preferences (default to off): 
> Confirm before moving files to the Trash

![trash-options](https://user-images.githubusercontent.com/10971704/50547436-45e6bd00-0c74-11e9-8f71-fb85ec455767.png)

#### 2. "Use safe defaults" sub-option for deleting files and emptying trash confirmation
While implementing the Move to Trash confirmation dialog above, I came across the following stanza in [GNOME HIG](
https://developer.gnome.org/hig/stable/dialogs.html.en):
> **Default action and escape**
> Assign the return key to activate the primary affirmative button in a dialog (for example Print in a print dialog). This is called the default action, and is indicated by a different visual style. *Do not make a button the default if its action is irreversible, destructive or otherwise inconvenient to the user.* [My emphasis]   If there is no appropriate button to designate as the default button, do not set one.

which makes me wonder whether buttons like *Empty Trash* and *Delete* should be made the default.

Turns out a [question](https://ux.stackexchange.com/questions/33275/which-button-should-get-the-focus-at-delete-dialogs) had been asked squarely on this (tl; dr: the 'answer' suggests in effect the affirmative button is more convenient than 'harmful' in light of the user's intention to initiate the action in the first place).

Still, to me it seems actions like *Empty Trash* and *Delete* are fairly irreversible; (and I didn't seem to find a way to set no default button), so I added a sub-option under "Ask before emptying the Trash or deleting files" to change the default button during confirmation to the negative (like *Cancel*) (so, at the risk of slight inconvenience, requires the user's mousing over or an extra Tab to show intention).

Of course, both the option and the sub-option are optional (and disabled by default).  I've also added a tooltip to the sub-option, to provide some (hopefully) expanatory text.

***

Sorry for the lengthy post.  (This's actually my first time submitting patches.)

Any feedback is welcome!   I'm more than happy to modify or improve the patch based on your feedback.

Thank you very much.

