### PR TITLE
Settings inheritance for thumbnailing and view type - Take 2

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -28,6 +28,11 @@
     <property name="can_focus">False</property>
     <property name="icon_name">view-compact-symbolic</property>
   </object>
+  <object class="GtkImage" id="image14">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">xapp-prefs-preview-symbolic</property>
+  </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -309,16 +314,13 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Always</col>
+        <col id="0" translatable="yes">Yes</col>
       </row>
       <row>
         <col id="0" translatable="yes">Local Files Only</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Per Folder</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Never</col>
+        <col id="0" translatable="yes">No</col>
       </row>
     </data>
   </object>
@@ -449,6 +451,22 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="inherit_view_checkbox">
+                                            <property name="label" translatable="yes">_Inherit view type from parent</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkBox" id="hbox11">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
@@ -490,7 +508,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -506,7 +524,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">2</property>
+                                            <property name="position">3</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -2240,6 +2258,22 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="inherit_show_thumbnails_checkbutton">
+                                            <property name="label" translatable="yes">_Inherit thumbnail visibility from parent</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkBox" id="hbox21">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
@@ -2281,7 +2315,7 @@
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3146,7 +3180,41 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <placeholder/>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkToggleButton" id="show_show_thumbnails_icon_toolbar_togglebutton">
+                                            <property name="name">show_show_thumbnails_icon_toolbar_togglebutton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">True</property>
+                                            <property name="image">image14</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Show Thumbnails</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">6</property>
+                                      </packing>
                                     </child>
                                   </object>
                                   <packing>

--- a/libnemo-private/nemo-directory.c
+++ b/libnemo-private/nemo-directory.c
@@ -1741,7 +1741,7 @@ nemo_directory_set_show_thumbnails (NemoDirectory         *directory,
   
   file = nemo_file_get(directory->details->location);
   nemo_file_set_boolean_metadata (file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, FALSE, show_thumbnails);
-  emit_change_signals_for_all_files(directory);
+  nemo_directory_force_reload (directory);
 }
 
 #if !defined (NEMO_OMIT_SELF_CHECK)

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4237,53 +4237,72 @@ gboolean
 nemo_file_should_show_thumbnail (NemoFile *file)
 {
 	GFilesystemPreviewType use_preview;
-    gboolean show_dir_thumbnails;
     NemoFile *dir;
+    char* metadata_str = NULL;
 
-    if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
+    if (!NEMO_IS_FILE (file)) {
         return FALSE;
     }
 
 	use_preview = nemo_file_get_filesystem_use_preview (file);
-    dir = nemo_file_is_directory(file) ? file : nemo_file_get_parent(file);
+    if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_NEVER) {
+        /* file system says to never thumbnail anything */
+		return FALSE;
+	}
     
-    show_dir_thumbnails = nemo_file_get_boolean_metadata (dir,
-                                                          NEMO_METADATA_KEY_SHOW_THUMBNAILS,
-                                                          FALSE);
-
-	/* If the thumbnail has already been created, don't care about the size
-	 * of the original file.
-	 */
+    /* Only care about the file size, if the thumbnail has not been created yet */
 	if (file->details->thumbnail_path == NULL &&
 	    nemo_file_get_size (file) > cached_thumbnail_limit) {
 		return FALSE;
 	}
 
-    if (file->details->thumbnail_access_problem)
+    if (file->details->thumbnail_access_problem) {
         return FALSE;
+    }
 
-    if (show_image_thumbs == NEMO_SPEED_TRADEOFF_ALWAYS) {
-		if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_NEVER) {
-			return FALSE;
-		} else {
-			return TRUE;
-		}
-	} else if (show_image_thumbs == NEMO_SPEED_TRADEOFF_PER_FOLDER) {
-		return show_dir_thumbnails;
-	} else {
-		if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_NEVER) {
-			/* file system says to never thumbnail anything */
-			return FALSE;
-		} else if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_IF_LOCAL) {
+    if (nemo_global_preferences_get_ignore_view_metadata ()) {
+        /* Use global preference */
+        if (show_image_thumbs == NEMO_SPEED_TRADEOFF_ALWAYS) {
+            return TRUE;
+        }
+        if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
+            return FALSE;
+        }
+        if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_IF_LOCAL) {
 			/* file system says we should treat file as if it's local */
 			return TRUE;
 		} else {
 			/* only local files */
 			return nemo_file_is_local (file);
 		}
-	}
+    }
 
-	return FALSE;
+    dir = nemo_file_is_directory(file) ? file : nemo_file_get_parent(file);
+    if (!g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS)) {
+        return nemo_file_get_boolean_metadata(dir, NEMO_METADATA_KEY_SHOW_THUMBNAILS, FALSE);
+    }
+
+    while (dir != NULL) {
+        metadata_str = nemo_file_get_metadata(dir,
+                                            NEMO_METADATA_KEY_SHOW_THUMBNAILS,
+                                            NULL);
+        if (metadata_str == NULL) { // do this here to avoid string comparisons with a NULL string
+            dir = nemo_file_get_parent(dir);
+        }
+        else if (g_ascii_strcasecmp (metadata_str, "true") == 0) {
+            g_free(metadata_str);
+            return TRUE;
+        }
+        else if (g_ascii_strcasecmp (metadata_str, "false") == 0) {
+            g_free(metadata_str);
+            return FALSE;
+        }
+        else {
+            g_free(metadata_str);
+            dir = nemo_file_get_parent(dir);
+        }
+    }
+    return FALSE;
 }
 
 void
@@ -8590,6 +8609,10 @@ nemo_file_class_init (NemoFileClass *class)
 	show_thumbnails_changed_callback (NULL);
 	g_signal_connect_swapped (nemo_preferences,
 				  "changed::" NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
+				  G_CALLBACK (show_thumbnails_changed_callback),
+				  NULL);
+    g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS,
 				  G_CALLBACK (show_thumbnails_changed_callback),
 				  NULL);
 

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4260,49 +4260,59 @@ nemo_file_should_show_thumbnail (NemoFile *file)
         return FALSE;
     }
 
-    if (nemo_global_preferences_get_ignore_view_metadata ()) {
-        /* Use global preference */
-        if (show_image_thumbs == NEMO_SPEED_TRADEOFF_ALWAYS) {
-            return TRUE;
+    if (!nemo_global_preferences_get_ignore_view_metadata ()) {
+        dir = nemo_file_is_directory(file) ? file : nemo_file_get_parent(file);
+        if (g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS)) {
+            while (dir != NULL) {
+                metadata_str = nemo_file_get_metadata(dir,
+                                                    NEMO_METADATA_KEY_SHOW_THUMBNAILS,
+                                                    NULL);
+                if (metadata_str == NULL) { // do this here to avoid string comparisons with a NULL string
+                    dir = nemo_file_get_parent(dir);
+                }
+                else if (g_ascii_strcasecmp (metadata_str, "true") == 0) {
+                    g_free(metadata_str);
+                    return TRUE;
+                }
+                else if (g_ascii_strcasecmp (metadata_str, "false") == 0) {
+                    g_free(metadata_str);
+                    return FALSE;
+                }
+                else {
+                    g_free(metadata_str);
+                    dir = nemo_file_get_parent(dir);
+                }
+            }
+        } else {
+            metadata_str = nemo_file_get_metadata(dir,
+                                                NEMO_METADATA_KEY_SHOW_THUMBNAILS,
+                                                NULL);
+            if (metadata_str != NULL ) {
+                if (g_ascii_strcasecmp (metadata_str, "true") == 0) {
+                    g_free(metadata_str);
+                    return TRUE;
+                }
+                else if (g_ascii_strcasecmp (metadata_str, "false") == 0) {
+                    g_free(metadata_str);
+                    return FALSE;
+                }
+            }
         }
-        if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
-            return FALSE;
-        }
-        if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_IF_LOCAL) {
-			/* file system says we should treat file as if it's local */
-			return TRUE;
-		} else {
-			/* only local files */
-			return nemo_file_is_local (file);
-		}
     }
 
-    dir = nemo_file_is_directory(file) ? file : nemo_file_get_parent(file);
-    if (!g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS)) {
-        return nemo_file_get_boolean_metadata(dir, NEMO_METADATA_KEY_SHOW_THUMBNAILS, FALSE);
+    /* Use global preference */
+    if (show_image_thumbs == NEMO_SPEED_TRADEOFF_ALWAYS) {
+        return TRUE;
     }
-
-    while (dir != NULL) {
-        metadata_str = nemo_file_get_metadata(dir,
-                                            NEMO_METADATA_KEY_SHOW_THUMBNAILS,
-                                            NULL);
-        if (metadata_str == NULL) { // do this here to avoid string comparisons with a NULL string
-            dir = nemo_file_get_parent(dir);
-        }
-        else if (g_ascii_strcasecmp (metadata_str, "true") == 0) {
-            g_free(metadata_str);
-            return TRUE;
-        }
-        else if (g_ascii_strcasecmp (metadata_str, "false") == 0) {
-            g_free(metadata_str);
-            return FALSE;
-        }
-        else {
-            g_free(metadata_str);
-            dir = nemo_file_get_parent(dir);
-        }
+    if (show_image_thumbs == NEMO_SPEED_TRADEOFF_NEVER) {
+        return FALSE;
     }
-    return FALSE;
+    if (use_preview == G_FILESYSTEM_PREVIEW_TYPE_IF_LOCAL) {
+        /* file system says we should treat file as if it's local */
+        return TRUE;
+    }
+    /* local files is the only left to check */
+    return nemo_file_is_local (file);
 }
 
 void

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -64,6 +64,12 @@ nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void)
 	return g_strdup (viewer_iid);
 }
 
+gboolean
+nemo_global_preferences_get_inherit_folder_viewer_preference (void)
+{
+		return g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER);
+}
+
 char *
 nemo_global_preferences_get_desktop_iid (void)
 {

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -92,6 +92,7 @@ typedef enum
 #define NEMO_PREFERENCES_SHOW_LIST_VIEW_ICON_TOOLBAR   "show-list-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR   "show-compact-view-icon-toolbar"
 #define NEMO_PREFERENCES_SHOW_ROOT_WARNING                "show-root-warning"
+#define NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR     "show-show-thumbnails-toolbar"
 
 /* Which views should be displayed for new windows */
 #define NEMO_WINDOW_STATE_START_WITH_STATUS_BAR		"start-with-status-bar"
@@ -114,6 +115,7 @@ typedef enum
 
 /* The default folder viewer - one of the two enums below */
 #define NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER		"default-folder-viewer"
+#define NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER		"inherit-folder-viewer"
 
 #define NEMO_PREFERENCES_SHOW_FULL_PATH_TITLES      "show-full-path-titles"
 
@@ -186,13 +188,13 @@ typedef enum
 {
 	NEMO_SPEED_TRADEOFF_ALWAYS,
 	NEMO_SPEED_TRADEOFF_LOCAL_ONLY,
-    NEMO_SPEED_TRADEOFF_NEVER,
-    NEMO_SPEED_TRADEOFF_PER_FOLDER
+    NEMO_SPEED_TRADEOFF_NEVER
 } NemoSpeedTradeoffValue;
 
 #define NEMO_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS "show-directory-item-counts"
 #define NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS	"show-image-thumbnails"
 #define NEMO_PREFERENCES_IMAGE_FILE_THUMBNAIL_LIMIT	"thumbnail-limit"
+#define NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS "inherit-show-thumbnails"
 
 typedef enum
 {
@@ -266,6 +268,7 @@ typedef enum
 void nemo_global_preferences_init                      (void);
 void nemo_global_preferences_finalize                  (void);
 char *nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void);
+gboolean nemo_global_preferences_get_inherit_folder_viewer_preference (void);
 char *nemo_global_preferences_get_desktop_iid (void);
 gboolean nemo_global_preferences_get_ignore_view_metadata (void);
 gint nemo_global_preferences_get_tooltip_flags (void);

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -3,7 +3,6 @@
     <value nick="always" value="0"/>
     <value nick="local-only" value="1"/>
     <value nick="never" value="2"/>
-    <value nick="per-folder" value="3"/>
   </enum>
 
   <enum id="org.nemo.ClickPolicy">
@@ -223,6 +222,11 @@
       <summary>When to show thumbnails of image files</summary>
       <description>Speed tradeoff for when to show an image file as a thumbnail. If set to "always" then always thumbnail,  even if the folder is on a remote server. If set to "local-only" then only show thumbnails for local file systems. If set to "never" then never bother to thumbnail images, just use a generic icon.</description>
     </key>
+    <key name="inherit-show-thumbnails" type="b">
+      <default>false</default>
+      <summary>Inherit thumbnail visibility from parent</summary>
+      <description>If set, folders will inherit their thumbnail visibility from their parents</description>
+    </key>
     <key name="thumbnail-limit" type="t">
       <default>1048576</default>
       <summary>Maximum image size for thumbnailing</summary>
@@ -265,6 +269,11 @@
       <default>'icon-view'</default>
       <summary>Default folder viewer</summary>
       <description>When a folder is visited this viewer is used unless you have selected another view for that particular folder. Possible values are "list-view", "icon-view" and "compact-view".</description>
+    </key>
+    <key name="inherit-folder-viewer" type="b">
+      <default>false</default>
+      <summary>Inherit the view type (icon, compact, list) from parent to children</summary>
+      <description>When a folder is visited the viewer is inherited from that folder's parent unless you have selected another view for that particular folder.</description>
     </key>
     <key name="date-format" enum="org.nemo.DateFormat">
       <default>'locale'</default>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -44,6 +44,7 @@
 
 /* string enum preferences */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET "default_view_combobox"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_VIEW_WIDGET "inherit_view_checkbox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_ICON_VIEW_ZOOM_WIDGET "icon_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_COMPACT_VIEW_ZOOM_WIDGET "compact_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LIST_VIEW_ZOOM_WIDGET "list_view_zoom_combobox"
@@ -79,6 +80,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ICON_VIEW_ICON_TOOLBAR_WIDGET "show_icon_view_icon_toolbar_togglebutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_LIST_VIEW_ICON_TOOLBAR_WIDGET "show_list_view_icon_toolbar_togglebutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_COMPACT_VIEW_ICON_TOOLBAR_WIDGET "show_compact_view_icon_toolbar_togglebutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SHOW_THUMBNAILS_ICON_TOOLBAR_WIDGET "show_show_thumbnails_icon_toolbar_togglebutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_FULL_PATH_IN_TITLE_BARS_WIDGET "show_full_path_in_title_bars_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_CLOSE_DEVICE_VIEW_ON_EJECT_WIDGET "close_device_view_on_eject_checkbutton"
@@ -90,6 +92,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_IN_TO_MENUS_WIDGET "places_in_to_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_SHOW_THUMBNAILS_WIDGET "inherit_show_thumbnails_checkbutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BULK_RENAME_WIDGET "bulk_rename_entry"
 
@@ -151,7 +154,6 @@ static const char * const date_format_values[] = {
 static const char * const preview_image_values[] = {
     "always",
     "local-only",
-    "per-folder",
     "never",
     NULL
 };
@@ -846,6 +848,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_COMPACT_VIEW_ICON_TOOLBAR_WIDGET,
 			   NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR);
+    bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SHOW_THUMBNAILS_ICON_TOOLBAR_WIDGET,
+			   NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR);
 
 	/* setup preferences */
 	bind_builder_bool (builder, nemo_icon_view_preferences,
@@ -878,6 +883,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 	bind_builder_bool (builder, nemo_tree_sidebar_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_TREE_VIEW_FOLDERS_WIDGET,
 			   NEMO_PREFERENCES_TREE_SHOW_ONLY_DIRECTORIES);
+  bind_builder_bool (builder, nemo_preferences,
+			   NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_VIEW_WIDGET,
+			   NEMO_PREFERENCES_INHERIT_FOLDER_VIEWER);
 
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET,
@@ -903,6 +911,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_IMAGE_WIDGET,
 			   NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
 			   (const char **) preview_image_values);
+    bind_builder_bool (builder, nemo_preferences,
+               NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_SHOW_THUMBNAILS_WIDGET,
+               NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS);
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_FOLDER_WIDGET,
 			   NEMO_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS,

--- a/src/nemo-toolbar.c
+++ b/src/nemo-toolbar.c
@@ -186,8 +186,7 @@ toolbar_update_appearance (NemoToolbar *self)
     else {gtk_widget_show (GTK_WIDGET(widgetitem));}
     
     widgetitem = self->priv->show_thumbnails_button;
-    icon_toolbar = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS) ==
-                    NEMO_SPEED_TRADEOFF_PER_FOLDER;
+    icon_toolbar = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR);
     if ( icon_toolbar == FALSE ) { gtk_widget_hide (widgetitem); }
     else {gtk_widget_show (GTK_WIDGET(widgetitem));}
 
@@ -475,6 +474,9 @@ nemo_toolbar_constructed (GObject *obj)
                   G_CALLBACK (toolbar_update_appearance), self);
     g_signal_connect_swapped (nemo_preferences,
                   "changed::" NEMO_PREFERENCES_SHOW_COMPACT_VIEW_ICON_TOOLBAR,
+                  G_CALLBACK (toolbar_update_appearance), self);
+    g_signal_connect_swapped (nemo_preferences,
+                  "changed::" NEMO_PREFERENCES_SHOW_SHOW_THUMBNAILS_TOOLBAR,
                   G_CALLBACK (toolbar_update_appearance), self);
     g_signal_connect_swapped (nemo_preferences,
                   "changed::" NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -505,21 +505,24 @@ static void
 nemo_view_reset_to_defaults (NemoView *view)
 {
     NemoFile *file;
+    NemoWindow *window;
     g_return_if_fail (NEMO_IS_VIEW (view));
 
     NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->reset_to_defaults (view);
 
     gboolean show_hidden = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_HIDDEN_FILES);
 
+    window = view->details->window;
     if (show_hidden) {
-        nemo_window_set_hidden_files_mode (view->details->window, NEMO_WINDOW_SHOW_HIDDEN_FILES_ENABLE);
+        nemo_window_set_hidden_files_mode (window, NEMO_WINDOW_SHOW_HIDDEN_FILES_ENABLE);
     } else {
-        nemo_window_set_hidden_files_mode (view->details->window, NEMO_WINDOW_SHOW_HIDDEN_FILES_DISABLE);
+        nemo_window_set_hidden_files_mode (window, NEMO_WINDOW_SHOW_HIDDEN_FILES_DISABLE);
     }
 
     file = view->details->slot->viewed_file;
     nemo_file_set_metadata(file, NEMO_METADATA_KEY_SHOW_THUMBNAILS, NULL, NULL);
-    emit_change_signals_for_all_files_in_all_directories ();
+    nemo_file_set_metadata(file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL, NULL);
+    gtk_action_activate (gtk_action_group_get_action (nemo_window_get_main_action_group (window), NEMO_ACTION_RELOAD));
 }
 
 static gboolean

--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -879,9 +879,28 @@ got_file_info_for_view_selection_callback (NemoFile *file,
 		mimetype = nemo_file_get_mime_type (file);
 
 		/* Look in metadata for view */
-		view_id = nemo_global_preferences_get_ignore_view_metadata () ? g_strdup (nemo_window_get_ignore_meta_view_id (window)) :
+		if (nemo_global_preferences_get_inherit_folder_viewer_preference ()) {
+        if (nemo_global_preferences_get_ignore_view_metadata ()) {
+        view_id = g_strdup (nemo_window_get_ignore_meta_view_id (window));
+        } else {
+            parent_file = file;
+            nemo_file_ref(parent_file); // Do this once for the initial file
+            while (parent_file) {
+                view_id = nemo_file_get_metadata (parent_file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
+                nemo_file_unref(parent_file);
+                if (view_id != NULL) {
+                    parent_file = NULL;
+                } else {
+                    parent_file = nemo_file_get_parent (parent_file);
+                }
+            }
+        }
+    } else {
+        view_id = nemo_global_preferences_get_ignore_view_metadata () ? g_strdup (nemo_window_get_ignore_meta_view_id (window)) :
                                                                         nemo_file_get_metadata (file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
-		if (view_id != NULL &&
+    }
+
+    if (view_id != NULL &&
 		    !nemo_view_factory_view_supports_uri (view_id,
 							      location,
 							      nemo_file_get_file_type (file),

--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -802,7 +802,7 @@ got_file_info_for_view_selection_callback (NemoFile *file,
 	char *mimetype;
 	NemoWindow *window;
 	NemoWindowSlot *slot;
-	NemoFile *viewed_file, *parent_file;
+	NemoFile *parent_file, *tmp;
 	GFile *location;
 	GMountOperation *mount_op;
 	MountNotMountedData *data;
@@ -887,11 +887,12 @@ got_file_info_for_view_selection_callback (NemoFile *file,
             nemo_file_ref(parent_file); // Do this once for the initial file
             while (parent_file) {
                 view_id = nemo_file_get_metadata (parent_file, NEMO_METADATA_KEY_DEFAULT_VIEW, NULL);
+                tmp = nemo_file_get_parent (parent_file);
                 nemo_file_unref(parent_file);
                 if (view_id != NULL) {
                     parent_file = NULL;
                 } else {
-                    parent_file = nemo_file_get_parent (parent_file);
+                    parent_file = tmp;
                 }
             }
         }
@@ -995,6 +996,7 @@ got_file_info_for_view_selection_callback (NemoFile *file,
 				nemo_window_pane_close_slot (slot->pane, slot);
 			} else {
 				/* We disconnected this, so we need to re-connect it */
+				NemoFile *viewed_file;
 				viewed_file = nemo_file_get (slot->location);
 				nemo_window_slot_set_viewed_file (slot, viewed_file);
 				nemo_file_monitor_add (viewed_file, &slot->viewed_file, 0);

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1694,21 +1694,6 @@ nemo_window_create_toolbar_action_group (NemoWindow *window)
 	return action_group;
 }
 
-static gboolean
-show_thumbnails_enum_get_mapper (GValue   *value,
-                                 GVariant *variant,
-                                 gpointer  user_data)
-{
-    const gchar *str;
-
-    str = g_variant_get_string (variant, NULL);
-
-    g_value_set_boolean (value,
-                         g_strcmp0 (str, "per-folder") == 0);
-
-    return TRUE;
-}
-
 static void
 window_menus_set_bindings (NemoWindow *window)
 {
@@ -1743,18 +1728,6 @@ window_menus_set_bindings (NemoWindow *window)
              action,
              "active",
              G_SETTINGS_BIND_DEFAULT);
-
-    action = gtk_action_group_get_action (action_group,
-                                          NEMO_ACTION_SHOW_THUMBNAILS);
-
-    g_settings_bind_with_mapping (nemo_preferences,
-                                  NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
-                                  action,
-                                  "visible",
-                                  G_SETTINGS_BIND_GET,
-                                  (GSettingsBindGetMapping) show_thumbnails_enum_get_mapper,
-                                  NULL,
-                                  NULL, NULL);
 
 	action = gtk_action_group_get_action (action_group,
 					      NEMO_ACTION_SHOW_HIDE_SIDEBAR);

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1463,10 +1463,7 @@ sync_thumbnail_action_callback (NemoFile *file,
         gboolean show_thumbnails;
 
         pane = nemo_window_get_active_pane(window);
-        show_thumbnails = nemo_file_get_boolean_metadata(
-                file,
-                NEMO_METADATA_KEY_SHOW_THUMBNAILS,
-                FALSE);
+        show_thumbnails = nemo_file_should_show_thumbnail (file);
 
         toolbar_set_show_thumbnails_button (show_thumbnails, pane);
         menu_set_show_thumbnails_action (show_thumbnails, window);

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1955,6 +1955,15 @@ nemo_window_init (NemoWindow *window)
 
 	/* Set initial window title */
 	gtk_window_set_title (GTK_WINDOW (window), _("Nemo"));
+
+    g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS,
+				  G_CALLBACK(nemo_window_sync_thumbnail_action),
+				  window);
+    g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_INHERIT_SHOW_THUMBNAILS,
+				  G_CALLBACK(nemo_window_sync_thumbnail_action),
+				  window);
 }
 
 static NemoIconInfo *


### PR DESCRIPTION
This adds settings to inherit the view type and thumbnailing setting from a parent.
If used, folders inherit those settings from their parent, if said folder does not have an own setting for it.
The per-folder-thumbnailing is reimplemented to respect the ignore-metadata setting.
This also fixes resetting the view.