### PR TITLE
Add tracker support

### DIFF
--- a/libnemo-private/meson.build
+++ b/libnemo-private/meson.build
@@ -91,6 +91,11 @@ if libexif_enabled
   nemo_private_deps += libexif
 endif
 
+if tracker_enabled
+  nemo_private_sources += 'nemo-search-engine-tracker.c'
+  nemo_private_deps += tracker_sparql
+endif
+
 if libselinux_enabled
   nemo_private_deps += libselinux
 endif

--- a/libnemo-private/nemo-search-engine-tracker.c
+++ b/libnemo-private/nemo-search-engine-tracker.c
@@ -1,0 +1,379 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+/*
+ * Copyright (C) 2005 Mr Jamie McCracken
+ *
+ * Nemo is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Nemo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; see the file COPYING.  If not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street - Suite 500,
+ * Boston, MA 02110-1335, USA.
+ *
+ * Author: Jamie McCracken <jamiemcc@gnome.org>
+ *
+ */
+
+#include <config.h>
+#include "nemo-search-engine-tracker.h"
+#include <gmodule.h>
+#include <string.h>
+#include <gio/gio.h>
+
+#include <libtracker-sparql/tracker-sparql.h>
+
+/* If defined, we use fts:match, this has to be enabled in Tracker to
+ * work which it usually is. The alternative is to undefine it and
+ * use filename matching instead. This doesn't use the content of the
+ * file however.
+ */
+#undef FTS_MATCHING
+
+struct NemoSearchEngineTrackerDetails {
+	TrackerSparqlConnection *connection;
+	NemoQuery *query;
+
+	gboolean       query_pending;
+	GCancellable  *cancellable;
+};
+
+G_DEFINE_TYPE (NemoSearchEngineTracker,
+	       nemo_search_engine_tracker,
+	       NEMO_TYPE_SEARCH_ENGINE);
+
+static void
+finalize (GObject *object)
+{
+	NemoSearchEngineTracker *tracker;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (object);
+
+	g_clear_object (&tracker->details->query);
+	g_clear_object (&tracker->details->cancellable);
+	g_clear_object (&tracker->details->connection);
+
+	G_OBJECT_CLASS (nemo_search_engine_tracker_parent_class)->finalize (object);
+}
+
+
+/* stolen from tracker sources, tracker.c */
+static void
+sparql_append_string_literal (GString     *sparql,
+                              const gchar *str)
+{
+	char *s;
+
+	s = tracker_sparql_escape_string (str);
+
+	g_string_append_c (sparql, '"');
+	g_string_append (sparql, s);
+	g_string_append_c (sparql, '"');
+
+	g_free (s);
+}
+
+static void cursor_callback (GObject      *object,
+			     GAsyncResult *result,
+			     gpointer      user_data);
+
+static void
+cursor_next (NemoSearchEngineTracker *tracker,
+             TrackerSparqlCursor    *cursor)
+{
+	tracker_sparql_cursor_next_async (cursor,
+	                                  tracker->details->cancellable,
+	                                  cursor_callback,
+	                                  tracker);
+}
+
+static void
+cursor_callback (GObject      *object,
+                 GAsyncResult *result,
+                 gpointer      user_data)
+{
+	NemoSearchEngineTracker *tracker;
+	GError *error = NULL;
+	TrackerSparqlCursor *cursor;
+	GList *hits;
+	gboolean success;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (user_data);
+
+	cursor = TRACKER_SPARQL_CURSOR (object);
+	success = tracker_sparql_cursor_next_finish (cursor, result, &error);
+
+	if (error) {
+		tracker->details->query_pending = FALSE;
+		nemo_search_engine_error (NEMO_SEARCH_ENGINE (tracker), error->message);
+		g_error_free (error);
+		g_object_unref (cursor);
+
+		return;
+	}
+
+	if (!success) {
+		tracker->details->query_pending = FALSE;
+		nemo_search_engine_finished (NEMO_SEARCH_ENGINE (tracker));
+		g_object_unref (cursor);
+
+		return;
+	}
+
+	/* We iterate result by result, not n at a time. */
+	hits = g_list_append (NULL, (gchar*) tracker_sparql_cursor_get_string (cursor, 0, NULL));
+	nemo_search_engine_hits_added (NEMO_SEARCH_ENGINE (tracker), hits);
+	g_list_free (hits);
+
+	/* Get next */
+	cursor_next (tracker, cursor);
+}
+
+static void
+query_callback (GObject      *object,
+                GAsyncResult *result,
+                gpointer      user_data)
+{
+	NemoSearchEngineTracker *tracker;
+	TrackerSparqlConnection *connection;
+	TrackerSparqlCursor *cursor;
+	GError *error = NULL;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (user_data);
+
+	connection = TRACKER_SPARQL_CONNECTION (object);
+	cursor = tracker_sparql_connection_query_finish (connection,
+	                                                 result,
+	                                                 &error);
+
+	if (error) {
+		tracker->details->query_pending = FALSE;
+		nemo_search_engine_error (NEMO_SEARCH_ENGINE (tracker), error->message);
+		g_error_free (error);
+		return;
+	}
+
+	if (!cursor) {
+		tracker->details->query_pending = FALSE;
+		nemo_search_engine_finished (NEMO_SEARCH_ENGINE (tracker));
+		return;
+	}
+
+	cursor_next (tracker, cursor);
+}
+
+static void
+nemo_search_engine_tracker_start (NemoSearchEngine *engine)
+{
+	NemoSearchEngineTracker *tracker;
+	gchar	*search_text, *location_uri;
+	GString *sparql;
+	GList *mimetypes, *l;
+	gint mime_count;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (engine);
+
+	if (tracker->details->query_pending) {
+		return;
+	}
+
+	if (tracker->details->query == NULL) {
+		return;
+	}
+
+	g_cancellable_reset (tracker->details->cancellable);
+
+	search_text = nemo_query_get_text (tracker->details->query);
+	location_uri = nemo_query_get_location (tracker->details->query);
+	mimetypes = nemo_query_get_mime_types (tracker->details->query);
+
+	mime_count = g_list_length (mimetypes);
+
+#ifdef FTS_MATCHING
+	/* Using FTS: */
+	sparql = g_string_new ("SELECT nie:url(?urn) "
+			       "WHERE {"
+			       "  ?urn a nfo:FileDataObject ;"
+			       "  tracker:available true ; ");
+
+	if (mime_count > 0) {
+		g_string_append (sparql, "nie:mimeType ?mime ;");
+	}
+
+	g_string_append (sparql, "  fts:match ");
+	sparql_append_string_literal (sparql, search_text);
+
+	if (location_uri || mime_count > 0) {
+		g_string_append (sparql, " . FILTER (");
+	
+		if (location_uri)  {
+			g_string_append (sparql, " fn:starts-with(nie:url(?urn),");
+			sparql_append_string_literal (sparql, location_uri);
+			g_string_append (sparql, ")");
+		}
+
+		if (mime_count > 0) {
+			if (location_uri) {
+				g_string_append (sparql, " && ");
+			}
+
+			g_string_append (sparql, "(");
+			for (l = mimetypes; l != NULL; l = l->next) {
+				if (l != mimetypes) {
+					g_string_append (sparql, " || ");
+				}
+
+				g_string_append (sparql, "?mime = ");
+				sparql_append_string_literal (sparql, l->data);
+			}
+			g_string_append (sparql, ")");
+		}
+
+		g_string_append (sparql, ")");
+	}
+
+	g_string_append (sparql, " } ORDER BY DESC(fts:rank(?urn)) ASC(nie:url(?urn))");
+#else  /* FTS_MATCHING */
+	/* Using filename matching: */
+	sparql = g_string_new ("SELECT nie:url(?urn) "
+			       "WHERE {"
+			       "  ?urn a nfo:FileDataObject ;");
+
+	if (mime_count > 0) {
+		g_string_append (sparql, "nie:mimeType ?mime ;");
+	}
+
+	g_string_append (sparql, "    tracker:available true ."
+			 "  FILTER (fn:contains(nfo:fileName(?urn),");
+
+	sparql_append_string_literal (sparql, search_text);
+
+	g_string_append (sparql, ")");
+
+	if (location_uri)  {
+		g_string_append (sparql, " && fn:starts-with(nie:url(?urn),");
+		sparql_append_string_literal (sparql, location_uri);
+		g_string_append (sparql, ")");
+	}
+
+	if (mime_count > 0) {
+		g_string_append (sparql, " && ");
+		g_string_append (sparql, "(");
+		for (l = mimetypes; l != NULL; l = l->next) {
+			if (l != mimetypes) {
+				g_string_append (sparql, " || ");
+			}
+
+			g_string_append (sparql, "?mime = ");
+			sparql_append_string_literal (sparql, l->data);
+		}
+		g_string_append (sparql, ")");
+	}
+
+	g_string_append (sparql, ")");
+
+
+	g_string_append (sparql, 
+			 "} ORDER BY DESC(nie:url(?urn)) DESC(nfo:fileName(?urn))");
+#endif /* FTS_MATCHING */
+
+	tracker_sparql_connection_query_async (tracker->details->connection,
+					       sparql->str,
+					       tracker->details->cancellable,
+					       query_callback,
+					       tracker);
+	g_string_free (sparql, TRUE);
+
+	tracker->details->query_pending = TRUE;
+
+	g_free (search_text);
+	g_free (location_uri);
+
+	if (mimetypes != NULL) {
+		g_list_free_full (mimetypes, g_free);
+	}
+}
+
+static void
+nemo_search_engine_tracker_stop (NemoSearchEngine *engine)
+{
+	NemoSearchEngineTracker *tracker;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (engine);
+	
+	if (tracker->details->query && tracker->details->query_pending) {
+		g_cancellable_cancel (tracker->details->cancellable);
+		tracker->details->query_pending = FALSE;
+	}
+}
+
+static void
+nemo_search_engine_tracker_set_query (NemoSearchEngine *engine, NemoQuery *query)
+{
+	NemoSearchEngineTracker *tracker;
+
+	tracker = NEMO_SEARCH_ENGINE_TRACKER (engine);
+
+	if (query) {
+		g_object_ref (query);
+	}
+
+	if (tracker->details->query) {
+		g_object_unref (tracker->details->query);
+	}
+
+	tracker->details->query = query;
+}
+
+static void
+nemo_search_engine_tracker_class_init (NemoSearchEngineTrackerClass *class)
+{
+	GObjectClass *gobject_class;
+	NemoSearchEngineClass *engine_class;
+
+	gobject_class = G_OBJECT_CLASS (class);
+	gobject_class->finalize = finalize;
+
+	engine_class = NEMO_SEARCH_ENGINE_CLASS (class);
+	engine_class->set_query = nemo_search_engine_tracker_set_query;
+	engine_class->start = nemo_search_engine_tracker_start;
+	engine_class->stop = nemo_search_engine_tracker_stop;
+
+	g_type_class_add_private (class, sizeof (NemoSearchEngineTrackerDetails));
+}
+
+static void
+nemo_search_engine_tracker_init (NemoSearchEngineTracker *engine)
+{
+	engine->details = G_TYPE_INSTANCE_GET_PRIVATE (engine, NEMO_TYPE_SEARCH_ENGINE_TRACKER,
+						       NemoSearchEngineTrackerDetails);
+}
+
+
+NemoSearchEngine *
+nemo_search_engine_tracker_new (void)
+{
+	NemoSearchEngineTracker *engine;
+	TrackerSparqlConnection *connection;
+	GError *error = NULL;
+
+	connection = tracker_sparql_connection_get (NULL, &error);
+
+	if (error) {
+		g_warning ("Could not establish a connection to Tracker: %s", error->message);
+		g_error_free (error);
+		return NULL;
+	}
+
+	engine = g_object_new (NEMO_TYPE_SEARCH_ENGINE_TRACKER, NULL);
+	engine->details->connection = connection;
+	engine->details->cancellable = g_cancellable_new ();
+
+	return NEMO_SEARCH_ENGINE (engine);
+}

--- a/libnemo-private/nemo-search-engine-tracker.h
+++ b/libnemo-private/nemo-search-engine-tracker.h
@@ -1,0 +1,51 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+/*
+ * Copyright (C) 2005 Mr Jamie McCracken
+ *
+ * Nemo is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Nemo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; see the file COPYING.  If not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street - Suite 500,
+ * Boston, MA 02110-1335, USA.
+ *
+ * Author: Jamie McCracken (jamiemcc@gnome.org)
+ *
+ */
+
+#ifndef NEMO_SEARCH_ENGINE_TRACKER_H
+#define NEMO_SEARCH_ENGINE_TRACKER_H
+
+#include <libnemo-private/nemo-search-engine.h>
+
+#define NEMO_TYPE_SEARCH_ENGINE_TRACKER		(nemo_search_engine_tracker_get_type ())
+#define NEMO_SEARCH_ENGINE_TRACKER(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), NEMO_TYPE_SEARCH_ENGINE_TRACKER, NemoSearchEngineTracker))
+#define NEMO_SEARCH_ENGINE_TRACKER_CLASS(klass)	(G_TYPE_CHECK_CLASS_CAST ((klass), NEMO_TYPE_SEARCH_ENGINE_TRACKER, NemoSearchEngineTrackerClass))
+#define NEMO_IS_SEARCH_ENGINE_TRACKER(obj)		(G_TYPE_CHECK_INSTANCE_TYPE ((obj), NEMO_TYPE_SEARCH_ENGINE_TRACKER))
+#define NEMO_IS_SEARCH_ENGINE_TRACKER_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE ((klass), NEMO_TYPE_SEARCH_ENGINE_TRACKER))
+#define NEMO_SEARCH_ENGINE_TRACKER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), NEMO_TYPE_SEARCH_ENGINE_TRACKER, NemoSearchEngineTrackerClass))
+
+typedef struct NemoSearchEngineTrackerDetails NemoSearchEngineTrackerDetails;
+
+typedef struct NemoSearchEngineTracker {
+	NemoSearchEngine parent;
+	NemoSearchEngineTrackerDetails *details;
+} NemoSearchEngineTracker;
+
+typedef struct {
+	NemoSearchEngineClass parent_class;
+} NemoSearchEngineTrackerClass;
+
+GType nemo_search_engine_tracker_get_type (void);
+
+NemoSearchEngine* nemo_search_engine_tracker_new (void);
+
+#endif /* NEMO_SEARCH_ENGINE_TRACKER_H */

--- a/libnemo-private/nemo-search-engine.c
+++ b/libnemo-private/nemo-search-engine.c
@@ -25,6 +25,10 @@
 #include "nemo-search-engine.h"
 #include "nemo-search-engine-simple.h"
 
+#ifdef ENABLE_TRACKER
+#include "nemo-search-engine-tracker.h"
+#endif
+
 enum {
 	HITS_ADDED,
 	HITS_SUBTRACTED,
@@ -91,6 +95,13 @@ NemoSearchEngine *
 nemo_search_engine_new (void)
 {
 	NemoSearchEngine *engine;
+	
+#ifdef ENABLE_TRACKER	
+	engine = nemo_search_engine_tracker_new ();
+	if (engine) {
+		return engine;
+	}
+#endif
 	
 	engine = nemo_search_engine_simple_new ();
 	return engine;

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,24 @@ xapp    = dependency('xapp',                        version: '>=1.4.0')
 
 # Facultative dependencies
 
+trackerChoice = get_option('tracker')
+tracker_enabled = false
+if trackerChoice != 'false'
+  trackerRequired = (trackerChoice == 'true')
+  # Check all the possible versions
+    tracker_sparql = dependency('tracker-sparql-1.0',  required: false)
+  if not tracker_sparql.found()
+    tracker_sparql = dependency('tracker-sparql-0.18', required: false)
+  endif
+  if not tracker_sparql.found()
+    tracker_sparql = dependency('tracker-sparql-0.16', required: trackerRequired)
+  endif
+
+  tracker_enabled = trackerRequired or tracker_sparql.found()
+endif
+conf.set('ENABLE_TRACKER', tracker_enabled)
+
+
 gtkdoc_enabled = get_option('gtk_doc')
 if gtkdoc_enabled
   find_program('gtkdoc-scan', required: true)
@@ -190,6 +208,7 @@ message('\n'.join(['',
 '    debugging support:  @0@'.format(buildtype),
 '    libexif support:    @0@'.format(libexif_enabled),
 '    exempi  support:    @0@'.format(exempi_enabled),
+'    Tracker support:    @0@'.format(tracker_enabled),
 '',
 '    nemo-extension documentation: @0@'.format(gtkdoc_enabled),
 '    nemo-extension introspection: @0@'.format(true),

--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,10 @@ tracker_enabled = false
 if trackerChoice != 'false'
   trackerRequired = (trackerChoice == 'true')
   # Check all the possible versions
+    tracker_sparql = dependency('tracker-sparql-2.0',  required: false)
+  if not tracker_sparql.found()
     tracker_sparql = dependency('tracker-sparql-1.0',  required: false)
+  endif
   if not tracker_sparql.found()
     tracker_sparql = dependency('tracker-sparql-0.18', required: false)
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,5 +10,7 @@ option('selinux', type : 'boolean', value : false,
        description: 'SELinux support')
 option('empty_view', type : 'boolean', value : false,
        description: 'Enable empty view')
+option('tracker',type : 'combo', choices : ['true', 'false', 'auto'], value : 'false',
+       description: 'Tracker support')
 option('profiling', type : 'boolean', value : false,
        description: 'keep frame pointers (for profiling purposes)')


### PR DESCRIPTION
This PR reverts 5db7a44e8086d1b77f6384b272353c932404a05a and applies a patch to add support for `tracker-2` taken from #2065 

There is really no reason to drop support for this when there is a patch that applies cleanly and keeps  it usable with current versions of tracker.