### PR TITLE
Fix segfault when g_file_info_get_symlink_target() returns "".

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -595,6 +595,7 @@ modify_link_hash_table (NemoFile *file,
 	}
 
 	target_uri = nemo_file_get_symbolic_link_target_uri (file);
+	g_return_if_fail (target_uri != NULL);
 
 	/* Find the old contents of the hash table. */
 	found = g_hash_table_lookup_extended
@@ -2591,7 +2592,9 @@ update_info_internal (NemoFile *file,
 		file->details->thumbnailing_failed = thumbnailing_failed;
 	}
 
-	symlink_name = g_file_info_get_symlink_target (info);
+	symlink_name = is_symlink ?
+		g_file_info_get_symlink_target (info) :
+		NULL;
 	if (g_strcmp0 (file->details->symlink_name, symlink_name) != 0) {
 		changed = TRUE;
 		g_free (file->details->symlink_name);


### PR DESCRIPTION
With some GIO backends (observed at least with sftp),
g_file_info_get_symlink_target() returns an empty string rather
than NULL for non-symlinks. A warning and then segfault result:

    ** (nemo:8386): WARNING **: 18:34:22.807: File has symlink target, but  is not marked as symlink

    Thread 1 "nemo" received signal SIGSEGV, Segmentation fault.
    0x00007ffff71beac0 in g_str_hash () from /usr/lib/libglib-2.0.so.0
    (gdb) bt
    #0  0x00007ffff71beac0 in g_str_hash () at /usr/lib/libglib-2.0.so.0
    #1  0x00007ffff71bfa2f in g_hash_table_lookup_extended () at /usr/lib/libglib-2.0.so.0
    #2  0x000055555564926e in modify_link_hash_table at ../libnemo-private/nemo-file.c:600
    #3  0x000055555564ed11 in add_to_link_hash_table at ../libnemo-private/nemo-file.c:642
    #4  update_info_internal at ../libnemo-private/nemo-file.c:2683
    #5  0x000055555564f767 in nemo_file_update_info  at ../libnemo-private/nemo-file.c:2702
    #6  0x00005555556263ec in query_info_callback at ../libnemo-private/nemo-directory-async.c:3230

Defend against this at two levels:
 - For non-symlinks, don't call g_file_info_get_symlink_target().
 - Use g_return_if_fail() to prevent NULL pointer dereference.