### PR TITLE
Added option to toggle sorting favorites before other files

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -573,6 +573,22 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="position">4</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="sort_favorites_first_checkbutton">
+                                            <property name="label" translatable="yes">Sort _favorites before other files</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">5</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -3241,7 +3241,7 @@ static int
 nemo_file_compare_for_sort_internal (NemoFile *file_1,
 					 NemoFile *file_2,
 					 gboolean directories_first,
-                     gboolean favorites_first,
+					 gboolean favorites_first,
 					 gboolean reversed)
 {
 	gboolean is_directory_1, is_directory_2;
@@ -3315,7 +3315,7 @@ nemo_file_compare_for_sort (NemoFile *file_1,
 				NemoFile *file_2,
 				NemoFileSortType sort_type,
 				gboolean directories_first,
-                gboolean favorites_first,
+				gboolean favorites_first,
 				gboolean reversed)
 {
 	int result;
@@ -3397,7 +3397,7 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 						 NemoFile                   *file_2,
 						 GQuark                          attribute,
 						 gboolean                        directories_first,
-                         gboolean                        favorites_first,
+						 gboolean                        favorites_first,
 						 gboolean                        reversed)
 {
 	int result;
@@ -3413,19 +3413,19 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_DISPLAY_NAME,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
 	} else if (attribute == attribute_size_q) {
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_SIZE,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
 	} else if (attribute == attribute_type_q) {
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_TYPE,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
 	} else if (attribute == attribute_detailed_type_q) {
         return nemo_file_compare_for_sort (file_1, file_2,
@@ -3440,7 +3440,7 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_MTIME,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
     } else if (attribute == attribute_accessed_date_q ||
                attribute == attribute_date_accessed_q ||
@@ -3448,7 +3448,7 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_ATIME,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
     } else if (attribute == attribute_creation_date_q ||
                attribute == attribute_date_created_q ||
@@ -3464,7 +3464,7 @@ nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 		return nemo_file_compare_for_sort (file_1, file_2,
 						       NEMO_FILE_SORT_BY_TRASHED_TIME,
 						       directories_first,
-                               favorites_first,
+						       favorites_first,
 						       reversed);
 	}
 
@@ -3501,13 +3501,13 @@ nemo_file_compare_for_sort_by_attribute     (NemoFile                   *file_1,
 						 NemoFile                   *file_2,
 						 const char                     *attribute,
 						 gboolean                        directories_first,
-                         gboolean                        favorites_first,
+						 gboolean                        favorites_first,
 						 gboolean                        reversed)
 {
 	return nemo_file_compare_for_sort_by_attribute_q (file_1, file_2,
 							      g_quark_from_string (attribute),
 							      directories_first,
-                                  favorites_first,
+							      favorites_first,
 							      reversed);
 }
 

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -433,19 +433,19 @@ int                     nemo_file_compare_for_sort                  (NemoFile   
 									 NemoFile                   *file_2,
 									 NemoFileSortType            sort_type,
 									 gboolean			 directories_first,
-                                     gboolean            favorites_first,
+									 gboolean            favorites_first,
 									 gboolean		  	 reversed);
 int                     nemo_file_compare_for_sort_by_attribute     (NemoFile                   *file_1,
 									 NemoFile                   *file_2,
 									 const char                     *attribute,
 									 gboolean                        directories_first,
-                                     gboolean                        favorites_first,
+									 gboolean                        favorites_first,
 									 gboolean                        reversed);
 int                     nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 									 NemoFile                   *file_2,
 									 GQuark                          attribute,
 									 gboolean                        directories_first,
-                                     gboolean                        favorites_first,
+									 gboolean                        favorites_first,
 									 gboolean                        reversed);
 gboolean                nemo_file_is_date_sort_attribute_q          (GQuark                          attribute);
 

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -433,16 +433,19 @@ int                     nemo_file_compare_for_sort                  (NemoFile   
 									 NemoFile                   *file_2,
 									 NemoFileSortType            sort_type,
 									 gboolean			 directories_first,
+                                     gboolean            favorites_first,
 									 gboolean		  	 reversed);
 int                     nemo_file_compare_for_sort_by_attribute     (NemoFile                   *file_1,
 									 NemoFile                   *file_2,
 									 const char                     *attribute,
 									 gboolean                        directories_first,
+                                     gboolean                        favorites_first,
 									 gboolean                        reversed);
 int                     nemo_file_compare_for_sort_by_attribute_q   (NemoFile                   *file_1,
 									 NemoFile                   *file_2,
 									 GQuark                          attribute,
 									 gboolean                        directories_first,
+                                     gboolean                        favorites_first,
 									 gboolean                        reversed);
 gboolean                nemo_file_is_date_sort_attribute_q          (GQuark                          attribute);
 

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -111,6 +111,7 @@ typedef enum
 
 /* Sorting order */
 #define NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST		"sort-directories-first"
+#define NEMO_PREFERENCES_SORT_FAVORITES_FIRST		"sort-favorites-first"
 #define NEMO_PREFERENCES_DEFAULT_SORT_ORDER			"default-sort-order"
 #define NEMO_PREFERENCES_DEFAULT_SORT_IN_REVERSE_ORDER	"default-sort-in-reverse-order"
 

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -247,6 +247,11 @@
       <summary>Show folders first in windows</summary>
       <description>If set to true, then Nemo shows folders prior to showing files in the icon and list views.</description>
     </key>
+    <key name="sort-favorites-first" type="b">
+      <default>true</default>
+      <summary>Show favorites first in windows</summary>
+      <description>If set to true, then Nemo shows favorites prior to other files in the icon and list views.</description>
+    </key>
     <key name="default-sort-order" enum="org.nemo.SortOrder">
       <aliases>
 	<alias value='modification_date' target='mtime'/>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -58,6 +58,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_VIEW_WIDGET "inherit_view_checkbox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_REVERSE_SORT_WIDGET "reverse_sort_checkbox"
 #define NEMO_FILE_MANAGEMENT_QUICK_RENAMES_WITH_PAUSE_IN_BETWEEN "quick_renames_with_pause_in_between"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_FAVORITES_FIRST_WIDGET "sort_favorites_first_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_FOLDERS_FIRST_WIDGET "sort_folders_first_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_COMPACT_LAYOUT_WIDGET "compact_layout_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LABELS_BESIDE_ICONS_WIDGET "labels_beside_icons_checkbutton"
@@ -913,6 +914,9 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
   bind_builder_bool (builder, nemo_preferences,
                NEMO_FILE_MANAGEMENT_PROPERTIES_REVERSE_SORT_WIDGET,
                NEMO_PREFERENCES_DEFAULT_SORT_IN_REVERSE_ORDER);
+  bind_builder_bool (builder, nemo_preferences,
+               NEMO_FILE_MANAGEMENT_PROPERTIES_FAVORITES_FIRST_WIDGET,
+               NEMO_PREFERENCES_SORT_FAVORITES_FIRST);
 	bind_builder_enum (builder, nemo_preferences,
 			   NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET,
 			   NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER,

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -495,7 +495,7 @@ fm_desktop_icon_container_icons_compare (NemoIconContainer *container,
 		return nemo_file_compare_for_sort
 			(file_a, file_b, NEMO_FILE_SORT_BY_DISPLAY_NAME,
 			 nemo_view_should_sort_directories_first (directory_view),
-             nemo_view_should_sort_favorites_first (directory_view),
+			 nemo_view_should_sort_favorites_first (directory_view),
 			 FALSE);
 	}
 

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -495,6 +495,7 @@ fm_desktop_icon_container_icons_compare (NemoIconContainer *container,
 		return nemo_file_compare_for_sort
 			(file_a, file_b, NEMO_FILE_SORT_BY_DISPLAY_NAME,
 			 nemo_view_should_sort_directories_first (directory_view),
+             nemo_view_should_sort_favorites_first (directory_view),
 			 FALSE);
 	}
 

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -1763,7 +1763,7 @@ nemo_icon_view_compare_files (NemoIconView   *icon_view,
 		(a, b, icon_view->details->sort->sort_type,
 		 /* Use type-unsafe cast for performance */
 		 nemo_view_should_sort_directories_first ((NemoView *)icon_view),
-         nemo_view_should_sort_favorites_first ((NemoView *)icon_view),
+		 nemo_view_should_sort_favorites_first ((NemoView *)icon_view),
 		 icon_view->details->sort_reversed);
 }
 

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -1763,6 +1763,7 @@ nemo_icon_view_compare_files (NemoIconView   *icon_view,
 		(a, b, icon_view->details->sort->sort_type,
 		 /* Use type-unsafe cast for performance */
 		 nemo_view_should_sort_directories_first ((NemoView *)icon_view),
+         nemo_view_should_sort_favorites_first ((NemoView *)icon_view),
 		 icon_view->details->sort_reversed);
 }
 
@@ -2152,6 +2153,19 @@ all_columns_same_width_changed_callback (gpointer callback_data)
 
 static void
 nemo_icon_view_sort_directories_first_changed (NemoView *directory_view)
+{
+	NemoIconView *icon_view;
+
+	icon_view = NEMO_ICON_VIEW (directory_view);
+
+	if (nemo_icon_view_using_auto_layout (icon_view)) {
+		nemo_icon_container_sort
+			(get_icon_container (icon_view));
+	}
+}
+
+static void
+nemo_icon_view_sort_favorites_first_changed (NemoView *directory_view)
 {
 	NemoIconView *icon_view;
 
@@ -2715,6 +2729,7 @@ nemo_icon_view_class_init (NemoIconViewClass *klass)
         nemo_view_class->merge_menus = nemo_icon_view_merge_menus;
         nemo_view_class->unmerge_menus = nemo_icon_view_unmerge_menus;
         nemo_view_class->sort_directories_first_changed = nemo_icon_view_sort_directories_first_changed;
+        nemo_view_class->sort_favorites_first_changed = nemo_icon_view_sort_favorites_first_changed;
         nemo_view_class->start_renaming_file = nemo_icon_view_start_renaming_file;
         nemo_view_class->update_menus = nemo_icon_view_update_menus;
 	nemo_view_class->using_manual_layout = nemo_icon_view_using_manual_layout;

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -72,6 +72,7 @@ struct NemoListModelDetails {
 	GtkSortType order;
 
 	gboolean sort_directories_first;
+    gboolean sort_favorites_first;
 
 	GtkTreeView *drag_view;
 	int drag_begin_x;
@@ -717,6 +718,7 @@ nemo_list_model_file_entry_compare_func (gconstpointer a,
 		result = nemo_file_compare_for_sort_by_attribute_q (file_entry1->file, file_entry2->file,
 									model->details->sort_attribute,
 									model->details->sort_directories_first,
+                                    model->details->sort_favorites_first,
 									(model->details->order == GTK_SORT_DESCENDING));
 	} else if (file_entry1->file == NULL) {
 		return -1;
@@ -737,6 +739,7 @@ nemo_list_model_compare_func (NemoListModel *model,
 	result = nemo_file_compare_for_sort_by_attribute_q (file1, file2,
 								model->details->sort_attribute,
 								model->details->sort_directories_first,
+                                model->details->sort_favorites_first,
 								(model->details->order == GTK_SORT_DESCENDING));
 
 	return result;
@@ -1435,6 +1438,17 @@ nemo_list_model_set_should_sort_directories_first (NemoListModel *model, gboolea
 	}
 
 	model->details->sort_directories_first = sort_directories_first;
+	nemo_list_model_sort (model);
+}
+
+void
+nemo_list_model_set_should_sort_favorites_first (NemoListModel *model, gboolean sort_favorites_first)
+{
+	if (model->details->sort_favorites_first == sort_favorites_first) {
+		return;
+	}
+
+	model->details->sort_favorites_first = sort_favorites_first;
 	nemo_list_model_sort (model);
 }
 

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -72,7 +72,7 @@ struct NemoListModelDetails {
 	GtkSortType order;
 
 	gboolean sort_directories_first;
-    gboolean sort_favorites_first;
+	gboolean sort_favorites_first;
 
 	GtkTreeView *drag_view;
 	int drag_begin_x;
@@ -718,7 +718,7 @@ nemo_list_model_file_entry_compare_func (gconstpointer a,
 		result = nemo_file_compare_for_sort_by_attribute_q (file_entry1->file, file_entry2->file,
 									model->details->sort_attribute,
 									model->details->sort_directories_first,
-                                    model->details->sort_favorites_first,
+									model->details->sort_favorites_first,
 									(model->details->order == GTK_SORT_DESCENDING));
 	} else if (file_entry1->file == NULL) {
 		return -1;
@@ -739,7 +739,7 @@ nemo_list_model_compare_func (NemoListModel *model,
 	result = nemo_file_compare_for_sort_by_attribute_q (file1, file2,
 								model->details->sort_attribute,
 								model->details->sort_directories_first,
-                                model->details->sort_favorites_first,
+								model->details->sort_favorites_first,
 								(model->details->order == GTK_SORT_DESCENDING));
 
 	return result;

--- a/src/nemo-list-model.h
+++ b/src/nemo-list-model.h
@@ -97,7 +97,8 @@ gboolean nemo_list_model_get_first_iter_for_file           (NemoListModel       
 								GtkTreeIter          *iter);
 void     nemo_list_model_set_should_sort_directories_first (NemoListModel          *model,
 								gboolean              sort_directories_first);
-
+void     nemo_list_model_set_should_sort_favorites_first (NemoListModel          *model,
+								gboolean              sort_favorites_first);
 int      nemo_list_model_get_sort_column_id_from_attribute (NemoListModel *model,
 								GQuark       attribute);
 GQuark   nemo_list_model_get_attribute_from_sort_column_id (NemoListModel *model,

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -3827,6 +3827,17 @@ nemo_list_view_sort_directories_first_changed (NemoView *view)
 							 nemo_view_should_sort_directories_first (view));
 }
 
+static void
+nemo_list_view_sort_favorites_first_changed (NemoView *view)
+{
+	NemoListView *list_view;
+
+	list_view = NEMO_LIST_VIEW (view);
+
+	nemo_list_model_set_should_sort_favorites_first (list_view->details->model,
+							 nemo_view_should_sort_favorites_first (view));
+}
+
 static int
 nemo_list_view_compare_files (NemoView *view, NemoFile *file1, NemoFile *file2)
 {
@@ -4086,6 +4097,7 @@ nemo_list_view_class_init (NemoListViewClass *class)
 	nemo_view_class->invert_selection = nemo_list_view_invert_selection;
 	nemo_view_class->compare_files = nemo_list_view_compare_files;
 	nemo_view_class->sort_directories_first_changed = nemo_list_view_sort_directories_first_changed;
+    nemo_view_class->sort_favorites_first_changed = nemo_list_view_sort_favorites_first_changed;
 	nemo_view_class->start_renaming_file = nemo_list_view_start_renaming_file;
 	nemo_view_class->get_zoom_level = nemo_list_view_get_zoom_level;
 	nemo_view_class->zoom_to_level = nemo_list_view_zoom_to_level;
@@ -4156,6 +4168,7 @@ nemo_list_view_init (NemoListView *list_view)
     nemo_list_view_click_to_rename_mode_changed (NEMO_VIEW (list_view));
 
 	nemo_list_view_sort_directories_first_changed (NEMO_VIEW (list_view));
+    nemo_list_view_sort_favorites_first_changed (NEMO_VIEW (list_view));
 
     list_view->details->current_selection_count = -1;
 

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -4097,7 +4097,7 @@ nemo_list_view_class_init (NemoListViewClass *class)
 	nemo_view_class->invert_selection = nemo_list_view_invert_selection;
 	nemo_view_class->compare_files = nemo_list_view_compare_files;
 	nemo_view_class->sort_directories_first_changed = nemo_list_view_sort_directories_first_changed;
-    nemo_view_class->sort_favorites_first_changed = nemo_list_view_sort_favorites_first_changed;
+	nemo_view_class->sort_favorites_first_changed = nemo_list_view_sort_favorites_first_changed;
 	nemo_view_class->start_renaming_file = nemo_list_view_start_renaming_file;
 	nemo_view_class->get_zoom_level = nemo_list_view_get_zoom_level;
 	nemo_view_class->zoom_to_level = nemo_list_view_zoom_to_level;
@@ -4168,7 +4168,7 @@ nemo_list_view_init (NemoListView *list_view)
     nemo_list_view_click_to_rename_mode_changed (NEMO_VIEW (list_view));
 
 	nemo_list_view_sort_directories_first_changed (NEMO_VIEW (list_view));
-    nemo_list_view_sort_favorites_first_changed (NEMO_VIEW (list_view));
+	nemo_list_view_sort_favorites_first_changed (NEMO_VIEW (list_view));
 
     list_view->details->current_selection_count = -1;
 

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -268,6 +268,7 @@ struct NemoViewDetails
 	gboolean is_renaming;
 
 	gboolean sort_directories_first;
+    gboolean sort_favorites_first;
 
 	gboolean show_foreign_files;
 	gboolean show_hidden_files;
@@ -2396,6 +2397,12 @@ nemo_view_should_sort_directories_first (NemoView *view)
 	return view->details->sort_directories_first;
 }
 
+gboolean
+nemo_view_should_sort_favorites_first (NemoView *view)
+{
+	return view->details->sort_favorites_first;
+}
+
 static void
 sort_directories_first_changed_callback (gpointer callback_data)
 {
@@ -2410,6 +2417,23 @@ sort_directories_first_changed_callback (gpointer callback_data)
 	if (preference_value != view->details->sort_directories_first) {
 		view->details->sort_directories_first = preference_value;
 		return NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->sort_directories_first_changed (view);
+	}
+}
+
+static void
+sort_favorites_first_changed_callback (gpointer callback_data)
+{
+	NemoView *view;
+	gboolean preference_value;
+
+	view = NEMO_VIEW (callback_data);
+
+	preference_value =
+		g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_FAVORITES_FIRST);
+
+	if (preference_value != view->details->sort_favorites_first) {
+		view->details->sort_favorites_first = preference_value;
+		return NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->sort_favorites_first_changed (view);
 	}
 }
 
@@ -2852,6 +2876,9 @@ nemo_view_init (NemoView *view)
 	view->details->sort_directories_first =
 		g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST);
 
+	view->details->sort_favorites_first =
+		g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SORT_FAVORITES_FIRST);
+
 	g_signal_connect_object (nemo_trash_monitor_get (), "trash_state_changed",
 				 G_CALLBACK (nemo_view_trash_state_changed_callback), view, 0);
 
@@ -2885,6 +2912,9 @@ nemo_view_init (NemoView *view)
 	g_signal_connect_swapped (nemo_preferences,
 				  "changed::" NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST,
 				  G_CALLBACK(sort_directories_first_changed_callback), view);
+    g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_SORT_FAVORITES_FIRST,
+				  G_CALLBACK(sort_favorites_first_changed_callback), view);
 	g_signal_connect_swapped (gnome_lockdown_preferences,
 				  "changed::" NEMO_PREFERENCES_LOCKDOWN_COMMAND_LINE,
 				  G_CALLBACK (schedule_update_menus), view);
@@ -3080,6 +3110,8 @@ nemo_view_finalize (GObject *object)
                           click_to_rename_changed_callback, view);
 	g_signal_handlers_disconnect_by_func (nemo_preferences,
 					      sort_directories_first_changed_callback, view);
+	g_signal_handlers_disconnect_by_func (nemo_preferences,
+					      sort_favorites_first_changed_callback, view);
 	g_signal_handlers_disconnect_by_func (nemo_window_state,
 					      nemo_view_display_selection_info, view);
     g_signal_handlers_disconnect_by_func (nemo_menu_config_preferences,

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -268,7 +268,7 @@ struct NemoViewDetails
 	gboolean is_renaming;
 
 	gboolean sort_directories_first;
-    gboolean sort_favorites_first;
+	gboolean sort_favorites_first;
 
 	gboolean show_foreign_files;
 	gboolean show_hidden_files;
@@ -2912,7 +2912,7 @@ nemo_view_init (NemoView *view)
 	g_signal_connect_swapped (nemo_preferences,
 				  "changed::" NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST,
 				  G_CALLBACK(sort_directories_first_changed_callback), view);
-    g_signal_connect_swapped (nemo_preferences,
+	g_signal_connect_swapped (nemo_preferences,
 				  "changed::" NEMO_PREFERENCES_SORT_FAVORITES_FIRST,
 				  G_CALLBACK(sort_favorites_first_changed_callback), view);
 	g_signal_connect_swapped (gnome_lockdown_preferences,

--- a/src/nemo-view.h
+++ b/src/nemo-view.h
@@ -300,7 +300,7 @@ struct NemoViewClass {
     void    (* click_policy_changed)       (NemoView *view);
 	void	(* click_to_rename_mode_changed)   (NemoView *view);
 	void	(* sort_directories_first_changed) (NemoView *view);
-    void	(* sort_favorites_first_changed) (NemoView *view);
+	void	(* sort_favorites_first_changed) (NemoView *view);
 
 	/* Get the id string for this view. Its a constant string, not memory managed */
 	const char *   (* get_view_id)            (NemoView          *view);

--- a/src/nemo-view.h
+++ b/src/nemo-view.h
@@ -300,6 +300,7 @@ struct NemoViewClass {
     void    (* click_policy_changed)       (NemoView *view);
 	void	(* click_to_rename_mode_changed)   (NemoView *view);
 	void	(* sort_directories_first_changed) (NemoView *view);
+    void	(* sort_favorites_first_changed) (NemoView *view);
 
 	/* Get the id string for this view. Its a constant string, not memory managed */
 	const char *   (* get_view_id)            (NemoView          *view);
@@ -361,6 +362,7 @@ void                nemo_view_pop_up_selection_context_menu    (NemoView  *view,
 gboolean            nemo_view_should_show_file                 (NemoView  *view,
 								    NemoFile     *file);
 gboolean	    nemo_view_should_sort_directories_first    (NemoView  *view);
+gboolean	    nemo_view_should_sort_favorites_first    (NemoView  *view);
 void                nemo_view_ignore_hidden_file_preferences   (NemoView  *view);
 void                nemo_view_set_show_foreign                 (NemoView  *view,
 								    gboolean          show_foreign);


### PR DESCRIPTION
Took a crack at implementing an option to toggle sorting favourites before other files, as requested in #2624. 

Changes are based off of the existing "sort folders before files" option and use a new gsettings key:

`gsettings set org.nemo.preferences sort-favorites-first (true|false)`

Demo:

![GIF Demo](https://user-images.githubusercontent.com/8319652/107104412-88820880-67ef-11eb-8c4c-dc1965b92ccb.gif)
