### PR TITLE
meson.build: Disable GLib deprecation warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ if not get_option('deprecated_warnings')
       '-Wno-deprecated-declarations',
       '-Wno-deprecated',
       '-Wno-declaration-after-statement',
+      '-DGLIB_DISABLE_DEPRECATION_WARNINGS',
     ],
     language: 'c',
   )


### PR DESCRIPTION
Based on https://github.com/GNOME/nautilus/commit/7605b17b2757fa3331f2551c04208e833cd723e1#diff-969b60ad3d206fd45c208e266ccfed38

Buildlog before

https://kojipkgs.fedoraproject.org//packages/nemo/4.4.1/2.fc32/data/logs/x86_64/build.log

Buildlog after

https://kojipkgs.fedoraproject.org//packages/nemo/4.4.1/3.fc32/data/logs/x86_64/build.log