### PR TITLE
Nemo view order in supported image viewers

### DIFF
--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -74,6 +74,9 @@ typedef enum
 /* Activating executable text files */
 #define NEMO_PREFERENCES_EXECUTABLE_TEXT_ACTIVATION		"executable-text-activation"
 
+/* Image viewers to pass nemo view sort order to */
+#define NEMO_PREFERENCES_IMAGE_VIEWERS_WITH_EXTERNAL_SORT "image-viewers-with-external-sort"
+
 /* Spatial or browser mode */
 #define NEMO_PREFERENCES_ALWAYS_USE_BROWSER			"always-use-browser"
 #define NEMO_PREFERENCES_NEW_TAB_POSITION			"tabs-open-position"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -206,6 +206,11 @@
       <summary>What to do with executable text files when activated</summary>
       <description>What to do with executable text files when they are activated (single or double clicked). Possible values are "launch" to launch them as programs, "ask" to ask what to do via a dialog, and "display" to display them as text files.</description>
     </key>
+    <key name="image-viewers-with-external-sort" type="as">
+      <default>['xviewer','feh','sxiv']</default>
+      <summary>Image viewer executables to pass sort order to</summary>
+      <description>When opening a single image with an application in this list, allow that viewer to display other images in the current nemo view, in the presented order (including searches). Other image viewers can be added, but are likely to ignore the order.</description>
+    </key>
     <key name="mouse-use-extra-buttons" type="b">
       <default>true</default>
       <summary>Use extra mouse button events in Nemo' browser window</summary>

--- a/src/nemo-mime-actions.c
+++ b/src/nemo-mime-actions.c
@@ -1452,10 +1452,13 @@ add_sorted_view_uris (GList *uris,
 					prior_uris = g_list_prepend (prior_uris, uri);
 				}
 
-				// Shuffle latest mime type to start of list, so fewer iterations are required for more common types.
-				supported_mime_types = g_list_remove_link (supported_mime_types, mime_type_link);
-				supported_mime_types = g_list_insert_before_link (
-					supported_mime_types, supported_mime_types, mime_type_link);
+				if (supported_mime_types != mime_type_link) {
+					// Shuffle latest mime type to start of list, so fewer iterations are required for more common types.
+					supported_mime_types = g_list_remove_link (supported_mime_types, mime_type_link);
+					supported_mime_types->prev = mime_type_link;
+					mime_type_link->next = supported_mime_types;
+					supported_mime_types = mime_type_link;
+				}
 			}
 			g_free (mime_type);
 		}
@@ -1464,8 +1467,12 @@ add_sorted_view_uris (GList *uris,
 	if (found_selected_uri) {
 		l = uris; // This will become the last list link.
 		uris = g_list_reverse (uris);
-		prior_uris = g_list_reverse (prior_uris);
-		l->next = prior_uris; //Connect the lists.
+		if (prior_uris != NULL) {
+			prior_uris = g_list_reverse (prior_uris);
+			// Connect the lists.
+			prior_uris->prev = l;
+			l->next = prior_uris;
+		}
 	} else {
 		// The selected file unexpectedly wasn't found, possibly due to custom application associations.
 		g_list_free_full (prior_uris, g_free);


### PR DESCRIPTION
Allow images to be viewed in supported image viewers in the same order as they are shown in the current nemo view (directory or search).

For example:

- If images are sorted in ascending date order, opening an image and pressing next/previous in the image view will go to the next/previous image chronologically.
- If the image is part of a search result, available images in the image viewer are limited to the other search results.

This is similar to how images are handled in Windows Explorer and Windows Photo Viewer, which I find so intuitive a feature, I didn't even think of it as one until moving to Linux on my personal machine.

So this is an implementation that seeks to address this in a way that doesn't require specific coupling between applications, or extensive changes to image viewers.

The interface the image viewer has to implement is a very simple one - it just has to accept a list of urls, and display them in the given order, rather than applying its own sorting. Bare bones image viewers like feh and sxiv already do this.

When opening a single image, nemo then checks if the default application to show it is on a list of supported ones, and sends the image viewer a list of all the image urls in the current view, in presented order. No extra application specific code / command line parameters are required.

Unfortunately the basic image viewers of various distros (xviewer, viewnior, ristretto) all seem to apply their own basic alphabetical sort to image lists, so there's an accompanying change to xviewer [here](https://github.com/linuxmint/xviewer/pull/134), since it's very likely this will be available on systems with nemo.

This is a change I think would add unavailable and useful functionality (particularly those moving from Windows; I've seen a few posts elsewhere about people missing this), and not get in the way for people who don't need it.

Passing big url lists around seemed acceptably performant from a few unscientific tests. It passed a folder of 4000 images to xviewer with no issue, which only thumbnailed images in its gallery preview as it needed them.



