### PR TITLE
Don't hyphenate long filenames

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -36,6 +36,15 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
+#ifndef PANGO_CHECK_VERSION
+#define PANGO_CHECK_VERSION(major, minor, micro)                          \
+ 	(PANGO_VERSION_MAJOR > (major) ||                                    \
+ 	(PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR > (minor)) || \
+ 	(PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR == (minor) && \
+ 	PANGO_VERSION_MICRO >= (micro)))
+#endif
+
+
 enum {
   MOVE_CURSOR,
   POPULATE_POPUP,
@@ -996,6 +1005,9 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
       if (label->font_desc != NULL)
 	pango_layout_set_font_description (label->layout, label->font_desc);
       
+#if PANGO_CHECK_VERSION (1, 44, 0)
+      pango_attr_list_insert (tmp_attrs, pango_attr_insert_hyphens_new (FALSE));
+#endif    
       pango_layout_set_attributes (label->layout, tmp_attrs);
       
       if (preedit_string)

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -52,6 +52,14 @@
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
 
+#ifndef PANGO_CHECK_VERSION
+#define PANGO_CHECK_VERSION(major, minor, micro)                          \
+ 	(PANGO_VERSION_MAJOR > (major) ||                                    \
+ 	(PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR > (minor)) || \
+ 	(PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR == (minor) && \
+ 	PANGO_VERSION_MICRO >= (micro)))
+#endif
+
 /* special text height handling
  * each item has three text height variables:
  *  + text_height: actual height of the displayed (i.e. on-screen) PangoLayout.
@@ -1408,12 +1416,18 @@ create_label_layout (NemoIconCanvasItem *item,
 	GString *str;
 	char *zeroified_text;
 	const char *p;
+#if PANGO_CHECK_VERSION (1, 44, 0)
+ 	PangoAttrList *attr_list;
+#endif
 
 	canvas_item = EEL_CANVAS_ITEM (item);
 
 	container = NEMO_ICON_CONTAINER (canvas_item->canvas);
 	context = gtk_widget_get_pango_context (GTK_WIDGET (canvas_item->canvas));
 	layout = pango_layout_new (context);
+#if PANGO_CHECK_VERSION (1, 44, 0)
+ 	attr_list = pango_attr_list_new ();
+#endif
 
 	zeroified_text = NULL;
 
@@ -1449,6 +1463,11 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_spacing (layout, LABEL_LINE_SPACING);
 	pango_layout_set_wrap (layout, PANGO_WRAP_WORD_CHAR);
 
+#if PANGO_CHECK_VERSION (1, 44, 0)
+ 	pango_attr_list_insert (attr_list, pango_attr_insert_hyphens_new (FALSE));
+ 	pango_layout_set_attributes (layout, attr_list);
+#endif
+
 	/* Create a font description */
 	if (container->details->font && g_strcmp0 (container->details->font, "") != 0) {
 		desc = pango_font_description_from_string (container->details->font);
@@ -1469,6 +1488,9 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_font_description (layout, desc);
 	pango_font_description_free (desc);
 	g_free (zeroified_text);
+#if PANGO_CHECK_VERSION (1, 44, 0)
+ 	pango_attr_list_unref (attr_list);
+#endif
 
 	return layout;
 }


### PR DESCRIPTION
Fixes for https://github.com/linuxmint/nemo/issues/2214

Pango 1.44 got the ability to automatically hyphenate on line breaks,
which is on by default, but can be set off by a new attribute.

As a result, we now hyphenate filenames, which is confusing, because
a filename may already include hyphens.

To restore the previous behavior, let's not insert hyphens when
breaking filenames in multiple lines.

Based on https://github.com/mate-desktop/caja/commit/b50e36b639aca25c8bf3d21dc1547fc6f7a6f442