### PR TITLE
Fixes #2499. Changes the option from -x to -- when using gnome-terminal

### DIFF
--- a/eel/eel-gnome-extensions.c
+++ b/eel/eel-gnome-extensions.c
@@ -77,8 +77,10 @@ prepend_terminal_to_command_line (const char *command_line)
         check = g_find_program_in_path ("gnome-terminal");
         if (check != NULL) {
             /* Note that gnome-terminal takes -x and
-             * as -e in gnome-terminal is broken we use that. */
-            prefix = g_strdup_printf ("gnome-terminal -x");
+             * as -e in gnome-terminal is broken we use that.
+               20201114 - There looks to be an issue with -x now with gnome-terminal
+               and -- is now the recommended option */
+            prefix = g_strdup_printf ("gnome-terminal --");
         } else {
             check = g_find_program_in_path ("nxterm");
 


### PR DESCRIPTION
This PR resolves #2499 

There still needs to be a change to setting the default exec-arg from "-x" to "--" in the case of gnome-terminal. But this PR will at least fix the issue if a user does not have a exec-arg setting in place.