### PR TITLE
Fix for #2513. Avoid single quote escape

### DIFF
--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1175,7 +1175,10 @@ get_path (NemoAction *action, NemoFile *file)
 
     orig = nemo_file_get_path (file);
 
-    quote_escaped = eel_str_escape_quotes (orig);
+    if (action->quote_type != QUOTE_TYPE_DOUBLE && action-quote_type != QUOTE_TYPE_SINGLE)
+        quote_escaped = eel_str_escape_quotes (orig);
+    else
+        quote_escaped = orig;
 
     if (action->escape_space) {
         ret = eel_str_escape_spaces (quote_escaped);
@@ -1184,7 +1187,9 @@ get_path (NemoAction *action, NemoFile *file)
     }
 
     g_free (orig);
-    g_free (quote_escaped);
+
+    if (quote_escaped != orig)
+        g_free (quote_escaped);
 
     return ret;
 }


### PR DESCRIPTION
This PR resolves #2513 

Skip escaping the quotes when the nemo action is using the Quote=double