### PR TITLE
Drop Debian menu file

### DIFF
--- a/debian/menu
+++ b/debian/menu
@@ -1,2 +1,0 @@
-?package(nemo):needs="X11" section="Applications/File Management" \
-  title="Nemo" command="/usr/bin/nemo" icon="/usr/share/pixmaps/nemo.xpm"


### PR DESCRIPTION
From Pino Toscano patch for debian packages.
Drop Debian menu file (wrongly installed in gir1.2-nemo-3.0) since nemo already
provides a .desktop file.