### PR TITLE
docs: added docs for the `--existing-window` flag

### DIFF
--- a/docs/nemo.1
+++ b/docs/nemo.1
@@ -47,6 +47,9 @@ Create the initial window with the given geometry.
 .B \-\-tabs\fR
 Open URIs in tabs.
 .TP
+.B \-\-existing-window\fR
+Open URIs in an existing window.
+.TP
 .B \-n
 .TP
 .B \-\-no-default-window


### PR DESCRIPTION
Added the new flag to the docs. I think `docs/nemo.1` is the only place where docs live. Correct me if I need to add it in more places.