### PR TITLE
build: use define_variable for typelib directory

### DIFF
--- a/libnemo-extension/meson.build
+++ b/libnemo-extension/meson.build
@@ -58,13 +58,15 @@ nemo_extension = declare_dependency(
   dependencies: nemo_extension_deps,
 )
 
+typelibdir = go_intr.get_pkgconfig_variable('typelibdir', define_variable: ['libdir', get_option('libdir')])
+
 gnome.generate_gir(nemo_extension_lib,
   sources: nemo_extension_sources + nemo_extension_headers,
   nsversion: '3.0',
   namespace: 'Nemo',
   includes: [ 'Gtk-3.0', 'Gio-2.0', 'GLib-2.0', ],
   include_directories: [ rootInclude, ],
-  install_dir_typelib: join_paths(go_intr.get_pkgconfig_variable('libdir'), 'girepository-1.0'),
+  install_dir_typelib: typelibdir,
   install: true,
 )
 


### PR DESCRIPTION
We use the typelibdir variable provided in gobject-introspection.pc
typelibdir=${libdir}/girepository-1.0
and replace $(libdir) with that of this project.