### PR TITLE
build: fix typelibdir in libnemo-extension/meson.build.

### DIFF
--- a/libnemo-extension/meson.build
+++ b/libnemo-extension/meson.build
@@ -61,7 +61,9 @@ nemo_extension = declare_dependency(
   dependencies: nemo_extension_deps,
 )
 
-typelibdir = go_intr.get_pkgconfig_variable('typelibdir', define_variable: ['libdir', get_option('libdir')])
+typelibdir = go_intr.get_pkgconfig_variable('typelibdir',
+  define_variable: ['libdir', join_paths(get_option('prefix'), get_option('libdir'))]
+)
 
 gnome.generate_gir(nemo_extension_lib,
   sources: nemo_extension_sources + nemo_extension_headers,


### PR DESCRIPTION
Without this commit, a build configured with --prefix=/usr and
--libdir=/usr/lib will generate typelibdir = "//lib/girepository-1.0",
which isn't correct.