### PR TITLE
nemo-mime-application-chooser.c: escape file names in Open With tab

### DIFF
--- a/libnemo-private/nemo-mime-application-chooser.c
+++ b/libnemo-private/nemo-mime-application-chooser.c
@@ -440,7 +440,7 @@ nemo_mime_application_chooser_apply_labels (NemoMimeApplicationChooser *chooser)
 		}
 
 		/* first %s is filename, second %s is mime-type description */
-		emname = g_strdup_printf ("<i>%s</i>", basename);
+		emname = g_markup_printf_escaped("<i>%s</i>", basename);
 		label = g_strdup_printf (_("Select an application in the list to open %s and other files of type \"%s\""),
 					 emname, description);
 


### PR DESCRIPTION
The creation of the label "Select an application in the list to open [...]" in the "Open With" file properties tab fails because of file names which include HTML special chars like ampersand or angle brackets.
I wasn't able to inject HTML into the label because of forbidden slashes in file names. HTML comments (`<!-- -->`) do work though!

Replaced `g_strdup_printf` with `g_markup_printf_escaped` to fix that.