### PR TITLE
make sure pango development files are installed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Build-Depends:
  libgtk-3-dev (>= 3.9.10),
  libgtk-3-doc,
  libnotify-dev (>= 0.7.0),
+ libpango1.0-dev,
  libx11-dev,
  libxapp-dev (>= 1.4.0),
  libxext-dev,

--- a/meson.build
+++ b/meson.build
@@ -131,6 +131,9 @@ if libselinux_enabled
 endif
 conf.set('HAVE_SELINUX', libselinux_enabled)
 
+# make sure pango development files are installed
+pango = dependency('pango', version: '>=1.40.0')
+# check for newer pango for necessary workarounds
 new_pango = dependency('pango', version: '>=1.44.0', required: false)
 if new_pango.found()
   conf.set('HAVE_PANGO_144', true)


### PR DESCRIPTION
Patch of Norbert Preining from debian packages.
With this check pango even if the version is lower that 1.44 (for example for
buster).
Added missed libpango1.0-dev in debian/control build-deps.

Note: I suppose Norbert set pango >=1.42 because is a version tested but probably an older version is supported, for example before meson port in configure.ac the min pango version required was 1.28.3, someone can confirm it or if a newer version is really required please?