### PR TITLE
file-operations: auto-escape filenames on fuseblk mounts

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -3369,6 +3369,7 @@ make_file_name_valid_for_dest_fs (char *filename,
 	if (dest_fs_type != NULL && filename != NULL) {
 		if (!strcmp (dest_fs_type, "fat")  ||
 		    !strcmp (dest_fs_type, "vfat") ||
+            !strcmp (dest_fs_type, "ntfs") ||
 		    !strcmp (dest_fs_type, "msdos") ||
 		    !strcmp (dest_fs_type, "msdosfs")) {
 			gboolean ret;

--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -3369,6 +3369,11 @@ make_file_name_valid_for_dest_fs (char *filename,
 	if (dest_fs_type != NULL && filename != NULL) {
 		if (!strcmp (dest_fs_type, "fat")  ||
 		    !strcmp (dest_fs_type, "vfat") ||
+            /* The fuseblk filesystem type could be of any type
+             * in theory, but in practice is usually NTFS or exFAT.
+             * This assumption is a pragmatic way to solve
+             * https://gitlab.gnome.org/GNOME/nautilus/-/issues/1343 */
+            !strcmp (dest_fs_type, "fuse") ||
             !strcmp (dest_fs_type, "ntfs") ||
 		    !strcmp (dest_fs_type, "msdos") ||
 		    !strcmp (dest_fs_type, "msdosfs")) {


### PR DESCRIPTION
Based on https://github.com/GNOME/nautilus/commit/c028e48e589d07360c7ea8939a7b334948ca0e0c