### PR TITLE
[WIP] Nemo actions: Add support for exec condition

### DIFF
--- a/files/usr/share/nemo/actions/sample.nemo_action
+++ b/files/usr/share/nemo/actions/sample.nemo_action
@@ -3,13 +3,11 @@
 #############################################
 #### DEBUGGING:
 ####
-#### Run Nemo with the environment
-#### variable NEMO_ACTION_VERBOSE
-#### set to get useful log output
-#### for debugging your actions
+#### Run Nemo in debug mode using with
+###  NEMO_DEBUG set to include 'Actions'
 ####
 #### i.e.    $ nemo --quit
-####         $ NEMO_ACTION_VERBOSE=1 nemo
+####         $ NEMO_DEBUG=Actions nemo --debug
 #############################################
 
 # Whether this action is active.  For troubleshooting.
@@ -88,6 +86,8 @@ Extensions=any;
 #     "gsettings <schema> <boolean key>"  is true
 #     "gsettings <schema> <key> <key-type> <[eq|ne|gt|lt]> <value>"
 #     "dbus <name>" exists
+#     "exec <program>" run program and check its exit code (0 is pass, non-0 is fail).
+#                      Enclose in < > if the program resides in the action's folder.
 
 #Conditions=desktop;
 

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1618,6 +1618,48 @@ get_gsettings_satisfied (NemoAction *action)
 }
 
 static gboolean
+check_exec_condition (NemoAction *action, const gchar *condition, GList *selection)
+{
+    gchar **split = g_strsplit (condition, " ", 2);
+    char *path;
+    char *command;
+    NemoFile *file;
+    int return_code;
+
+    if (g_strv_length (split) != 2) {
+        g_strfreev (split);
+        return FALSE;
+    }
+
+    if (g_strcmp0 (split[0], "exec") != 0) {
+        g_strfreev (split);
+        return FALSE;
+    }
+
+    if (selection && g_list_length (selection) > 0) {
+        file = NEMO_FILE (selection->data);
+        path = nemo_file_get_path (file);
+        command = g_strdup_printf ("%s '%s'", split[1], path);
+        g_free (path);
+    }
+    else {
+      command = g_strdup (split[1]);
+    }
+    g_strfreev (split);
+
+    return_code = system (command);
+    printf ("%s returned %d\n", command, return_code);
+    g_free (command);
+
+    if (return_code == 0) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+}
+
+static gboolean
 get_is_dir (NemoFile *file)
 {
     gboolean ret = FALSE;
@@ -1712,6 +1754,8 @@ nemo_action_get_visibility (NemoAction *action,
                     }
                 }
                 condition_type_show = is_removable;
+            } else if (g_str_has_prefix (condition, "exec")) {
+                condition_type_show = check_exec_condition (action, condition, selection);
             }
 
             if (!condition_type_show)


### PR DESCRIPTION
The idea is to make it possible for an action to specify a condition which runs a command.

Say we want a "Set as wallpaper" action but only for pictures which dimensions are more than 1000x1000px. We can write a /usr/bin/check-picture-is-big program which calculates the dimensions of the selected picture and returns 0 if it's 1000x1000px or more, or 1 otherwise.

This PR adds the ability for the action to specify:

`Conditions=exec /usr/bin/check-picture-is-big %f`

TODO:

 - [x] Optimize action visibility check to only run exec when everything else matches
 - [x] Support multiple selection
 - [x] Support using %F and all, within the exec condition
 - [x] Review performance and eventual memory leaks
 - [x] Support local path (to be able to place commands/scripts in the same directory as the action file)?

