### PR TITLE
Fix #2347 - Nemo menu unaccessible after hiding it

### DIFF
--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -563,7 +563,7 @@ hide_menu_on_delay (NemoWindow *window)
 }
 
 static gboolean
-on_menu_focus_out (GtkWidget *widget,
+on_menu_focus_out (GtkMenuShell *widget,
                    GdkEvent  *event,
                    gpointer   user_data)
 {
@@ -577,7 +577,11 @@ on_menu_focus_out (GtkWidget *widget,
      * complete their click action. */
     clear_menu_hide_delay (window);
 
-    window->details->menu_hide_delay_id = g_timeout_add (200, (GSourceFunc) hide_menu_on_delay, window);
+    /* When a submenu pops-up, the menu loses focus. The menu should disappear
+     * only when none of its elements is selected. */
+    if (!gtk_menu_shell_get_selected_item (widget)) {
+        window->details->menu_hide_delay_id = g_timeout_add (200, (GSourceFunc) hide_menu_on_delay, window);
+    }
 
     return GDK_EVENT_PROPAGATE;
 }

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -586,6 +586,17 @@ on_menu_focus_out (GtkMenuShell *widget,
     return GDK_EVENT_PROPAGATE;
 }
 
+void
+on_menu_selection_done (GtkMenuShell *menushell,
+                        gpointer      user_data)
+{
+	NemoWindow *window = NEMO_WINDOW (user_data);
+
+	/* Remove the menu inmediately after selecting an item. */
+	clear_menu_hide_delay (window);
+	window->details->menu_hide_delay_id = g_timeout_add (0, (GSourceFunc) hide_menu_on_delay, window);
+}
+
 static void
 nemo_window_constructed (GObject *self)
 {
@@ -630,6 +641,12 @@ nemo_window_constructed (GObject *self)
     g_signal_connect_object (menu,
                              "focus-out-event",
                              G_CALLBACK (on_menu_focus_out),
+                             window,
+                             0);
+
+    g_signal_connect_object (menu,
+                             "selection-done",
+                             G_CALLBACK (on_menu_selection_done),
                              window,
                              0);
 


### PR DESCRIPTION
The menu bar seems to lose focus after a sub-menu appears. As a workaround, one may check whether some element is selected before hiding it.

I added also some more code (I am no C programmer, this part can be improved for sure) to hide the menu immediately after choosing an option, otherwise there is still a small delay and the experience feels weird.

~~**Remark**: on a touchscreen, you can't keep your finger pressed against the options and then release to select, so if you do not hit the proper option on your first try, then the menu also closes. This is sub-optimal.~~

~~**Remark 2**: this also seems to happen with a mouse.~~