### PR TITLE
Don't warn about thumbnail cache problems when thumbnails are disabled

### DIFF
--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -1968,10 +1968,13 @@ nemo_window_slot_queue_reload (NemoWindowSlot *slot,
 void
 nemo_window_slot_check_bad_cache_bar (NemoWindowSlot *slot)
 {
+    int show_image_thumbs;
     if (NEMO_IS_DESKTOP_WINDOW (nemo_window_slot_get_window (slot)))
         return;
 
-    if (nemo_application_get_cache_bad (nemo_application_get_singleton ()) &&
+    show_image_thumbs = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS);
+    if (show_image_thumbs != NEMO_SPEED_TRADEOFF_NEVER &&
+        nemo_application_get_cache_bad (nemo_application_get_singleton ()) &&
         !nemo_application_get_cache_problem_ignored (nemo_application_get_singleton ())) {
         if (slot->cache_bar != NULL) {
             gtk_widget_show (slot->cache_bar);


### PR DESCRIPTION
With this change, the warning about the problems with the thumbnail cache is only shown when thumbnails are enabled.

Usually, I set my thumbnail cache to read-only to prevent new thumbnails from being generated (due to privacy concerns). Dismissing the warning during every boot gets a bit tiring... :wink: 