### PR TITLE
[WIP] Settings inheritance for thumbnailing and view type

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -318,6 +318,9 @@
         <col id="0" translatable="yes">Per Folder</col>
       </row>
       <row>
+        <col id="0" translatable="yes">Per Folder - Inherit From Parent</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">Never</col>
       </row>
     </data>
@@ -449,6 +452,22 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="inherit_view_checkbox">
+                                            <property name="label" translatable="yes">_Inherit view type from parent</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkBox" id="hbox11">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
@@ -490,7 +509,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -506,7 +525,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">2</property>
+                                            <property name="position">3</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -2195,6 +2214,23 @@
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">6</property>
                                         <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Choose how to use thumbnails.
+If set to "Per folder", each folder has its own setting.
+If set to "Per Folder - Inherit from Parent", folders without an own setting inherit it from their parents.&lt;/i&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkBox" id="hbox20">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
@@ -2236,7 +2272,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">0</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -2281,7 +2317,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -64,6 +64,12 @@ nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void)
 	return g_strdup (viewer_iid);
 }
 
+gboolean
+nemo_global_preferences_get_inherit_folder_viewer_preference ()
+{
+		return g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER);
+}
+
 char *
 nemo_global_preferences_get_desktop_iid (void)
 {

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -114,6 +114,7 @@ typedef enum
 
 /* The default folder viewer - one of the two enums below */
 #define NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER		"default-folder-viewer"
+#define NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER		"inherit-folder-viewer"
 
 #define NEMO_PREFERENCES_SHOW_FULL_PATH_TITLES      "show-full-path-titles"
 
@@ -187,7 +188,8 @@ typedef enum
 	NEMO_SPEED_TRADEOFF_ALWAYS,
 	NEMO_SPEED_TRADEOFF_LOCAL_ONLY,
     NEMO_SPEED_TRADEOFF_NEVER,
-    NEMO_SPEED_TRADEOFF_PER_FOLDER
+    NEMO_SPEED_TRADEOFF_PER_FOLDER,
+    NEMO_SPEED_TRADEOFF_PER_FOLDER_WITH_INHERITANCE
 } NemoSpeedTradeoffValue;
 
 #define NEMO_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS "show-directory-item-counts"
@@ -266,6 +268,7 @@ typedef enum
 void nemo_global_preferences_init                      (void);
 void nemo_global_preferences_finalize                  (void);
 char *nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void);
+gboolean nemo_global_preferences_get_inherit_folder_viewer_preference ();
 char *nemo_global_preferences_get_desktop_iid (void);
 gboolean nemo_global_preferences_get_ignore_view_metadata (void);
 gint nemo_global_preferences_get_tooltip_flags (void);

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -4,6 +4,7 @@
     <value nick="local-only" value="1"/>
     <value nick="never" value="2"/>
     <value nick="per-folder" value="3"/>
+    <value nick="per-folder-with-inheritance" value="4"/>
   </enum>
 
   <enum id="org.nemo.ClickPolicy">
@@ -265,6 +266,11 @@
       <default>'icon-view'</default>
       <summary>Default folder viewer</summary>
       <description>When a folder is visited this viewer is used unless you have selected another view for that particular folder. Possible values are "list-view", "icon-view" and "compact-view".</description>
+    </key>
+    <key name="inherit-folder-viewer" type="b">
+      <default>false</default>
+      <summary>Inherit the view type (icon, compact, list) from parent to children</summary>
+      <description>When a folder is visited the viewer is inherited from that folder's parent unless you have selected another view for that particular folder.</description>
     </key>
     <key name="date-format" enum="org.nemo.DateFormat">
       <default>'locale'</default>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -44,6 +44,7 @@
 
 /* string enum preferences */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET "default_view_combobox"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_VIEW_WIDGET "inherit_view_checkbox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_ICON_VIEW_ZOOM_WIDGET "icon_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_COMPACT_VIEW_ZOOM_WIDGET "compact_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LIST_VIEW_ZOOM_WIDGET "list_view_zoom_combobox"
@@ -152,6 +153,7 @@ static const char * const preview_image_values[] = {
     "always",
     "local-only",
     "per-folder",
+    "per-folder-with-inheritance",
     "never",
     NULL
 };
@@ -883,7 +885,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET,
 			   NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER,
 			   (const char **) default_view_values);
-	bind_builder_enum (builder, nemo_icon_view_preferences,
+	bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_VIEW_WIDGET,
+			   NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER);
+  bind_builder_enum (builder, nemo_icon_view_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_ICON_VIEW_ZOOM_WIDGET,
 			   NEMO_PREFERENCES_ICON_VIEW_DEFAULT_ZOOM_LEVEL,
 			   (const char **) zoom_values);

--- a/src/nemo-toolbar.c
+++ b/src/nemo-toolbar.c
@@ -101,6 +101,7 @@ toolbar_update_appearance (NemoToolbar *self)
 	GtkWidget *widgetitem;
 	gboolean icon_toolbar;
 	gboolean show_location_entry;
+  gint speed_tradeoff;
 
     nemo_toolbar_update_root_state (self);
 
@@ -186,8 +187,9 @@ toolbar_update_appearance (NemoToolbar *self)
     else {gtk_widget_show (GTK_WIDGET(widgetitem));}
     
     widgetitem = self->priv->show_thumbnails_button;
-    icon_toolbar = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS) ==
-                    NEMO_SPEED_TRADEOFF_PER_FOLDER;
+    speed_tradeoff = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS);
+    icon_toolbar = speed_tradeoff == NEMO_SPEED_TRADEOFF_PER_FOLDER ||
+                   speed_tradeoff == NEMO_SPEED_TRADEOFF_PER_FOLDER_WITH_INHERITANCE;
     if ( icon_toolbar == FALSE ) { gtk_widget_hide (widgetitem); }
     else {gtk_widget_show (GTK_WIDGET(widgetitem));}
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -519,6 +519,7 @@ nemo_view_reset_to_defaults (NemoView *view)
 
     file = view->details->slot->viewed_file;
     nemo_file_set_metadata(file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, NULL, NULL);
+    nemo_file_set_metadata(file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL, NULL);
     emit_change_signals_for_all_files_in_all_directories ();
 }
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -505,22 +505,25 @@ static void
 nemo_view_reset_to_defaults (NemoView *view)
 {
     NemoFile *file;
+    NemoWindow *window;
     g_return_if_fail (NEMO_IS_VIEW (view));
 
     NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->reset_to_defaults (view);
 
     gboolean show_hidden = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
 
+    window = view->details->window;
     if (show_hidden) {
-        nemo_window_set_hidden_files_mode (view->details->window, NEMO_WINDOW_SHOW_HIDDEN_FILES_ENABLE);
+        nemo_window_set_hidden_files_mode (window, NEMO_WINDOW_SHOW_HIDDEN_FILES_ENABLE);
     } else {
-        nemo_window_set_hidden_files_mode (view->details->window, NEMO_WINDOW_SHOW_HIDDEN_FILES_DISABLE);
+        nemo_window_set_hidden_files_mode (window, NEMO_WINDOW_SHOW_HIDDEN_FILES_DISABLE);
     }
 
     file = view->details->slot->viewed_file;
     nemo_file_set_metadata(file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, NULL, NULL);
     nemo_file_set_metadata(file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL, NULL);
-    emit_change_signals_for_all_files_in_all_directories ();
+
+    gtk_action_activate (gtk_action_group_get_action (nemo_window_get_main_action_group (window), NEMO_ACTION_RELOAD));
 }
 
 static gboolean

--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -879,9 +879,28 @@ got_file_info_for_view_selection_callback (NemoFile *file,
 		mimetype = nemo_file_get_mime_type (file);
 
 		/* Look in metadata for view */
-		view_id = nemo_global_preferences_get_ignore_view_metadata () ? g_strdup (nemo_window_get_ignore_meta_view_id (window)) :
-                                                                        nemo_file_get_metadata (file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
-		if (view_id != NULL &&
+        if (nemo_global_preferences_get_inherit_folder_viewer_preference ()) {
+            if (nemo_global_preferences_get_ignore_view_metadata ()) {
+            view_id = g_strdup (nemo_window_get_ignore_meta_view_id (window));
+            } else {
+                parent_file = file;
+                nemo_file_ref(parent_file); // Do this once for the initial file
+                while (parent_file) {
+                    view_id = nemo_file_get_metadata (parent_file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
+                    nemo_file_unref(parent_file);
+                    if (view_id != NULL) {
+                        parent_file = NULL;
+                    } else {
+                        parent_file = nemo_file_get_parent (parent_file);
+                    }
+                }
+            }
+        } else {
+            view_id = nemo_global_preferences_get_ignore_view_metadata () ? g_strdup (nemo_window_get_ignore_meta_view_id (window)) :
+                                                                            nemo_file_get_metadata (file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
+        }
+
+        if (view_id != NULL &&
 		    !nemo_view_factory_view_supports_uri (view_id,
 							      location,
 							      nemo_file_get_file_type (file),

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1667,7 +1667,7 @@ show_thumbnails_enum_get_mapper (GValue   *value,
     str = g_variant_get_string (variant, NULL);
 
     g_value_set_boolean (value,
-                         g_strcmp0 (str, "per-folder") == 0);
+                         g_str_has_prefix (str, "per-folder"));
 
     return TRUE;
 }

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1463,10 +1463,7 @@ sync_thumbnail_action_callback (NemoFile *file,
         gboolean show_thumbnails;
 
         pane = nemo_window_get_active_pane(window);
-        show_thumbnails = nemo_file_get_boolean_metadata(
-                file,
-                NEMO_METADATA_KEY_SHOW_THUMBNAILS,
-                FALSE);
+        show_thumbnails = nemo_file_should_show_thumbnail (file);
 
         toolbar_set_show_thumbnails_button (show_thumbnails, pane);
         menu_set_show_thumbnails_action (show_thumbnails, window);


### PR DESCRIPTION
This adds settings to inherit the view type and thumbnailing setting from a parent.
If used, folders inherit those settings from their parent, if said folder does not have an own setting for it.
This also fixes resetting the view.