### PR TITLE
[wip] Performance improvements

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@ CONFIGURE_EXTRA_FLAGS = \
 	--libexecdir=/usr/lib/$(DEB_HOST_MULTIARCH)/nemo \
 	-D deprecated_warnings=false \
 	-D gtk_doc=true \
+	-D profiling=true \
 	-D selinux=false
 
 export LDFLAGS+=-Wl,-z,defs -Wl,-O1 -Wl,--as-needed

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -1645,7 +1645,7 @@ lacks_btime (NemoFile *file)
 static gboolean
 lacks_filesystem_info (NemoFile *file)
 {
-	return !file->details->filesystem_info_is_up_to_date;
+	return nemo_file_is_directory (file) && !file->details->filesystem_info_is_up_to_date;
 }
 
 static gboolean
@@ -1692,7 +1692,8 @@ lacks_extension_info (NemoFile *file)
 static gboolean
 lacks_thumbnail (NemoFile *file)
 {
-	return nemo_file_should_show_thumbnail (file) &&
+	return file->details->thumbnail_requested_once &&
+        nemo_file_should_show_thumbnail (file) &&
 		file->details->thumbnail_path != NULL &&
 		!file->details->thumbnail_is_up_to_date;
 }

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -3654,6 +3654,7 @@ thumbnail_done (NemoDirectory *directory,
             file->details->thumbnail_throttle_count = 1;
 		} else {
 			g_free (file->details->thumbnail_path);
+            g_object_unref (pixbuf);
 			file->details->thumbnail_path = NULL;
 		}
 

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -1692,7 +1692,7 @@ lacks_extension_info (NemoFile *file)
 static gboolean
 lacks_thumbnail (NemoFile *file)
 {
-	return file->details->thumbnail_requested_once &&
+	return file->details->load_thumb &&
         nemo_file_should_show_thumbnail (file) &&
 		file->details->thumbnail_path != NULL &&
 		!file->details->thumbnail_is_up_to_date;
@@ -3630,7 +3630,6 @@ thumbnail_done (NemoDirectory *directory,
 {
 	const char *thumb_mtime_str;
 	time_t thumb_mtime = 0;
-	
 	file->details->thumbnail_is_up_to_date = TRUE;
 	file->details->thumbnail_tried_original  = tried_original;
 	if (file->details->thumbnail) {

--- a/libnemo-private/nemo-directory.h
+++ b/libnemo-private/nemo-directory.h
@@ -239,5 +239,4 @@ gboolean           nemo_directory_is_editable              (NemoDirectory       
 
 void               nemo_directory_set_show_thumbnails      (NemoDirectory         *directory,
                                 gboolean show_thumbnails);
-
 #endif /* NEMO_DIRECTORY_H */

--- a/libnemo-private/nemo-file-private.h
+++ b/libnemo-private/nemo-file-private.h
@@ -56,6 +56,8 @@ struct NemoFileDetails
 	
 	eel_ref_str name;
 
+    gchar *cached_uri;
+
 	/* File info: */
 	GFileType type;
 
@@ -222,7 +224,7 @@ struct NemoFileDetails
 	eel_boolean_bit filesystem_readonly           : 1;
 	eel_boolean_bit filesystem_use_preview        : 2; /* GFilesystemPreviewType */
     eel_boolean_bit filesystem_info_is_up_to_date : 1;
-	eel_boolean_bit thumbnail_requested_once      : 1;
+	eel_boolean_bit load_thumb                    : 1;
 
     NemoFilePinning pinning;
 

--- a/libnemo-private/nemo-file-private.h
+++ b/libnemo-private/nemo-file-private.h
@@ -221,7 +221,8 @@ struct NemoFileDetails
 
 	eel_boolean_bit filesystem_readonly           : 1;
 	eel_boolean_bit filesystem_use_preview        : 2; /* GFilesystemPreviewType */
-	eel_boolean_bit filesystem_info_is_up_to_date : 1;
+    eel_boolean_bit filesystem_info_is_up_to_date : 1;
+	eel_boolean_bit thumbnail_requested_once      : 1;
 
     NemoFilePinning pinning;
 

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -189,6 +189,7 @@ const char *            nemo_file_peek_name                         (NemoFile   
 GFile *                 nemo_file_get_location                      (NemoFile                   *file);
 char *			 nemo_file_get_description			 (NemoFile			 *file);
 char *                  nemo_file_get_uri                           (NemoFile                   *file);
+const char *            nemo_file_peek_uri                          (NemoFile                   *file);
 char *                  nemo_file_get_path                          (NemoFile                   *file);
 char *                  nemo_file_get_uri_scheme                    (NemoFile                   *file);
 NemoFile *          nemo_file_get_parent                        (NemoFile                   *file);
@@ -522,7 +523,7 @@ void     nemo_file_set_is_desktop_orphan          (NemoFile *file, gboolean is_d
 
 gboolean nemo_file_get_pinning                    (NemoFile *file);
 void     nemo_file_set_pinning                    (NemoFile *file, gboolean  pin);
-gboolean nemo_file_check_delayed_icon             (NemoFile *file);
+void nemo_file_set_load_thumb                     (NemoFile *file, gboolean load_thumb);
 /* Debugging */
 void                    nemo_file_dump                              (NemoFile                   *file);
 

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -240,6 +240,7 @@ NemoRequestStatus   nemo_file_get_deep_counts                   (NemoFile       
 									 gboolean                        force);
 gboolean                nemo_file_should_show_thumbnail             (NemoFile                   *file);
 void                    nemo_file_delete_thumbnail                  (NemoFile                   *file);
+gboolean                nemo_file_has_loaded_thumbnail              (NemoFile                   *file);
 gboolean                nemo_file_should_show_directory_item_count  (NemoFile                   *file);
 gboolean                nemo_file_should_show_type                  (NemoFile                   *file);
 GList *                 nemo_file_get_keywords                      (NemoFile                   *file);
@@ -521,7 +522,7 @@ void     nemo_file_set_is_desktop_orphan          (NemoFile *file, gboolean is_d
 
 gboolean nemo_file_get_pinning                    (NemoFile *file);
 void     nemo_file_set_pinning                    (NemoFile *file, gboolean  pin);
-
+gboolean nemo_file_check_delayed_icon             (NemoFile *file);
 /* Debugging */
 void                    nemo_file_dump                              (NemoFile                   *file);
 

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -2022,6 +2022,23 @@ nemo_icon_canvas_item_set_entire_text (NemoIconCanvasItem       *item,
 	}
 }
 
+gint
+nemo_icon_canvas_item_get_fixed_text_height_for_layout (NemoIconCanvasItem *item)
+{
+    NemoIconContainer *container;
+    PangoLayout *layout;
+    gint line_height, total_height, lines;
+
+    container = NEMO_ICON_CONTAINER (EEL_CANVAS_ITEM (item)->canvas);
+    lines = nemo_icon_container_get_max_layout_lines (container);
+    lines += nemo_icon_container_get_additional_text_line_count (container);
+    layout = create_label_layout (item, "-");
+    pango_layout_get_pixel_size (layout, NULL, &line_height);
+
+    total_height = (line_height * lines) + (LABEL_LINE_SPACING * (lines - 1));
+    return total_height;
+}
+
 /* Class initialization function for the icon canvas item. */
 static void
 nemo_icon_canvas_item_class_init (NemoIconCanvasItemClass *class)

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -2036,6 +2036,8 @@ nemo_icon_canvas_item_get_fixed_text_height_for_layout (NemoIconCanvasItem *item
     pango_layout_get_pixel_size (layout, NULL, &line_height);
 
     total_height = (line_height * lines) + (LABEL_LINE_SPACING * (lines - 1));
+    g_object_unref (layout);
+
     return total_height;
 }
 

--- a/libnemo-private/nemo-icon-canvas-item.h
+++ b/libnemo-private/nemo-icon-canvas-item.h
@@ -104,7 +104,7 @@ void        nemo_icon_canvas_item_set_is_visible           (NemoIconCanvasItem  
 /* whether the entire label text must be visible at all times */
 void        nemo_icon_canvas_item_set_entire_text          (NemoIconCanvasItem       *icon_item,
 								gboolean                      entire_text);
-
+gint        nemo_icon_canvas_item_get_fixed_text_height_for_layout (NemoIconCanvasItem *item);
 G_END_DECLS
 
 #endif /* NEMO_ICON_CANVAS_ITEM_H */

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -2787,6 +2787,7 @@ finalize (GObject *object)
     g_slice_free (NemoViewLayoutConstants, details->view_constants);
 
 	g_free (details);
+    g_list_free (details->current_selection);
 
 	G_OBJECT_CLASS (nemo_icon_container_parent_class)->finalize (object);
 }

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -1024,6 +1024,7 @@ redo_layout_internal (NemoIconContainer *container)
 	}
 
 	nemo_icon_container_update_scroll_region (container);
+    queue_update_visible_icons (container, INITIAL_UPDATE_VISIBLE_DELAY);
 
 	process_pending_icon_to_reveal (container);
 	process_pending_icon_to_rename (container);
@@ -5653,7 +5654,7 @@ update_visible_icons_cb (NemoIconContainer *container)
                     nemo_file_set_load_thumb (file, TRUE);
 
                     if (nemo_file_is_thumbnailing (file)) {
-                        nemo_thumbnail_prioritize (nemo_file_peek_uri (file));
+                        nemo_icon_container_prioritize_thumbnailing (container, icon);
                     } else {
                         nemo_file_invalidate_attributes (file, NEMO_FILE_ATTRIBUTES_FOR_ICON);
                     }
@@ -8124,14 +8125,10 @@ void
 nemo_icon_container_set_ok_to_load_thumbs (NemoIconContainer *container,
                                            gboolean           ok)
 {
-    gboolean old_ok = container->details->ok_to_load_thumbs;
-
     container->details->ok_to_load_thumbs = ok;
 
-    if (ok != old_ok) {
-        if (ok) {
-            queue_update_visible_icons (container, INITIAL_UPDATE_VISIBLE_DELAY);
-        }
+    if (ok) {
+        queue_update_visible_icons (container, INITIAL_UPDATE_VISIBLE_DELAY);
     }
 }
 

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5827,6 +5827,8 @@ nemo_icon_container_invalidate_labels (NemoIconContainer *container)
     GList *p;
     NemoIcon *icon;
 
+    container->details->fixed_text_height = -1;
+
     for (p = container->details->icons; p != NULL; p = p->next) {
         icon = p->data;
 
@@ -8094,5 +8096,12 @@ nemo_icon_container_update_icon (NemoIconContainer *container,
 {
     NEMO_ICON_CONTAINER_GET_CLASS (container)->update_icon (container, icon);
 }
+
+gint
+nemo_icon_container_get_additional_text_line_count (NemoIconContainer *container)
+{
+    NEMO_ICON_CONTAINER_GET_CLASS (container)->get_additional_text_line_count (container);
+}
+
 
 #endif /* ! NEMO_OMIT_SELF_CHECK */

--- a/libnemo-private/nemo-icon-container.h
+++ b/libnemo-private/nemo-icon-container.h
@@ -142,7 +142,8 @@ typedef struct {
 						   NemoIconData *data,
 						   int icon_size,
 						   gboolean for_drag_accept,
-						   gboolean *has_window_open);
+						   gboolean *has_window_open,
+                           gboolean visible);
 	void         (* get_icon_text)            (NemoIconContainer *container,
 						   NemoIconData *data,
 						   char **editable_text,
@@ -150,7 +151,8 @@ typedef struct {
                            gboolean *pinned,
 						   gboolean include_invisible);
     void         (* update_icon)              (NemoIconContainer *container,
-                                               NemoIcon          *icon);
+                                               NemoIcon          *icon,
+                                               gboolean           visible);
 	char *       (* get_icon_description)     (NemoIconContainer *container,
 						   NemoIconData *data);
 	int          (* compare_icons)            (NemoIconContainer *container,

--- a/libnemo-private/nemo-icon-container.h
+++ b/libnemo-private/nemo-icon-container.h
@@ -163,6 +163,7 @@ typedef struct {
 						   NemoIconData *data);
     gint         (* get_max_layout_lines_for_pango) (NemoIconContainer *container);
     gint         (* get_max_layout_lines)           (NemoIconContainer *container);
+    gint         (* get_additional_text_line_count) (NemoIconContainer *container);
 
 	/* Queries on icons for subclass/client.
 	 * These must be implemented => These are signals !
@@ -371,4 +372,5 @@ void              nemo_icon_container_widget_to_file_operation_position (NemoIco
 void         nemo_icon_container_setup_tooltip_preference_callback (NemoIconContainer *container);
 void         nemo_icon_container_update_tooltip_text (NemoIconContainer  *container,
                                                       NemoIconCanvasItem *item);
+gint         nemo_icon_container_get_additional_text_line_count (NemoIconContainer *container);
 #endif /* NEMO_ICON_CONTAINER_H */

--- a/libnemo-private/nemo-icon-container.h
+++ b/libnemo-private/nemo-icon-container.h
@@ -373,4 +373,6 @@ void         nemo_icon_container_setup_tooltip_preference_callback (NemoIconCont
 void         nemo_icon_container_update_tooltip_text (NemoIconContainer  *container,
                                                       NemoIconCanvasItem *item);
 gint         nemo_icon_container_get_additional_text_line_count (NemoIconContainer *container);
+void         nemo_icon_container_set_ok_to_load_thumbs (NemoIconContainer *container,
+                                                        gboolean           ok);
 #endif /* NEMO_ICON_CONTAINER_H */

--- a/libnemo-private/nemo-icon-private.h
+++ b/libnemo-private/nemo-icon-private.h
@@ -300,6 +300,12 @@ struct NemoIconContainerDetails {
 	eel_boolean_bit store_layout_timestamps : 1;
 	eel_boolean_bit store_layout_timestamps_when_finishing_new_icons : 1;
 
+    gint ok_to_load_thumbs;
+    guint update_visible_icons_id;
+
+    GQueue *lazy_icon_load_queue;
+    guint lazy_icon_load_id;
+
     GList *current_selection;
     gint current_selection_count;
     gint fixed_text_height;

--- a/libnemo-private/nemo-icon-private.h
+++ b/libnemo-private/nemo-icon-private.h
@@ -389,7 +389,8 @@ NemoIconInfo *nemo_icon_container_get_icon_images (NemoIconContainer *container,
                                                    NemoIconData      *data,
                                                    int                    size,
                                                    gboolean               for_drag_accept,
-                                                   gboolean              *has_open_window);
+                                                   gboolean              *has_open_window,
+                                                   gboolean               visible);
 void          nemo_icon_container_get_icon_text (NemoIconContainer *container,
                                                  NemoIconData      *data,
                                                  char                 **editable_text,

--- a/libnemo-private/nemo-icon-private.h
+++ b/libnemo-private/nemo-icon-private.h
@@ -302,6 +302,7 @@ struct NemoIconContainerDetails {
 
     GList *current_selection;
     gint current_selection_count;
+    gint fixed_text_height;
 };
 
 typedef struct {

--- a/libnemo-private/nemo-icon.h
+++ b/libnemo-private/nemo-icon.h
@@ -70,6 +70,8 @@ typedef struct {
 	eel_boolean_bit is_visible : 1;
 
 	eel_boolean_bit has_lazy_position : 1;
+
+    eel_boolean_bit ok_to_show_thumb : 1;
 } NemoIcon;
 
 #endif /* NEMO_ICON_CONTAINER_PRIVATE_H */

--- a/libnemo-private/nemo-thumbnails.c
+++ b/libnemo-private/nemo-thumbnails.c
@@ -612,6 +612,7 @@ thumbnail_thread_starter_cb (gpointer data)
     thumbnail_thread_is_running = TRUE;
 
     g_task_run_in_thread (thumbnail_task, thumbnail_thread);
+    g_object_unref (thumbnail_task);
 
     thumbnail_thread_starter_id = 0;
     return FALSE;
@@ -691,7 +692,9 @@ nemo_create_thumbnail (NemoFile      *file,
 
         if (thumbnail_thread_is_running == FALSE &&
             thumbnail_thread_starter_id == 0) {
-            thumbnail_thread_starter_id = g_idle_add_full (G_PRIORITY_LOW, thumbnail_thread_starter_cb, NULL, NULL);
+            thumbnail_thread_starter_id = g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
+                                                           thumbnail_thread_starter_cb,
+                                                           NULL, NULL);
         }
     } else {
         if (DEBUGGING) {

--- a/libnemo-private/nemo-thumbnails.c
+++ b/libnemo-private/nemo-thumbnails.c
@@ -423,6 +423,7 @@ thumbnail_thread_notify_file_changed (gpointer image_uri)
         nemo_file_unref (file);
     }
     g_free (image_uri);
+    g_printerr ("length: %d  REMOVE\n" , g_hash_table_size (thumbnails_to_make_hash));
 
     return FALSE;
 }
@@ -659,7 +660,7 @@ nemo_create_thumbnail (NemoFile      *file,
         thumbnails_to_make_hash = g_hash_table_new (g_str_hash,
                                 g_str_equal);
     }
-
+    g_printerr ("length: %d  ADD\n" , g_hash_table_size (thumbnails_to_make_hash));
     /* Check if it is already in the list of thumbnails to make. */
     existing = g_hash_table_lookup (thumbnails_to_make_hash, info->image_uri);
 
@@ -724,4 +725,16 @@ gboolean
 nemo_thumbnail_factory_check_status (void)
 {
     return gnome_desktop_thumbnail_cache_check_permissions (get_thumbnail_factory (), TRUE);
+}
+
+gboolean
+nemo_thumbnail_factory_has_thumbnail (NemoFile *file)
+{
+    g_autofree gchar *existing;
+
+    existing = gnome_desktop_thumbnail_factory_lookup (get_thumbnail_factory(),
+                                                       nemo_file_peek_uri (file),
+                                                       nemo_file_get_mtime (file));
+
+    return !!existing;
 }

--- a/libnemo-private/nemo-thumbnails.h
+++ b/libnemo-private/nemo-thumbnails.h
@@ -45,5 +45,5 @@ void       nemo_thumbnail_remove_from_queue     (const char   *file_uri);
 void       nemo_thumbnail_prioritize            (const char   *file_uri);
 
 gboolean   nemo_thumbnail_factory_check_status          (void);
-
+gboolean   nemo_thumbnail_factory_has_thumbnail (NemoFile *file);
 #endif /* NEMO_THUMBNAILS_H */

--- a/libnemo-private/nemo-thumbnails.h
+++ b/libnemo-private/nemo-thumbnails.h
@@ -32,7 +32,7 @@
 #define THUMBNAIL_CREATION_DELAY_SECS 3
 
 /* Returns NULL if there's no thumbnail yet. */
-void       nemo_create_thumbnail                (NemoFile *file, gint throttle_count);
+void       nemo_create_thumbnail                (NemoFile *file, gint throttle_count, gboolean prioritize);
 gboolean   nemo_can_thumbnail                   (NemoFile *file);
 gboolean   nemo_can_thumbnail_internally        (NemoFile *file);
 gboolean   nemo_thumbnail_is_mimetype_limited_by_size

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -576,6 +576,7 @@ nemo_application_quit_mainloop (GApplication *app)
 
     nemo_icon_info_clear_caches ();
     save_accel_map (NULL);
+    g_object_unref (NEMO_APPLICATION (app)->undo_manager);
 
     nemo_application_notify_unmount_done (NEMO_APPLICATION (app), NULL);
 

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -85,7 +85,8 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
                                           NemoIconData      *data,
                                           int                size,
                                           gboolean           for_drag_accept,
-					                      gboolean          *has_window_open)
+					                      gboolean          *has_window_open,
+                                          gboolean           visible)
 {
 	NemoIconView *icon_view;
 	NemoFile *file;
@@ -108,7 +109,7 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
 	flags = NEMO_FILE_ICON_FLAGS_USE_MOUNT_ICON_AS_EMBLEM |
 			NEMO_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE;
 
-    if (container->details->ok_to_load_thumbs != 0) {
+    if (visible) {
         flags |= NEMO_FILE_ICON_FLAGS_USE_THUMBNAILS;
     }
 
@@ -206,7 +207,7 @@ nemo_icon_view_container_prioritize_thumbnailing (NemoIconContainer *container,
 
 	g_assert (NEMO_IS_FILE (file));
 
-    if (nemo_can_thumbnail (file)) {
+    if (nemo_can_thumbnail (file) && !nemo_file_has_loaded_thumbnail (file)) {
         nemo_create_thumbnail (file, 0, TRUE);
     }
 }
@@ -1483,7 +1484,8 @@ icon_get_size (NemoIconContainer *container,
 
 static void
 nemo_icon_view_container_update_icon (NemoIconContainer *container,
-                                      NemoIcon          *icon)
+                                      NemoIcon          *icon,
+                                      gboolean           visible)
 {
     NemoIconContainerDetails *details;
     guint icon_size;
@@ -1521,7 +1523,8 @@ nemo_icon_view_container_update_icon (NemoIconContainer *container,
                                                      icon->data,
                                                      icon_size,
                                                      icon == details->drop_target,
-                                                     &has_open_window);
+                                                     &has_open_window,
+                                                     visible);
 
     if (container->details->forced_icon_size > 0) {
         gint scale_factor;

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -106,8 +106,11 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
 	*has_window_open = nemo_file_has_open_window (file);
 
 	flags = NEMO_FILE_ICON_FLAGS_USE_MOUNT_ICON_AS_EMBLEM |
-            NEMO_FILE_ICON_FLAGS_USE_THUMBNAILS |
 			NEMO_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE;
+
+    if (container->details->ok_to_load_thumbs != 0) {
+        flags |= NEMO_FILE_ICON_FLAGS_USE_THUMBNAILS;
+    }
 
 	if (for_drag_accept) {
 		flags |= NEMO_FILE_ICON_FLAGS_FOR_DRAG_ACCEPT;
@@ -198,17 +201,14 @@ nemo_icon_view_container_prioritize_thumbnailing (NemoIconContainer *container,
 						      NemoIconData      *data)
 {
 	NemoFile *file;
-	char *uri;
 
 	file = (NemoFile *) data;
 
 	g_assert (NEMO_IS_FILE (file));
 
-	if (nemo_file_is_thumbnailing (file)) {
-		uri = nemo_file_get_uri (file);
-		nemo_thumbnail_prioritize (uri);
-		g_free (uri);
-	}
+    if (nemo_can_thumbnail (file)) {
+        nemo_create_thumbnail (file, 0, TRUE);
+    }
 }
 
 static void
@@ -2056,7 +2056,7 @@ nemo_icon_view_container_get_max_layout_lines (NemoIconContainer  *container)
 static gint
 nemo_icon_view_container_get_additional_text_line_count (NemoIconContainer *container)
 {
-    GQuark *attributes;
+    G_GNUC_UNUSED GQuark *attributes;
     gint len;
 
     attributes = nemo_icon_view_container_get_icon_text_attribute_names (container, &len);

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -117,7 +117,7 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
 		                                       nemo_view_get_directory_as_file (NEMO_VIEW (icon_view)));
 
     scale = gtk_widget_get_scale_factor (GTK_WIDGET (icon_view));
-	icon_info = nemo_file_get_icon (file, size, 0, scale, flags);
+	icon_info = nemo_file_get_icon (file, size, size, scale, flags);
 
 	/* apply emblems */
 	if (emblem_icons != NULL) {
@@ -755,7 +755,7 @@ lay_down_icons_horizontal (NemoIconContainer *container,
     text_size = nemo_get_icon_text_width_for_zoom_level (container->details->zoom_level);
 
     use_size = MAX (icon_size, text_size) + 15;
-
+    icon_size /= ppu;
     if (container->details->label_position == NEMO_ICON_LABEL_POSITION_BESIDE) {
         /* Would it be worth caching these bounds for the next loop? */
         for (p = icons; p != NULL; p = p->next) {
@@ -787,6 +787,10 @@ lay_down_icons_horizontal (NemoIconContainer *container,
     for (p = icons; p != NULL; p = p->next) {
         icon = p->data;
 
+        if (container->details->fixed_text_height == -1) {
+            container->details->fixed_text_height = nemo_icon_canvas_item_get_fixed_text_height_for_layout (icon->item) / ppu;
+        }
+
         /* Assume it's only one level hierarchy to avoid costly affine calculations */
         nemo_icon_canvas_item_get_bounds_for_layout (icon->item,
                                  &bounds.x0, &bounds.y0,
@@ -805,16 +809,18 @@ lay_down_icons_horizontal (NemoIconContainer *container,
                 y += gap;
             } else {
                 /* Advance to the baseline. */
-                y += gap + max_height_above;
+                // y += gap + max_height_above;
+                y += gap + icon_size;
             }
 
-            lay_down_one_line (container, line_start, p, y, max_height_above, positions, FALSE, gap);
+            lay_down_one_line (container, line_start, p, y, icon_size, positions, FALSE, gap);
 
             if (container->details->label_position == NEMO_ICON_LABEL_POSITION_BESIDE) {
                 y += max_height_above + max_height_below + gap;
             } else {
                 /* Advance to next line. */
-                y += max_height_below + gap;
+                // y += max_height_below + gap;
+                y += container->details->fixed_text_height + gap;
             }
 
             line_width = container->details->label_position == NEMO_ICON_LABEL_POSITION_BESIDE ? gap : 0;
@@ -855,10 +861,10 @@ lay_down_icons_horizontal (NemoIconContainer *container,
                 y += gap;
             } else {
                 /* Advance to the baseline. */
-                y += gap + max_height_above;
+                y += gap + icon_size;
             }
 
-        lay_down_one_line (container, line_start, NULL, y, max_height_above, positions, TRUE, gap);
+        lay_down_one_line (container, line_start, NULL, y, icon_size, positions, TRUE, gap);
     }
 
     g_array_free (positions, TRUE);
@@ -2041,10 +2047,21 @@ nemo_icon_view_container_get_max_layout_lines (NemoIconContainer  *container)
     }
 
     if (limit <= 0) {
-        return G_MAXINT;
+        return 3;
     }
 
     return limit;
+}
+
+static gint
+nemo_icon_view_container_get_additional_text_line_count (NemoIconContainer *container)
+{
+    GQuark *attributes;
+    gint len;
+
+    attributes = nemo_icon_view_container_get_icon_text_attribute_names (container, &len);
+
+    return len;
 }
 
 static void
@@ -2096,6 +2113,7 @@ nemo_icon_view_container_class_init (NemoIconViewContainerClass *klass)
     ic_class->finish_adding_new_icons = nemo_icon_view_container_finish_adding_new_icons;
     ic_class->icon_get_bounding_box = nemo_icon_view_container_icon_get_bounding_box;
     ic_class->set_zoom_level = nemo_icon_view_container_set_zoom_level;
+    ic_class->get_additional_text_line_count = nemo_icon_view_container_get_additional_text_line_count;
 }
 
 static void

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -64,7 +64,8 @@ nemo_icon_view_grid_container_get_icon_images (NemoIconContainer *container,
 					      NemoIconData      *data,
 					      int                    size,
 					      gboolean               for_drag_accept,
-					      gboolean              *has_window_open)
+					      gboolean              *has_window_open,
+                          gboolean               visible)
 {
 	NemoIconView *icon_view;
 	NemoFile *file;
@@ -848,7 +849,8 @@ nemo_icon_view_grid_container_move_icon (NemoIconContainer *container,
 
 static void
 nemo_icon_view_grid_container_update_icon (NemoIconContainer *container,
-                                           NemoIcon          *icon)
+                                           NemoIcon          *icon,
+                                           gboolean           visible)
 {
     NemoIconContainerDetails *details;
     guint icon_size;
@@ -876,7 +878,7 @@ nemo_icon_view_grid_container_update_icon (NemoIconContainer *container,
     /* Get the icons. */
     icon_info = nemo_icon_container_get_icon_images (container, icon->data, icon_size,
                                                      icon == details->drop_target,
-                                                     &has_open_window);
+                                                     &has_open_window, TRUE);
 
     scale_factor = gtk_widget_get_scale_factor (GTK_WIDGET (container));
     pixbuf = nemo_icon_info_get_desktop_pixbuf_at_size (icon_info,

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -1545,6 +1545,12 @@ nemo_icon_view_grid_container_get_max_layout_lines (NemoIconContainer  *containe
     return limit;
 }
 
+static gint
+nemo_icon_view_grid_container_get_additional_text_line_count (NemoIconContainer *container)
+{
+    return quarkv_length (NEMO_ICON_VIEW_GRID_CONTAINER (container)->attributes);
+}
+
 static void
 captions_changed_callback (NemoIconContainer *container)
 {
@@ -1672,6 +1678,7 @@ nemo_icon_view_grid_container_class_init (NemoIconViewGridContainerClass *klass)
 	ic_class->prioritize_thumbnailing = nemo_icon_view_grid_container_prioritize_thumbnailing;
     ic_class->get_max_layout_lines_for_pango = nemo_icon_view_grid_container_get_max_layout_lines_for_pango;
     ic_class->get_max_layout_lines = nemo_icon_view_grid_container_get_max_layout_lines;
+    ic_class->get_additional_text_line_count = nemo_icon_view_grid_container_get_additional_text_line_count;
 
 	ic_class->compare_icons = nemo_icon_view_grid_container_compare_icons;
 	ic_class->freeze_updates = nemo_icon_view_grid_container_freeze_updates;

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -985,6 +985,8 @@ nemo_icon_view_begin_loading (NemoView *view)
 	uri = nemo_file_get_uri (file);
 	icon_container = GTK_WIDGET (get_icon_container (icon_view));
 
+    nemo_icon_container_set_ok_to_load_thumbs (NEMO_ICON_CONTAINER (icon_container), FALSE);
+
 	nemo_icon_container_begin_loading (NEMO_ICON_CONTAINER (icon_container));
 
 	nemo_icon_container_set_allow_moves (NEMO_ICON_CONTAINER (icon_container),
@@ -1090,7 +1092,7 @@ nemo_icon_view_end_loading (NemoView *view,
 
 	monitor = nemo_clipboard_monitor_get ();
 	info = nemo_clipboard_monitor_get_clipboard_info (monitor);
-
+    nemo_icon_container_set_ok_to_load_thumbs (NEMO_ICON_CONTAINER (icon_container), TRUE);
 	icon_view_notify_clipboard_info (monitor, info, icon_view);
 }
 

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -81,8 +81,6 @@ struct NemoListModelDetails {
 
 	GList *highlight_files;
     gboolean temp_unsorted;
-
-    gboolean ok_to_load_thumbs;
 };
 
 typedef struct {
@@ -320,7 +318,7 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
 			flags = NEMO_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE |
 				NEMO_FILE_ICON_FLAGS_USE_MOUNT_ICON_AS_EMBLEM;
 
-            if (model->details->ok_to_load_thumbs) {
+            if (file_entry->ok_to_show_thumb) {
                 flags |= NEMO_FILE_ICON_FLAGS_USE_THUMBNAILS;
             }
 
@@ -1844,11 +1842,4 @@ nemo_list_model_set_expanding (NemoListModel *model, NemoDirectory *directory)
 
     entry = g_sequence_get (ptr);
     entry->expanding = TRUE;
-}
-
-void
-nemo_list_model_set_ok_to_load_thumbs (NemoListModel *model,
-                                       gboolean       ok)
-{
-    model->details->ok_to_load_thumbs = ok;
 }

--- a/src/nemo-list-model.h
+++ b/src/nemo-list-model.h
@@ -55,6 +55,7 @@ enum {
 	NEMO_LIST_MODEL_LARGEST_ICON_COLUMN,
 	NEMO_LIST_MODEL_FILE_NAME_IS_EDITABLE_COLUMN,
     NEMO_LIST_MODEL_TEXT_WEIGHT_COLUMN,
+    NEMO_LIST_MODEL_ICON_SHOWN,
 	NEMO_LIST_MODEL_NUM_COLUMNS
 };
 
@@ -137,4 +138,7 @@ void              nemo_list_model_set_highlight_for_files (NemoListModel *model,
 void              nemo_list_model_set_temporarily_disable_sort (NemoListModel *model, gboolean disable);
 gboolean          nemo_list_model_get_temporarily_disable_sort (NemoListModel *model);
 void              nemo_list_model_set_expanding                (NemoListModel *model, NemoDirectory *directory);
+void              nemo_list_model_set_ok_to_load_thumbs (NemoListModel *model,
+                                                         gboolean       ok);
+
 #endif /* NEMO_LIST_MODEL_H */

--- a/src/nemo-list-model.h
+++ b/src/nemo-list-model.h
@@ -138,7 +138,6 @@ void              nemo_list_model_set_highlight_for_files (NemoListModel *model,
 void              nemo_list_model_set_temporarily_disable_sort (NemoListModel *model, gboolean disable);
 gboolean          nemo_list_model_get_temporarily_disable_sort (NemoListModel *model);
 void              nemo_list_model_set_expanding                (NemoListModel *model, NemoDirectory *directory);
-void              nemo_list_model_set_ok_to_load_thumbs (NemoListModel *model,
-                                                         gboolean       ok);
+
 
 #endif /* NEMO_LIST_MODEL_H */

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -2197,7 +2197,7 @@ prioritize_visible_files (NemoListView *view)
     GdkRectangle vrect;
     GtkTreeIter iter;
     GtkTreePath *path;
-    gint icon_size, cy, bottom_y, stepdown;
+    gint icon_size, cy, start_y, end_y, stepdown;
     gint bin_y;
 
     gtk_tree_view_get_visible_rect (view->details->tree_view,
@@ -2208,20 +2208,17 @@ prioritize_visible_files (NemoListView *view)
                                                     1, vrect.y,
                                                     NULL, &bin_y);
 
-    /* Start at the bottom of the view and scan our way up.  We do it in reverse here
-     * because we're placing files on top of the thumbnailer stack, and so the last file
-     * added will be the first thumbnailed. */
-
-    /* Start the first pixel and work up in smallish steps relative to the current icon size. */
     stepdown = icon_size * .75;
-    bottom_y = bin_y + vrect.height;
-    // cy = bottom_y - 1;
-    cy = bottom_y + vrect.height / 2;
 
-    // queue_list = NULL;
+    start_y = bin_y - (vrect.height / 2);
+    end_y = bin_y + vrect.height + (vrect.height / 2);
+
     last_file = NULL;
+    cy = end_y;
 
-    while (cy > (bin_y - vrect.height / 2)) {
+    // Images that start out un-thumbnailed end up resolving in reverse
+    // order, so work bottom-up here.
+    while (cy > start_y) {
         if (gtk_tree_view_get_path_at_pos (view->details->tree_view,
                                            1, cy,
                                            &path, NULL, NULL, NULL)) {

--- a/src/nemo-pathbar.c
+++ b/src/nemo-pathbar.c
@@ -400,6 +400,7 @@ nemo_path_bar_finalize (GObject *object)
     g_clear_object (&path_bar->priv->xdg_public_path);
     g_clear_object (&path_bar->priv->xdg_templates_path);
     g_clear_object (&path_bar->priv->xdg_videos_path);
+    g_clear_object (&path_bar->priv->desktop_path);
 
     g_signal_handlers_disconnect_by_func (nemo_preferences,
                           desktop_location_changed_callback,

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -4304,6 +4304,9 @@ nemo_places_sidebar_dispose (GObject *object)
 
 	g_clear_object (&sidebar->store);
 
+    g_clear_pointer (&sidebar->top_bookend_uri, g_free);
+    g_clear_pointer (&sidebar->bottom_bookend_uri, g_free);
+
 	if (sidebar->go_to_after_mount_slot) {
 		g_object_remove_weak_pointer (G_OBJECT (sidebar->go_to_after_mount_slot),
 					      (gpointer *) &sidebar->go_to_after_mount_slot);

--- a/src/nemo-query-editor.c
+++ b/src/nemo-query-editor.c
@@ -102,6 +102,7 @@ nemo_query_editor_dispose (GObject *object)
 	editor = NEMO_QUERY_EDITOR (object);
 
     g_clear_pointer (&editor->priv->base_uri, g_free);
+    g_clear_pointer (&editor->priv->last_set_query_text, g_free);
 
 	if (editor->priv->typing_timeout_id > 0) {
 		g_source_remove (editor->priv->typing_timeout_id);
@@ -299,6 +300,7 @@ add_key_to_faves (NemoQueryEditor *editor,
                                        on_saved_searches_setting_changed,
                                        editor);
 
+    g_clear_pointer (&editor->priv->faves, g_strfreev);
     editor->priv->faves = (gchar **) g_ptr_array_free (array, FALSE);
 }
 
@@ -351,6 +353,7 @@ remove_key_from_faves (NemoQueryEditor *editor,
     g_free (key);
     g_free (uri);
 
+    g_clear_pointer (&editor->priv->faves, g_strfreev);
     editor->priv->faves = (gchar **) g_ptr_array_free (array, FALSE);
 }
 
@@ -455,6 +458,7 @@ on_menu_item_activated (GtkMenuItem *item,
 
         g_free (favorite_location);
         g_free (favorite_key);
+        g_object_unref (query);
     }
 }
 
@@ -699,6 +703,7 @@ on_saved_searches_setting_changed (GSettings *settings,
 
     editor = NEMO_QUERY_EDITOR (user_data);
 
+    g_clear_pointer (&editor->priv->faves, g_strfreev);
     editor->priv->faves = g_settings_get_strv (settings, key);
 }
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -5072,7 +5072,7 @@ setup_bookmark_action(      char *action_name,
                             action_name,
                             GTK_UI_MANAGER_MENUITEM,
                             FALSE);
-
+    g_object_unref (action);
     g_free (action_name);
 }
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -96,13 +96,13 @@
 #include <libnemo-private/nemo-debug.h>
 
 /* Minimum starting update inverval */
-#define UPDATE_INTERVAL_MIN 50
+#define UPDATE_INTERVAL_MIN 200
 /* Maximum update interval */
-#define UPDATE_INTERVAL_MAX 2050
+#define UPDATE_INTERVAL_MAX 2000
 /* Amount of miliseconds the update interval is increased */
 #define UPDATE_INTERVAL_INC 250
 /* Interval at which the update interval is increased */
-#define UPDATE_INTERVAL_TIMEOUT_INTERVAL 250
+#define UPDATE_INTERVAL_TIMEOUT_INTERVAL 500
 /* Milliseconds that have to pass without a change to reset the update interval */
 #define UPDATE_INTERVAL_RESET 1000
 
@@ -111,7 +111,7 @@
 #define DUPLICATE_HORIZONTAL_ICON_OFFSET 70
 #define DUPLICATE_VERTICAL_ICON_OFFSET   30
 
-#define MAX_QUEUED_UPDATES 500
+#define MAX_QUEUED_UPDATES 250
 
 #define NEMO_VIEW_MENU_PATH_OPEN_PLACEHOLDER                  "/MenuBar/File/Open Placeholder"
 #define NEMO_VIEW_MENU_PATH_APPLICATIONS_SUBMENU_PLACEHOLDER  "/MenuBar/File/Open Placeholder/Open With/Applications Placeholder"


### PR DESCRIPTION
Use a static spacing for the icon layout, this eliminates constant re-layouts as thumbnails are loaded.

Delay thumbnail loading initially, until the view is finished being populated.  This is by far the costliest async operation, and when loading a pre-existing thumbnail ends up having a large impact on view loading time.  
The file may already have a thumbnail (if it was spawned by another folder or tab), in this case we delay using that thumbnail until the end.

Once the view is fully populated, the currently visible items have their thumbnails loaded.  As the view is scrolled, the thumbnails will be loaded on demand.

