### PR TITLE
settings: Set the default width of the sidebar to 170

### DIFF
--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -592,7 +592,7 @@
       <description>Whether the navigation window should be maximized by default.</description>
     </key>
     <key name="sidebar-width" type="i">
-      <default>148</default>
+      <default>170</default>
       <summary>Width of the side pane</summary>
       <description>The default width of the side pane in new windows.</description>
     </key>


### PR DESCRIPTION
The current setting of 148 causes text like "Downloads" to be ellipsized by
default. Up the size some to prevent this.