### PR TITLE
Add exec-args for open terminal

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -235,6 +235,7 @@ typedef enum
 
 /* Terminal */
 #define GNOME_DESKTOP_TERMINAL_EXEC        "exec"
+#define GNOME_DESKTOP_TERMINAL_EXEC_ARGS   "exec-arg"
 
 /* Tooltips */
 #define NEMO_PREFERENCES_TOOLTIPS_DESKTOP              "tooltips-on-desktop"

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7196,10 +7196,12 @@ open_as_root (const gchar *path)
 static void
 open_in_terminal (const gchar *path)
 {
-    gchar *argv[2];
+    gchar *argv[3];
     argv[0] = g_settings_get_string (gnome_terminal_preferences,
 				     GNOME_DESKTOP_TERMINAL_EXEC);
-    argv[1] = NULL;
+    argv[1] = g_settings_get_string (gnome_terminal_preferences,
+				     GNOME_DESKTOP_TERMINAL_EXEC_ARGS);
+    argv[2] = NULL;
     g_spawn_async(path, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }
 

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1243,9 +1243,10 @@ action_new_folder_callback (GtkAction *action,
 static void
 open_in_terminal_other (const gchar *path)
 {
-    gchar *argv[2];
+    gchar *argv[3];
     argv[0] = g_settings_get_string (gnome_terminal_preferences, GNOME_DESKTOP_TERMINAL_EXEC);
-    argv[1] = NULL;
+    argv[1] = g_settings_get_string (gnome_terminal_preferences, GNOME_DESKTOP_TERMINAL_EXEC_ARGS);
+    argv[2] = NULL;
     g_spawn_async(path, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }
 


### PR DESCRIPTION
I have
```bash
gsettings list-recursively org.cinnamon.desktop.default-applications.terminal
```
out:
```
org.cinnamon.desktop.default-applications.terminal exec-arg '--new-tab'
org.cinnamon.desktop.default-applications.terminal exec 'terminator
```
But "Open Terminal" action ignores exec-args. Fixed.
**Note:** it's can conflict with default terminal `-x` options.