### PR TITLE
data/nemo.desktop.in: fix icon

### DIFF
--- a/data/nemo.desktop.in
+++ b/data/nemo.desktop.in
@@ -95,7 +95,7 @@ Comment[zh_CN]=访问和组织文件
 Comment[zh_HK]=存取與組織檔案
 Comment[zh_TW]=存取並組織檔案
 Exec=nemo %U
-Icon=folder
+Icon=system-file-manager
 # Translators: these are keywords of the file manager
 Keywords=folders;filesystem;explorer;
 Terminal=false

--- a/generate_additional_file
+++ b/generate_additional_file
@@ -19,7 +19,7 @@ prefix = """[Desktop Entry]
 """
 
 suffix = """Exec=nemo %U
-Icon=folder
+Icon=system-file-manager
 # Translators: these are keywords of the file manager
 Keywords=folders;filesystem;explorer;
 Terminal=false


### PR DESCRIPTION
Replace icon "folder" with "system-file-manager". Issue #1686 discussed
already, that it should not use "folder" to follow free desktop
standards, and it was changed to "nemo" in 5d4ca0 ("Rename Nemo icon
from places to nemo"). It looks like it was changed back by accident in
099421 ("l10n: Update POT file and generate files").

Change it to "system-file-manager", because that makes it pick up a nice
icon with the default GNOME theme. Adjust "generate_additional_file"
too, so it won't get overwritten by a accident again.