### PR TITLE
nemo-global-preferences: use 'extern' properly

### DIFF
--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -36,6 +36,27 @@
 #include <glib/gi18n.h>
 #include <gio/gdesktopappinfo.h>
 
+GSettings *nemo_preferences;
+GSettings *nemo_icon_view_preferences;
+GSettings *nemo_list_view_preferences;
+GSettings *nemo_compact_view_preferences;
+GSettings *nemo_desktop_preferences;
+GSettings *nemo_tree_sidebar_preferences;
+GSettings *nemo_window_state;
+GSettings *nemo_plugin_preferences;
+GSettings *nemo_menu_config_preferences;
+GSettings *gnome_lockdown_preferences;
+GSettings *gnome_background_preferences;
+GSettings *gnome_media_handling_preferences;
+GSettings *gnome_terminal_preferences;
+GSettings *cinnamon_privacy_preferences;
+GSettings *cinnamon_interface_preferences;
+
+GTimeZone      *prefs_current_timezone;
+gboolean        prefs_current_24h_time_format;
+NemoDateFormat  prefs_current_date_format;
+
+GTimer    *nemo_startup_timer;
 
 static gboolean ignore_view_metadata = FALSE;
 static gboolean inherit_folder_view_preference = FALSE;

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -276,28 +276,28 @@ gint nemo_global_preferences_get_tooltip_flags (void);
 gboolean nemo_global_preferences_should_load_plugin (const gchar *name, const gchar *key);
 gchar **nemo_global_preferences_get_fileroller_mimetypes (void);
 
-GSettings *nemo_preferences;
-GSettings *nemo_icon_view_preferences;
-GSettings *nemo_list_view_preferences;
-GSettings *nemo_compact_view_preferences;
-GSettings *nemo_desktop_preferences;
-GSettings *nemo_tree_sidebar_preferences;
-GSettings *nemo_window_state;
-GSettings *nemo_plugin_preferences;
-GSettings *nemo_menu_config_preferences;
-GSettings *gnome_lockdown_preferences;
-GSettings *gnome_background_preferences;
-GSettings *gnome_media_handling_preferences;
-GSettings *gnome_terminal_preferences;
-GSettings *cinnamon_privacy_preferences;
-GSettings *cinnamon_interface_preferences;
+extern GSettings *nemo_preferences;
+extern GSettings *nemo_icon_view_preferences;
+extern GSettings *nemo_list_view_preferences;
+extern GSettings *nemo_compact_view_preferences;
+extern GSettings *nemo_desktop_preferences;
+extern GSettings *nemo_tree_sidebar_preferences;
+extern GSettings *nemo_window_state;
+extern GSettings *nemo_plugin_preferences;
+extern GSettings *nemo_menu_config_preferences;
+extern GSettings *gnome_lockdown_preferences;
+extern GSettings *gnome_background_preferences;
+extern GSettings *gnome_media_handling_preferences;
+extern GSettings *gnome_terminal_preferences;
+extern GSettings *cinnamon_privacy_preferences;
+extern GSettings *cinnamon_interface_preferences;
 
 /* Cached for fast access and used in nemo-file.c for constructing date/time strings */
-GTimeZone      *prefs_current_timezone;
-gboolean        prefs_current_24h_time_format;
-NemoDateFormat  prefs_current_date_format;
+extern GTimeZone      *prefs_current_timezone;
+extern gboolean        prefs_current_24h_time_format;
+extern NemoDateFormat  prefs_current_date_format;
 
-GTimer    *nemo_startup_timer;
+extern GTimer    *nemo_startup_timer;
 
 G_END_DECLS
 


### PR DESCRIPTION
Fixes https://github.com/linuxmint/nemo/issues/2305

Based on https://gitlab.gnome.org/GNOME/nautilus/commit/96554c2020b19c11eb065b24c9fc5457626c8bc2