### PR TITLE
Added option to change default password save settings in mount dialog.

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -212,56 +212,6 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
       </row>
     </data>
   </object>
-  <object class="GtkListStore" id="model64">
-    <columns>
-      <!-- column-name gchararray -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">100 KB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">500 KB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">1 MB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">3 MB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">5 MB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">10 MB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">100 MB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">1 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">2 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">4 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">8 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">16 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">32 GB</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">64 GB</col>
-      </row>
-    </data>
-  </object>
   <object class="GtkListStore" id="model4">
     <columns>
       <!-- column-name gchararray -->
@@ -334,6 +284,56 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
       </row>
       <row>
         <col id="0" translatable="yes">Never</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="model64">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">100 KB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">500 KB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">1 MB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">3 MB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">5 MB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">10 MB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">100 MB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">1 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">2 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">4 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">8 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">16 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">32 GB</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">64 GB</col>
       </row>
     </data>
   </object>
@@ -1579,6 +1579,106 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="vbox20">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="border_width">6</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel" id="label1">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Remember Passwords Default&lt;/b&gt;</property>
+                                    <property name="use_markup">True</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkAlignment" id="alignment10">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">40</property>
+                                    <property name="right_padding">40</property>
+                                    <child>
+                                      <object class="GtkBox" id="vbox39">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="passwords_forget_immediately_radiobutton">
+                                            <property name="label" translatable="yes">_Forget password immediately</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="passwords_remember_logout_radiobutton">
+                                            <property name="label" translatable="yes">_Remember password until you logout</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="active">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">passwords_forget_immediately_radiobutton</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="passwords_remember_forever_radiobutton">
+                                            <property name="label" translatable="yes">_Remember forever</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">passwords_forget_immediately_radiobutton</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -74,6 +74,9 @@ typedef enum
 /* Activating executable text files */
 #define NEMO_PREFERENCES_EXECUTABLE_TEXT_ACTIVATION		"executable-text-activation"
 
+/* Default for remembering password */
+#define NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT		"remember-passwords-default"
+
 /* Spatial or browser mode */
 #define NEMO_PREFERENCES_ALWAYS_USE_BROWSER			"always-use-browser"
 #define NEMO_PREFERENCES_NEW_TAB_POSITION			"tabs-open-position"
@@ -181,6 +184,13 @@ enum
 	NEMO_EXECUTABLE_TEXT_LAUNCH,
 	NEMO_EXECUTABLE_TEXT_DISPLAY,
 	NEMO_EXECUTABLE_TEXT_ASK
+};
+
+enum
+{
+	NEMO_REMEMBER_PASSWORDS_IMMEDIATELY,
+	NEMO_REMEMBER_PASSWORDS_LOGOUT,
+	NEMO_REMEMBER_PASSWORDS_FOREVER
 };
 
 typedef enum

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -15,6 +15,12 @@
     <value nick="display" value="1"/>
     <value nick="ask" value="2"/>
   </enum>
+  
+  <enum id="org.nemo.RememberPasswords">
+  	<value nick="immediately" value="0"/>
+    <value nick="logout" value="1"/>
+    <value nick="forever" value="2"/>
+  </enum>
 
   <enum id="org.nemo.FolderView">
     <value nick="icon-view" value="0"/>
@@ -205,6 +211,11 @@
       <default>'ask'</default>
       <summary>What to do with executable text files when activated</summary>
       <description>What to do with executable text files when they are activated (single or double clicked). Possible values are "launch" to launch them as programs, "ask" to ask what to do via a dialog, and "display" to display them as text files.</description>
+    </key>
+    <key name="remember-passwords-default" enum="org.nemo.RememberPasswords">
+      <default>'logout'</default>
+      <summary>Default option selected when prompted for a password.</summary>
+      <description>Default save option when prompted for a password. Can be used to prevent accidentally saving passwords to the keyring.</description>
     </key>
     <key name="mouse-use-extra-buttons" type="b">
       <default>true</default>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -194,6 +194,20 @@ static const char * const executable_text_values[] = {
 	NULL
 };
 
+static const char * const remember_passwords_components[] = {
+	"passwords_forget_immediately_radiobutton",
+	"passwords_remember_logout_radiobutton",
+	"passwords_remember_forever_radiobutton",
+	NULL
+};
+
+static const char * const remember_passwords_values[] = {
+	"immediately",
+	"logout",
+	"forever",
+	NULL
+};
+
 static const char * const size_prefixes_values[] = {
 	"base-10",
 	"base-10-full",
@@ -962,6 +976,11 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 			    (const char **) executable_text_components,
 			    NEMO_PREFERENCES_EXECUTABLE_TEXT_ACTIVATION,
 			    (const char **) executable_text_values);
+
+	bind_builder_radio (builder, nemo_preferences,
+			    (const char **) remember_passwords_components,
+			    NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT,
+			    (const char **) remember_passwords_values);
 
 	bind_builder_uint_enum (builder, nemo_preferences,
 				NEMO_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_LIMIT_WIDGET,

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7614,8 +7614,30 @@ action_mount_volume_callback (GtkAction *action,
 	GList *selection, *l;
 	NemoView *view;
 	GMountOperation *mount_op;
+	int preferences_value;
+	GPasswordSave save_pref;
 
-        view = NEMO_VIEW (data);
+	preferences_value = g_settings_get_enum	(nemo_preferences,
+								 NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT);
+
+	switch (preferences_value) {
+	case NEMO_REMEMBER_PASSWORDS_IMMEDIATELY:
+		save_pref = G_PASSWORD_SAVE_NEVER;
+		break;
+	case NEMO_REMEMBER_PASSWORDS_LOGOUT:
+		save_pref = G_PASSWORD_SAVE_FOR_SESSION;
+		break;
+	case NEMO_REMEMBER_PASSWORDS_FOREVER:
+		save_pref = G_PASSWORD_SAVE_PERMANENTLY;
+		break;
+	default:
+		/* Complain non-fatally, since preference data can't be trusted */
+		g_warning ("Unknown value %d for NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT",
+			   preferences_value);
+		save_pref = G_PASSWORD_SAVE_FOR_SESSION;
+	}
+
+    view = NEMO_VIEW (data);
 
 	selection = nemo_view_get_selection (view);
 	for (l = selection; l != NULL; l = l->next) {
@@ -7623,7 +7645,7 @@ action_mount_volume_callback (GtkAction *action,
 
 		if (nemo_file_can_mount (file)) {
 			mount_op = gtk_mount_operation_new (nemo_view_get_containing_window (view));
-			g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+			g_mount_operation_set_password_save (mount_op, save_pref);
 			nemo_file_mount (file, mount_op, NULL,
 					     file_mount_callback, NULL);
 			g_object_unref (mount_op);
@@ -7776,6 +7798,7 @@ action_self_mount_volume_callback (GtkAction *action,
 	NemoFile *file;
 	NemoView *view;
 	GMountOperation *mount_op;
+	int preferences_value;
 
 	view = NEMO_VIEW (data);
 
@@ -7785,7 +7808,26 @@ action_self_mount_volume_callback (GtkAction *action,
 	}
 
 	mount_op = gtk_mount_operation_new (nemo_view_get_containing_window (view));
-	g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+
+	preferences_value = g_settings_get_enum	(nemo_preferences,
+								 NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT);
+	switch (preferences_value) {
+	case NEMO_REMEMBER_PASSWORDS_IMMEDIATELY:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_NEVER);
+		break;
+	case NEMO_REMEMBER_PASSWORDS_LOGOUT:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+		break;
+	case NEMO_REMEMBER_PASSWORDS_FOREVER:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_PERMANENTLY);
+		break;
+	default:
+		/* Complain non-fatally, since preference data can't be trusted */
+		g_warning ("Unknown value %d for NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT",
+			   preferences_value);
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+	}
+
 	nemo_file_mount (file, mount_op, NULL, file_mount_callback, NULL);
 	g_object_unref (mount_op);
 }
@@ -7895,6 +7937,7 @@ action_location_mount_volume_callback (GtkAction *action,
 	NemoFile *file;
 	NemoView *view;
 	GMountOperation *mount_op;
+	int preferences_value;
 
 	view = NEMO_VIEW (data);
 
@@ -7904,7 +7947,26 @@ action_location_mount_volume_callback (GtkAction *action,
 	}
 
 	mount_op = gtk_mount_operation_new (nemo_view_get_containing_window (view));
-	g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+
+	preferences_value = g_settings_get_enum	(nemo_preferences,
+								 NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT);
+	switch (preferences_value) {
+	case NEMO_REMEMBER_PASSWORDS_IMMEDIATELY:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_NEVER);
+		break;
+	case NEMO_REMEMBER_PASSWORDS_LOGOUT:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+		break;
+	case NEMO_REMEMBER_PASSWORDS_FOREVER:
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_PERMANENTLY);
+		break;
+	default:
+		/* Complain non-fatally, since preference data can't be trusted */
+		g_warning ("Unknown value %d for NEMO_PREFERENCES_REMEMBER_PASSWORDS_DEFAULT",
+			   preferences_value);
+		g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
+	}
+
 	nemo_file_mount (file, mount_op, NULL, file_mount_callback, NULL);
 	g_object_unref (mount_op);
 }


### PR DESCRIPTION
I added added an option in the Edit/Preferences/Behavior menu to change the default selection when prompted for a password. 
 
Currently the default is hard coded to remember passwords for the duration of the session.  For security purposes I would prefer not to have the passwords for my encrypted drives being saved in the gnome keyring since any application running as myself can query it.  When prompted for the password I usually select the forget option, however sometimes I forget.  I would like to be able to change this default in the settings so I don't have to check that option every time.  

I added this change to all places I found calls to `g_mount_operation_set_password_save` except in `nemo-connect-server-dialog.c` since that file was using a different default.  