### PR TITLE
nemo-view.c: Only update the context menu when it's about to be shown.

### DIFF
--- a/src/nemo-desktop-icon-grid-view.c
+++ b/src/nemo-desktop-icon-grid-view.c
@@ -349,7 +349,7 @@ nemo_desktop_icon_grid_view_dispose (GObject *object)
 					      NULL);
 
 	g_signal_handlers_disconnect_by_func (gnome_lockdown_preferences,
-					      nemo_view_update_menus,
+					      nemo_view_menu_needs_update,
 					      icon_view);
 
 	G_OBJECT_CLASS (nemo_desktop_icon_grid_view_parent_class)->dispose (object);
@@ -641,7 +641,7 @@ nemo_desktop_icon_grid_view_constructed (GObject *object)
 
     g_signal_connect_swapped (gnome_lockdown_preferences,
                   "changed::" NEMO_PREFERENCES_LOCKDOWN_COMMAND_LINE,
-                  G_CALLBACK (nemo_view_update_menus),
+                  G_CALLBACK (nemo_view_menu_needs_update),
                   desktop_icon_grid_view);
 }
 
@@ -716,7 +716,7 @@ action_reverse_sort_callback (GtkAction               *action,
     nemo_icon_container_sort (get_icon_container (view));
     nemo_icon_container_redo_layout (container);
 
-    nemo_view_update_menus (NEMO_VIEW (view));
+    nemo_view_menu_needs_update (NEMO_VIEW (view));
 
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 }
@@ -737,7 +737,7 @@ set_sort_type (NemoDesktopIconGridView *view,
 
     nemo_icon_container_redo_layout (get_icon_container (view));
 
-    nemo_view_update_menus (NEMO_VIEW (view));
+    nemo_view_menu_needs_update (NEMO_VIEW (view));
 
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 }
@@ -775,7 +775,7 @@ set_direction (NemoDesktopIconGridView *view,
 
     nemo_icon_view_set_directory_horizontal_layout (NEMO_ICON_VIEW (view), file, horizontal);
 
-    nemo_view_update_menus (NEMO_VIEW (view));
+    nemo_view_menu_needs_update (NEMO_VIEW (view));
 
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 }
@@ -830,7 +830,7 @@ action_desktop_size_callback (GtkAction               *action,
 
     nemo_icon_container_redo_layout (container);
 
-    nemo_view_update_menus (NEMO_VIEW (view));
+    nemo_view_menu_needs_update (NEMO_VIEW (view));
 
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 }
@@ -1245,7 +1245,7 @@ nemo_desktop_icon_grid_view_set_grid_adjusts (NemoDesktopIconGridView *view,
 
     nemo_icon_container_redo_layout (container);
 
-    nemo_view_update_menus (NEMO_VIEW (view));
+    nemo_view_menu_needs_update (NEMO_VIEW (view));
 
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 

--- a/src/nemo-desktop-icon-view.c
+++ b/src/nemo-desktop-icon-view.c
@@ -273,7 +273,7 @@ nemo_desktop_icon_view_dispose (GObject *object)
 					      NULL);
 
 	g_signal_handlers_disconnect_by_func (gnome_lockdown_preferences,
-					      nemo_view_update_menus,
+					      nemo_view_menu_needs_update,
 					      icon_view);
 
 	G_OBJECT_CLASS (nemo_desktop_icon_view_parent_class)->dispose (object);
@@ -595,7 +595,7 @@ nemo_desktop_icon_view_constructed (GObject *object)
 
     g_signal_connect_swapped (gnome_lockdown_preferences,
                   "changed::" NEMO_PREFERENCES_LOCKDOWN_COMMAND_LINE,
-                  G_CALLBACK (nemo_view_update_menus),
+                  G_CALLBACK (nemo_view_menu_needs_update),
                   desktop_icon_view);
 }
 

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -1143,9 +1143,9 @@ nemo_icon_view_set_zoom_level (NemoIconView *view,
 
 	g_signal_emit_by_name (view, "zoom_level_changed");
 
-	if (nemo_view_get_active (NEMO_VIEW (view))) {
-		nemo_view_update_menus (NEMO_VIEW (view));
-	}
+    if (nemo_view_get_active (NEMO_VIEW (view))) {
+        nemo_view_menu_needs_update (NEMO_VIEW (view));
+    }
 }
 
 static void
@@ -1909,7 +1909,7 @@ nemo_icon_view_react_to_icon_change_idle_callback (gpointer data)
 	/* Rebuild the menus since some of them (e.g. Restore Stretched Icons)
 	 * may be different now.
 	 */
-	nemo_view_update_menus (NEMO_VIEW (icon_view));
+        nemo_view_menu_needs_update (NEMO_VIEW (icon_view));
 
         /* Don't call this again (unless rescheduled) */
         return FALSE;
@@ -2404,10 +2404,10 @@ create_icon_container (NemoIconView *icon_view)
 	g_signal_connect_object (icon_container, "icon_rename_ended",
 				 G_CALLBACK (icon_rename_ended_cb), icon_view, 0);
 	g_signal_connect_object (icon_container, "icon_stretch_started",
-				 G_CALLBACK (nemo_view_update_menus), icon_view,
+				 G_CALLBACK (nemo_view_menu_needs_update), icon_view,
 				 G_CONNECT_SWAPPED);
 	g_signal_connect_object (icon_container, "icon_stretch_ended",
-				 G_CALLBACK (nemo_view_update_menus), icon_view,
+				 G_CALLBACK (nemo_view_menu_needs_update), icon_view,
 				 G_CONNECT_SWAPPED);
 
 	g_signal_connect_object (icon_container, "get_stored_layout_timestamp",

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -3570,7 +3570,7 @@ nemo_list_view_set_zoom_level (NemoListView *view,
 	gtk_cell_renderer_set_fixed_size (GTK_CELL_RENDERER (view->details->pixbuf_cell),
 					  -1, icon_size);
 
-	nemo_view_update_menus (NEMO_VIEW (view));
+	nemo_view_menu_needs_update (NEMO_VIEW (view));
 
 	/* FIXME: https://bugzilla.gnome.org/show_bug.cgi?id=641518 */
 	gtk_tree_view_columns_autosize (view->details->tree_view);

--- a/src/nemo-view.h
+++ b/src/nemo-view.h
@@ -431,7 +431,6 @@ void              nemo_view_pop_up_location_context_menu (NemoView    *view,
 							      GdkEventButton  *event,
 							      const char      *location);
 void              nemo_view_grab_focus                 (NemoView      *view);
-void              nemo_view_update_menus               (NemoView      *view);
 void              nemo_view_new_folder                 (NemoView      *view);
-
+void              nemo_view_menu_needs_update          (NemoView      *view);
 #endif /* NEMO_VIEW_H */

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -658,7 +658,7 @@ action_split_view_callback (GtkAction *action,
 
 		slot = nemo_window_get_active_slot (window);
 		if (slot != NULL) {
-			nemo_view_update_menus (slot->content_view);
+			nemo_view_menu_needs_update (slot->content_view);
 		}
 	}
 


### PR DESCRIPTION
Previously, the menu was updated when the selection changed, during
loading of the view, when a file in the view (or the view location
itself) changed and many other events. This would end up causing
a lot of unnecessary updates, which could have a noticeable impact
on performance.

Instead, only flag the menu as needing an update when any of these
events occurs, and only actually update the menu just before showing
it.

ref: #2718