### PR TITLE
[WIP] Show tab area permanently if desired

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+nemo (3.8.6) tara; urgency=medium
+
+  [ Michael Webster ]
+  * nemo-icon-canvas-item.c: Insert some space between the icon and label bounds in compact view.
+  * nemo-query-editor.c: don't intercept keys when hidden.
+  * nemo-places-sidebar.c: Fix a few issues with mounting/ejecting - some incorrect _finish functions and some assumptions of error always being set.
+
+ -- Clement Lefebvre <root@linuxmint.com>  Tue, 11 Sep 2018 14:52:55 +0100
+
 nemo (3.8.5) tara; urgency=medium
 
   [ Michael Webster ]

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="model1">
@@ -260,6 +260,9 @@
     <property name="default_width">800</property>
     <property name="default_height">600</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -1085,6 +1088,23 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="show_tab_area_checkbutton">
+                                            <property name="label" translatable="yes">Always show tab area (change effective for new panes)</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="padding">3</property>
+                                            <property name="position">5</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="ignore_view_metadata_checkbutton">
                                             <property name="label" translatable="yes">Ignore per-folder view preferences</property>
                                             <property name="visible">True</property>
@@ -1098,7 +1118,7 @@
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">5</property>
+                                            <property name="position">6</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1115,7 +1135,7 @@
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">6</property>
+                                            <property name="position">7</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1132,7 +1152,7 @@
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">7</property>
+                                            <property name="position">8</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3064,9 +3084,6 @@
     <action-widgets>
       <action-widget response="-7">closebutton1</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
     <style>
       <class name="nemo-properties-dialog"/>
     </style>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -120,6 +120,7 @@ typedef enum
 #define NEMO_PREFERENCES_CLOSE_DEVICE_VIEW_ON_EJECT "close-device-view-on-device-eject"
 
 #define NEMO_PREFERENCES_START_WITH_DUAL_PANE "start-with-dual-pane"
+#define NEMO_PREFERENCES_SHOW_TAB_AREA "show-tab-area"
 #define NEMO_PREFERENCES_IGNORE_VIEW_METADATA "ignore-view-metadata"
 #define NEMO_PREFERENCES_SHOW_BOOKMARKS_IN_TO_MENUS "show-bookmarks-in-to-menus"
 #define NEMO_PREFERENCES_SHOW_PLACES_IN_TO_MENUS "show-places-in-to-menus"

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -49,6 +49,7 @@
 
 /* gap between bottom of icon and start of text box */
 #define LABEL_OFFSET 1
+#define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
 
 /* special text height handling
@@ -656,7 +657,7 @@ compute_text_rectangle (const NemoIconCanvasItem *item,
 
 	if (NEMO_ICON_CONTAINER (EEL_CANVAS_ITEM (item)->canvas)->details->label_position == NEMO_ICON_LABEL_POSITION_BESIDE) {
 		if (!nemo_icon_container_is_layout_rtl (NEMO_ICON_CONTAINER (EEL_CANVAS_ITEM (item)->canvas))) {
-                	text_rectangle.x0 = icon_rectangle.x1;
+                	text_rectangle.x0 = icon_rectangle.x1 + LABEL_OFFSET_BESIDES;
                 	text_rectangle.x1 = text_rectangle.x0 + text_dx + text_width;
 		} else {
                 	text_rectangle.x1 = icon_rectangle.x0;

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -295,6 +295,11 @@
       <summary>Whether to default to showing dual-pane view when a new window is opened</summary>
       <description>If set to true, new Nemo windows will default to showing two panes</description>
     </key>
+    <key name="show-tab-area" type="b">
+      <default>false</default>
+      <summary>Whether to default to showing the tab area even if there is only one tab</summary>
+      <description>If set to true, the tab area will always be visible in every pane</description>
+    </key>
     <key name="ignore-view-metadata" type="b">
       <default>false</default>
       <summary>Whether to ignore folder metadata for view zoom levels and layouts</summary>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build file
 
 # https://github.com/linuxmint/nemo
-project('nemo', 'c', version: '3.8.5',
+project('nemo', 'c', version: '3.8.6',
   meson_version: '>=0.37.0'
 )
 

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -85,6 +85,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTORUN_MEDIA_WIDGET "media_autorun_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ADVANCED_PERMISSIONS_WIDGET "show_advanced_permissions_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET "start_with_dual_pane_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_TAB_AREA_WIDGET "show_tab_area_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_IN_TO_MENUS_WIDGET "places_in_to_checkbutton"
@@ -938,6 +939,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET,
                        NEMO_PREFERENCES_START_WITH_DUAL_PANE);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_TAB_AREA_WIDGET,
+                       NEMO_PREFERENCES_SHOW_TAB_AREA);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET,

--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -404,10 +404,13 @@ nemo_notebook_insert_page (GtkNotebook *gnotebook,
 										     menu_label,
 										     position);
 
+	// Attention: The callback notebook_page_added_cb invoked by the preceding function call
+	// may have destroyed the tab_widget (in case of tab dragging and dropping to a freshly
+	// created window)
+
 	gtk_notebook_set_show_tabs (gnotebook,
 				    gtk_notebook_get_n_pages (gnotebook) > 1 ||
 					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
-	gtk_notebook_set_tab_reorderable (gnotebook, tab_widget, TRUE);
 
     // set detachable state depending on number of slots (a single slot
 	// should stay where it is)
@@ -416,6 +419,7 @@ nemo_notebook_insert_page (GtkNotebook *gnotebook,
 	{
 		GtkWidget *tab_widget_temp = gtk_notebook_get_nth_page (gnotebook, i);
 		gtk_notebook_set_tab_detachable (gnotebook, tab_widget_temp, num_pages > 1);
+		gtk_notebook_set_tab_reorderable (gnotebook, tab_widget_temp, TRUE);
 	}
 
 	return position;

--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -235,7 +235,7 @@ nemo_notebook_init (NemoNotebook *notebook)
 {
 	gtk_notebook_set_scrollable (GTK_NOTEBOOK (notebook), TRUE);
 	gtk_notebook_set_show_border (GTK_NOTEBOOK (notebook), FALSE);
-	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (notebook), FALSE);
+	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (notebook), TRUE);
 
 	/* Make it so that pressing ctrl+tab/ctrl+shift+tab switches the currently
 	 * focused tab.
@@ -402,7 +402,7 @@ nemo_notebook_insert_page (GtkNotebook *gnotebook,
 										     position);
 
 	gtk_notebook_set_show_tabs (gnotebook,
-				    gtk_notebook_get_n_pages (gnotebook) > 1);
+				    gtk_notebook_get_n_pages (gnotebook) > 0);
 	gtk_notebook_set_tab_reorderable (gnotebook, tab_widget, TRUE);
 	gtk_notebook_set_tab_detachable (gnotebook, tab_widget, TRUE);
 
@@ -459,7 +459,7 @@ nemo_notebook_remove (GtkContainer *container,
 	GTK_CONTAINER_CLASS (nemo_notebook_parent_class)->remove (container, tab_widget);
 
 	gtk_notebook_set_show_tabs (gnotebook,
-				    gtk_notebook_get_n_pages (gnotebook) > 1);
+				    gtk_notebook_get_n_pages (gnotebook) > 0);
 
 }
 

--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -408,7 +408,15 @@ nemo_notebook_insert_page (GtkNotebook *gnotebook,
 				    gtk_notebook_get_n_pages (gnotebook) > 1 ||
 					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 	gtk_notebook_set_tab_reorderable (gnotebook, tab_widget, TRUE);
-	gtk_notebook_set_tab_detachable (gnotebook, tab_widget, TRUE);
+
+    // set detachable state depending on number of slots (a single slot
+	// should stay where it is)
+	gint num_pages = gtk_notebook_get_n_pages (gnotebook);
+	for (gint i = 0; i < num_pages; i++)
+	{
+		GtkWidget *tab_widget_temp = gtk_notebook_get_nth_page (gnotebook, i);
+		gtk_notebook_set_tab_detachable (gnotebook, tab_widget_temp, num_pages > 1);
+	}
 
 	return position;
 }
@@ -466,6 +474,14 @@ nemo_notebook_remove (GtkContainer *container,
 				    gtk_notebook_get_n_pages (gnotebook) > 1 || 
 					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 
+    // set detachable state depending on number of slots (a single slot
+	// should stay where it is)
+	gint num_pages = gtk_notebook_get_n_pages (gnotebook);
+	if (num_pages == 1)
+	{
+		GtkWidget *tab_widget_temp = gtk_notebook_get_nth_page (gnotebook, 0);
+		gtk_notebook_set_tab_detachable (gnotebook, tab_widget_temp, num_pages > 1);
+	}
 }
 
 void

--- a/src/nemo-notebook.c
+++ b/src/nemo-notebook.c
@@ -38,6 +38,8 @@
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
+#include <libnemo-private/nemo-global-preferences.h>
+
 #define AFTER_ALL_TABS -1
 #define NOT_IN_APP_WINDOWS -2
 
@@ -235,7 +237,8 @@ nemo_notebook_init (NemoNotebook *notebook)
 {
 	gtk_notebook_set_scrollable (GTK_NOTEBOOK (notebook), TRUE);
 	gtk_notebook_set_show_border (GTK_NOTEBOOK (notebook), FALSE);
-	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (notebook), TRUE);
+	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (notebook),
+			  g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 
 	/* Make it so that pressing ctrl+tab/ctrl+shift+tab switches the currently
 	 * focused tab.
@@ -402,7 +405,8 @@ nemo_notebook_insert_page (GtkNotebook *gnotebook,
 										     position);
 
 	gtk_notebook_set_show_tabs (gnotebook,
-				    gtk_notebook_get_n_pages (gnotebook) > 0);
+				    gtk_notebook_get_n_pages (gnotebook) > 1 ||
+					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 	gtk_notebook_set_tab_reorderable (gnotebook, tab_widget, TRUE);
 	gtk_notebook_set_tab_detachable (gnotebook, tab_widget, TRUE);
 
@@ -459,7 +463,8 @@ nemo_notebook_remove (GtkContainer *container,
 	GTK_CONTAINER_CLASS (nemo_notebook_parent_class)->remove (container, tab_widget);
 
 	gtk_notebook_set_show_tabs (gnotebook,
-				    gtk_notebook_get_n_pages (gnotebook) > 0);
+				    gtk_notebook_get_n_pages (gnotebook) > 1 || 
+					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 
 }
 

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -2741,31 +2741,48 @@ unmount_shortcut_cb (GtkMenuItem           *item,
 }
 
 static void
+handle_mount_unmount_failure (const gchar *primary,
+                              GError      *error)
+{
+    const gchar *message = NULL;
+
+    if (error && error->code == G_IO_ERROR_FAILED_HANDLED) {
+        return;
+    }
+
+    if (error) {
+        message = error->message;
+    }
+
+    eel_show_error_dialog (primary,
+                           message,
+                           NULL);
+}
+
+static void
 drive_eject_cb (GObject *source_object,
 		GAsyncResult *res,
 		gpointer user_data)
 {
 	NemoWindow *window;
 	GError *error;
-	char *primary;
-	char *name;
 
 	window = user_data;
 	g_object_unref (window);
 
 	error = NULL;
 	if (!g_drive_eject_with_operation_finish (G_DRIVE (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_drive_get_name (G_DRIVE (source_object));
-			primary = g_strdup_printf (_("Unable to eject %s"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-				       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+        char *name, *primary;
+
+        name = g_drive_get_name (G_DRIVE (source_object));
+        primary = g_strdup_printf (_("Unable to eject %s"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void
@@ -2775,25 +2792,23 @@ volume_eject_cb (GObject *source_object,
 {
 	NemoWindow *window;
 	GError *error;
-	char *primary;
-	char *name;
 
 	window = user_data;
 	g_object_unref (window);
 
 	error = NULL;
 	if (!g_volume_eject_with_operation_finish (G_VOLUME (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_volume_get_name (G_VOLUME (source_object));
-			primary = g_strdup_printf (_("Unable to eject %s"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-					       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+        char *name, *primary;
+
+        name = g_volume_get_name (G_VOLUME (source_object));
+        primary = g_strdup_printf (_("Unable to eject %s"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void
@@ -2803,25 +2818,23 @@ mount_eject_cb (GObject *source_object,
 {
 	NemoWindow *window;
 	GError *error;
-	char *primary;
-	char *name;
 
 	window = user_data;
 	g_object_unref (window);
 
 	error = NULL;
 	if (!g_mount_eject_with_operation_finish (G_MOUNT (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_mount_get_name (G_MOUNT (source_object));
-			primary = g_strdup_printf (_("Unable to eject %s"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-					       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+        char *name, *primary;
+
+        name = g_mount_get_name (G_MOUNT (source_object));
+        primary = g_strdup_printf (_("Unable to eject %s"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void
@@ -2945,22 +2958,20 @@ drive_poll_for_media_cb (GObject *source_object,
 			 gpointer user_data)
 {
 	GError *error;
-	char *primary;
-	char *name;
 
 	error = NULL;
 	if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_drive_get_name (G_DRIVE (source_object));
-			primary = g_strdup_printf (_("Unable to poll %s for media changes"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-					       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+        char *name, *primary;
+
+        name = g_drive_get_name (G_DRIVE (source_object));
+        primary = g_strdup_printf (_("Unable to poll %s for media changes"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void
@@ -2990,22 +3001,21 @@ drive_start_cb (GObject      *source_object,
 		gpointer      user_data)
 {
 	GError *error;
-	char *primary;
-	char *name;
 
 	error = NULL;
-	if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_drive_get_name (G_DRIVE (source_object));
-			primary = g_strdup_printf (_("Unable to start %s"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-					       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+
+	if (!g_drive_start_finish (G_DRIVE (source_object), res, &error)) {
+        char *name, *primary;
+
+        name = g_drive_get_name (G_DRIVE (source_object));
+        primary = g_strdup_printf (_("Unable to start %s"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void
@@ -3042,25 +3052,24 @@ drive_stop_cb (GObject *source_object,
 {
 	NemoWindow *window;
 	GError *error;
-	char *primary;
-	char *name;
 
 	window = user_data;
 	g_object_unref (window);
 
 	error = NULL;
-	if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error)) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
-			name = g_drive_get_name (G_DRIVE (source_object));
-			primary = g_strdup_printf (_("Unable to stop %s"), name);
-			g_free (name);
-			eel_show_error_dialog (primary,
-					       error->message,
-					       NULL);
-			g_free (primary);
-		}
-		g_error_free (error);
-	}
+
+    if (!g_drive_stop_finish (G_DRIVE (source_object), res, &error)) {
+        char *name, *primary;
+
+        name = g_drive_get_name (G_DRIVE (source_object));
+        primary = g_strdup_printf (_("Unable to stop %s"), name);
+
+        handle_mount_unmount_failure (primary, error);
+
+        g_free (name);
+        g_free (primary);
+        g_clear_error (&error);
+    }
 }
 
 static void

--- a/src/nemo-query-editor.c
+++ b/src/nemo-query-editor.c
@@ -720,11 +720,6 @@ nemo_query_editor_init (NemoQueryEditor *editor)
                       G_CALLBACK (entry_changed_cb),
                       editor);
 
-    g_signal_connect (priv->entry,
-                      "key-press-event",
-                      G_CALLBACK (on_key_press_event),
-                      editor);
-
     gtk_entry_set_icon_from_icon_name (GTK_ENTRY (priv->entry),
                                        GTK_ENTRY_ICON_PRIMARY,
                                        "edit-find-symbolic");
@@ -882,8 +877,17 @@ nemo_query_editor_set_active (NemoQueryEditor *editor,
         g_clear_pointer (&editor->priv->base_uri, g_free);
         editor->priv->base_uri = base_uri;
 
+        g_signal_connect (editor->priv->entry,
+                          "key-press-event",
+                          G_CALLBACK (on_key_press_event),
+                          editor);
+
         update_fav_icon (editor);
     } else {
+        g_signal_handlers_disconnect_by_func (editor->priv->entry,
+                                              on_key_press_event,
+                                              editor);
+
         gtk_widget_hide (editor->priv->infobar);
     }
 }

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -690,7 +690,23 @@ notebook_page_added_cb (GtkNotebook *notebook,
 	g_object_set_data (G_OBJECT (page), "dnd-window-slot",
 		   GINT_TO_POINTER (FALSE));
 
-	dummy_slot = g_list_nth_data (pane->slots, 0);
+	// Transfer location from newly arrived slot to the default slot which was
+	// just created without location in case of DND in the freshly generated window
+	if (gtk_notebook_get_n_pages (notebook) == 2) { // should always be true
+		GFile *location = nemo_window_slot_get_location (g_list_nth_data (pane->slots, 1));
+		if (location) {
+			nemo_window_slot_open_location (g_list_nth_data (pane->slots, 0), location, 0);
+			g_object_unref (location);
+		}
+		nemo_window_set_active_slot (pane->window, g_list_nth_data (pane->slots, 0));
+
+		// Delete newly arrived slot with number 1 (instead of default slot with number 0)
+		dummy_slot = g_list_nth_data (pane->slots, 1);
+	}
+	else {
+		dummy_slot = g_list_nth_data (pane->slots, 0);
+	}
+	
 	if (dummy_slot != NULL) {
 		nemo_window_pane_remove_slot_unsafe (
 			dummy_slot->pane, dummy_slot);

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -550,9 +550,6 @@ notebook_button_press_cb (GtkWidget *widget,
 	NemoNotebook *notebook;
 	int tab_clicked;
 
-	if (event->type != GDK_BUTTON_PRESS)
-		return FALSE;
-
 	/* Not a button event we actually care about, so just bail */
 	if (event->button != 1 && event->button != 2 && event->button != 3)
 		return FALSE;
@@ -561,6 +558,19 @@ notebook_button_press_cb (GtkWidget *widget,
 	notebook = NEMO_NOTEBOOK (pane->notebook);
 	tab_clicked = nemo_notebook_find_tab_num_at_pos (
 		notebook, event->x_root, event->y_root);
+
+	// Duplicate double-clicked tab, set focus on new tab
+	if (event->button == 1 && event->type == GDK_2BUTTON_PRESS) {
+		gtk_notebook_set_current_page (GTK_NOTEBOOK (notebook),
+				tab_clicked);
+		nemo_window_pane_set_active (pane, TRUE);
+		nemo_window_pane_grab_focus (pane);
+
+		nemo_window_new_tab (pane->window);
+    }
+
+	if (event->type != GDK_BUTTON_PRESS)
+		return FALSE;
 
 	/* Do not change the current page on middle-click events. Close the
 	 * clicked tab instead.

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -932,7 +932,7 @@ nemo_window_pane_constructed (GObject *obj)
 			  G_CALLBACK (notebook_page_removed_cb),
 			  pane);
 
-	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (pane->notebook), FALSE);
+	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (pane->notebook), TRUE);
 	gtk_notebook_set_show_border (GTK_NOTEBOOK (pane->notebook), FALSE);
 	gtk_notebook_set_group_name (GTK_NOTEBOOK (pane->notebook), "nemo-slots");
 	gtk_widget_show (pane->notebook);
@@ -1234,7 +1234,7 @@ nemo_window_pane_remove_slot_unsafe (NemoWindowPane *pane,
 					   pane);
 
 	gtk_notebook_set_show_tabs (notebook,
-				    gtk_notebook_get_n_pages (notebook) > 1);
+				    gtk_notebook_get_n_pages (notebook) > 0);
 	pane->slots = g_list_remove (pane->slots, slot);
 }
 

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -932,7 +932,8 @@ nemo_window_pane_constructed (GObject *obj)
 			  G_CALLBACK (notebook_page_removed_cb),
 			  pane);
 
-	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (pane->notebook), TRUE);
+	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (pane->notebook), 
+			  g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 	gtk_notebook_set_show_border (GTK_NOTEBOOK (pane->notebook), FALSE);
 	gtk_notebook_set_group_name (GTK_NOTEBOOK (pane->notebook), "nemo-slots");
 	gtk_widget_show (pane->notebook);
@@ -1234,7 +1235,8 @@ nemo_window_pane_remove_slot_unsafe (NemoWindowPane *pane,
 					   pane);
 
 	gtk_notebook_set_show_tabs (notebook,
-				    gtk_notebook_get_n_pages (notebook) > 0);
+				    gtk_notebook_get_n_pages (notebook) > 1 || 
+					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 	pane->slots = g_list_remove (pane->slots, slot);
 }
 

--- a/src/nemo-window-pane.c
+++ b/src/nemo-window-pane.c
@@ -1244,9 +1244,6 @@ nemo_window_pane_remove_slot_unsafe (NemoWindowPane *pane,
 					   G_CALLBACK (notebook_switch_page_cb),
 					   pane);
 
-	gtk_notebook_set_show_tabs (notebook,
-				    gtk_notebook_get_n_pages (notebook) > 1 || 
-					g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_TAB_AREA ));
 	pane->slots = g_list_remove (pane->slots, slot);
 }
 


### PR DESCRIPTION
In this PR a new setting is introduced ("Always show tab area") in the preferences dialogue box under "Behavior". If this checkbox is marked, all panes always show the tab area even if there is only one tab.

Two downfalls:
(1) On my current system, with the library packages provided by the distribution (Ubuntu 18.04), I only can build nemo 3.8, therefore the PR is not tested with master and does not merge cleanly with master.
(2) Right now, changes in the new setting only become effective for new panes, not for the already existing ones (however, add/remove tab from pane also causes an update). This could be improved by a callback function which updates all panes after a change to this setting was made (on closing the preferences dialogue box). Unfortunately, I don't have the time to dig that deeply in the code basis of nemo right now (I am also not a GTK expert), therefore I have decided to just create this PR as a starting point for further discussion or code development in this area.