### PR TITLE
file-operations: auto-escape filenames on native ntfs mounts

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -3369,6 +3369,7 @@ make_file_name_valid_for_dest_fs (char *filename,
 	if (dest_fs_type != NULL && filename != NULL) {
 		if (!strcmp (dest_fs_type, "fat")  ||
 		    !strcmp (dest_fs_type, "vfat") ||
+            !strcmp (dest_fs_type, "ntfs") ||
 		    !strcmp (dest_fs_type, "msdos") ||
 		    !strcmp (dest_fs_type, "msdosfs")) {
 			gboolean ret;


### PR DESCRIPTION
Based on https://github.com/GNOME/nautilus/commit/f03cb9f79a2f005326834dc082dfbae4e0a4b786