### PR TITLE
nemo-notebook: Add a minimum width for the tab labels

### DIFF
--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -349,6 +349,7 @@ build_tab_label (NemoNotebook *nb, NemoWindowSlot *slot)
 
 	/* setup label */
 	label = gtk_label_new (NULL);
+    gtk_label_set_width_chars (GTK_LABEL (label), 8);
 	gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
 	gtk_label_set_single_line_mode (GTK_LABEL (label), TRUE);
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);


### PR DESCRIPTION
This way we don't end up with labels that show only three dots when you have
a few open tabs.