### PR TITLE
Remove self-check functionality

### DIFF
--- a/docs/nemo.1
+++ b/docs/nemo.1
@@ -32,11 +32,6 @@ Nemo is the file manager for the Cinnamon desktop.
 Nemo follows the usual GNU command line syntax, with long options starting
 with two dashes (`-'). A summary of options is included below.
 .TP
-.B \-c
-.TP
-.B \-\-check
-Perform a quick set of self-check tests.
-.TP
 .B \-g
 .TP
 .B \-\-geometry=\fIGEOMETRY\fR

--- a/src/nemo-main-application.c
+++ b/src/nemo-main-application.c
@@ -84,6 +84,9 @@
 
 #define NEMO_ACCEL_MAP_SAVE_DELAY 30
 
+/* Disable the self-check functionality */
+#define NEMO_OMIT_SELF_CHECK "omit"
+
 static void     mount_removed_callback            (GVolumeMonitor            *monitor,
 						   GMount                    *mount,
 						   NemoMainApplication       *application);


### PR DESCRIPTION
This PR resolves #2415. Removed the ability to run nemo self-checks. Removed option from nemo man page.

If anything needs to be fixed, changed, or removed, just let me know and I'll make the changes accordingly. Thanks.