### PR TITLE
Add %e action token (extension stripped filename)

### DIFF
--- a/files/usr/share/nemo/actions/sample.nemo_action
+++ b/files/usr/share/nemo/actions/sample.nemo_action
@@ -22,7 +22,7 @@ Active=false
 # %f or %N (deprecated) - insert display name of first selected file
 # %p - insert display name of parent directory
 # %D - insert device path of file (i.e. /dev/sdb1)
-
+# %e - insert display name of first selected file with the extension stripped
 
 # The name to show in the menu, locale supported with standard desktop spec.
 # **** REQUIRED ****

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -19,6 +19,7 @@
 
 #include "nemo-action.h"
 #include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
 #include <glib/gi18n.h>
 #include <gdk/gdk.h>
 #include "nemo-file-utilities.h"
@@ -1158,6 +1159,10 @@ find_token_type (const gchar *str, TokenType *token_type)
             *token_type = TOKEN_DEVICE;
             return ptr;
         }
+        if (g_str_has_prefix (ptr, TOKEN_EXEC_FILE_NO_EXT)) {
+            *token_type = TOKEN_FILE_DISPLAY_NAME_NO_EXT;
+            return ptr;
+        }
     }
 
     return NULL;
@@ -1349,6 +1354,15 @@ default_parent_display_name:
                     str = insert_quote (action, str);
                     first = FALSE;
                 }
+            } else {
+                goto default_parent_path;
+            }
+            break;
+        case TOKEN_FILE_DISPLAY_NAME_NO_EXT:
+            if (g_list_length (selection) > 0) {
+                gchar *file_display_name = nemo_file_get_display_name (NEMO_FILE (selection->data));
+                str = score_append (action, str, eel_filename_strip_extension (file_display_name));
+                g_free (file_display_name);
             } else {
                 goto default_parent_path;
             }

--- a/libnemo-private/nemo-action.h
+++ b/libnemo-private/nemo-action.h
@@ -49,6 +49,7 @@
 #define TOKEN_EXEC_FILE_NAME "%f"
 #define TOKEN_EXEC_PARENT_NAME "%p"
 #define TOKEN_EXEC_DEVICE "%D"
+#define TOKEN_EXEC_FILE_NO_EXT "%e"
 
 #define TOKEN_LABEL_FILE_NAME "%N" // Leave in for compatibility, same as TOKEN_EXEC_FILE_NAME
 
@@ -97,7 +98,8 @@ typedef enum {
     TOKEN_FILE_DISPLAY_NAME,
     TOKEN_PARENT_DISPLAY_NAME,
     TOKEN_PARENT_PATH,
-    TOKEN_DEVICE
+    TOKEN_DEVICE,
+    TOKEN_FILE_DISPLAY_NAME_NO_EXT
 } TokenType;
 
 struct _NemoAction {


### PR DESCRIPTION
The new modifier will return the file name with the extension stripped.
This allows us to create actions such as "Extract \<archive.ext\> to \<archive\>..." to avoid a situation where common "Extract here" actions would otherwise dump contents of the archive to the current directory if it does not contain a root directory inside while being quicker to use than "Extract to" actions, for example:
```[Nemo Action]
Active=true
Name=Extract to %e...
Comment=Extract "%f" to "%e"
Exec=file-roller --extract-to=%P/%e %F
Icon-Name=gnome-mime-application-x-compress
Selection=notnone
Extensions=zip;7z;ar;cbz;cpio;exe;iso;jar;tar;tar.Z;tar.bz2;tar.gz;tar.lz;tar.lzma;tar.xz;
Quote=double
```