### PR TITLE
Add escaping for percent sign in action Exec

### DIFF
--- a/files/usr/share/nemo/actions/sample.nemo_action
+++ b/files/usr/share/nemo/actions/sample.nemo_action
@@ -23,6 +23,7 @@ Active=false
 # %p - insert display name of parent directory
 # %D - insert device path of file (i.e. /dev/sdb1)
 # %e - insert display name of first selected file with the extension stripped
+# %% - insert a literal percent sign, don't treat the next character as a token
 
 # The name to show in the menu, locale supported with standard desktop spec.
 # **** REQUIRED ****

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1163,6 +1163,10 @@ find_token_type (const gchar *str, TokenType *token_type)
             *token_type = TOKEN_FILE_DISPLAY_NAME_NO_EXT;
             return ptr;
         }
+        if (g_str_has_prefix (ptr, TOKEN_EXEC_LITERAL_PERCENT)) {
+            *token_type = TOKEN_LITERAL_PERCENT;
+            return ptr;
+        }
     }
 
     return NULL;
@@ -1270,6 +1274,9 @@ get_insertion_string (NemoAction *action, TokenType token_type, GList *selection
     gboolean first = TRUE;
 
     switch (token_type) {
+        case TOKEN_LITERAL_PERCENT:
+            str = g_string_append(str, "%");
+            break;
         case TOKEN_PATH_LIST:
             if (g_list_length (selection) > 0) {
                 for (l = selection; l != NULL; l = l->next) {

--- a/libnemo-private/nemo-action.h
+++ b/libnemo-private/nemo-action.h
@@ -50,6 +50,7 @@
 #define TOKEN_EXEC_PARENT_NAME "%p"
 #define TOKEN_EXEC_DEVICE "%D"
 #define TOKEN_EXEC_FILE_NO_EXT "%e"
+#define TOKEN_EXEC_LITERAL_PERCENT "%%"
 
 #define TOKEN_LABEL_FILE_NAME "%N" // Leave in for compatibility, same as TOKEN_EXEC_FILE_NAME
 
@@ -99,7 +100,8 @@ typedef enum {
     TOKEN_PARENT_DISPLAY_NAME,
     TOKEN_PARENT_PATH,
     TOKEN_DEVICE,
-    TOKEN_FILE_DISPLAY_NAME_NO_EXT
+    TOKEN_FILE_DISPLAY_NAME_NO_EXT,
+    TOKEN_LITERAL_PERCENT
 } TokenType;
 
 struct _NemoAction {


### PR DESCRIPTION
I ran into a situation where a tool I was trying to call as an action also uses `%` tokens in its format string. Nemo stops processing tokens if it hits one it doesn't know about, so there was no way to run this tool directly. I considered just making it ignore unknown token types, but decided it would be better to add `%%` to insert a literal `%` in the command, since you might need to pass one that _is_ a valid action token.