### PR TITLE
Add places sidebar preferences

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -64,6 +64,10 @@ typedef enum
 
 /* Sidebar panels  */
 #define NEMO_PREFERENCES_TREE_SHOW_ONLY_DIRECTORIES         "show-only-directories"
+#define NEMO_PREFERENCES_PLACES_SHOW_RECENT                 "places-show-recent"
+#define NEMO_PREFERENCES_PLACES_SHOW_TRASH                  "places-show-trash"
+#define NEMO_PREFERENCES_PLACES_SHOW_BOOKMARKS              "places-show-bookmarks"
+#define NEMO_PREFERENCES_PLACES_SHOW_NETWORK                "places-show-network"
 
 /* Single/Double click preference  */
 #define NEMO_PREFERENCES_CLICK_POLICY			"click-policy"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -74,7 +74,7 @@
   <schema id="org.nemo.preferences" path="/org/nemo/preferences/" gettext-domain="nemo">
     <key name="tabs-open-position" enum="org.nemo.TabPosition">
       <aliases>
-	<alias value='after_current_tab' target='after-current-tab'/>
+        <alias value='after_current_tab' target='after-current-tab'/>
       </aliases>
       <default>'after-current-tab'</default>
       <summary>Where to position newly open tabs in browser windows.</summary>
@@ -249,7 +249,7 @@
     </key>
     <key name="default-sort-order" enum="org.nemo.SortOrder">
       <aliases>
-	<alias value='modification_date' target='mtime'/>
+        <alias value='modification_date' target='mtime'/>
       </aliases>
       <default>'name'</default>
       <summary>Default sort order</summary>
@@ -398,6 +398,26 @@
     <key name="enable-mime-actions-make-executable" type="b">
       <default>false</default>
       <summary>Display the 'Make executable and run' button in the mime-action dialog (open an unknown filetype)</summary>
+    </key>
+    <key name="places-show-recent" type="b">
+      <default>true</default>
+      <summary>Show recent entry in the places sidebar</summary>
+      <description>If set to true, then Nemo shows the Recent sidebar places entry.</description>
+    </key>
+    <key name="places-show-trash" type="b">
+      <default>true</default>
+      <summary>Show trash entry in the places sidebar</summary>
+      <description>If set to true, then Nemo shows the Trash sidebar places entry.</description>
+    </key>
+    <key name="places-show-bookmarks" type="b">
+      <default>true</default>
+      <summary>Show recent entry in the bookmarks sidebar</summary>
+      <description>If set to true, then Nemo shows the Bookmarks sidebar places entry.</description>
+    </key>
+    <key name="places-show-network" type="b">
+      <default>true</default>
+      <summary>Show network entry in the places sidebar</summary>
+      <description>If set to true, then Nemo shows the Network sidebar places entry.</description>
     </key>
   </schema>
 

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -111,6 +111,11 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_SKIP_FILE_OP_QUEUE_WIDGET "skip_file_op_queue_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET "click_double_parent_folder_checkbutton"
 
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_RECENT "places_show_recent"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_TRASH "places_show_trash"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_BOOKMARKS "places_show_bookmarks"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_NETWORK "places_show_network"
+
 /* int enums */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_LIMIT_WIDGET "preview_image_size_combobox"
 
@@ -1047,6 +1052,22 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET,
                        NEMO_PREFERENCES_CLICK_DOUBLE_PARENT_FOLDER);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_RECENT,
+                       NEMO_PREFERENCES_PLACES_SHOW_RECENT);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_TRASH,
+                       NEMO_PREFERENCES_PLACES_SHOW_TRASH);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_BOOKMARKS,
+                       NEMO_PREFERENCES_PLACES_SHOW_BOOKMARKS);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_SHOW_NETWORK,
+                       NEMO_PREFERENCES_PLACES_SHOW_NETWORK);
 
     setup_tooltip_items (builder);
     connect_tooltip_items (builder);


### PR DESCRIPTION
This adds customization preferences to toggle the following items from the places sidebar:
* Recent
* Trash
* Bookmarks group
* Network group

There's no GUI way to toggle them as I'm not familiar with Glade however they can be toggled using gsetting for the time being:
* `gsettings set org.nemo.preferences places-show-recent (true|false)`
* `gsettings set org.nemo.preferences places-show-trash (true|false)`
* `gsettings set org.nemo.preferences places-show-bookmarks (true|false)`
* `gsettings set org.nemo.preferences places-show-network (true|false)`
