### PR TITLE
file-operations: fix copying from the trash

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -3532,7 +3532,7 @@ get_target_file_with_custom_name (GFile *src,
 
 			/* if file is being restored from trash make sure it uses its original name */
 			if (g_file_has_uri_scheme (src, "trash")) {
-				copyname = g_strdup (g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH));
+				copyname = g_path_get_basename (g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH));
 			}
 
 			if (copyname == NULL) {


### PR DESCRIPTION
Fixes https://github.com/linuxmint/mint19.3-beta/issues/40 and https://github.com/linuxmint/nemo/issues/1814 and https://github.com/linuxmint/nemo/issues/1935

Based on https://gitlab.gnome.org/GNOME/nautilus/commit/0dfb6dec99c166cd35d9d87da82653f93365b227