### PR TITLE
make ps2txt search helper work on non-debianlike distros

### DIFF
--- a/files/usr/share/nemo/search-helpers/ps2ascii.nemo_search_helper
+++ b/files/usr/share/nemo/search-helpers/ps2ascii.nemo_search_helper
@@ -1,5 +1,5 @@
 [Nemo Search Cat Helper]
-TryExec=ps2txt
-Exec=ps2txt %s
+TryExec=ps2ascii
+Exec=ps2ascii %s
 MimeType=application/ps;
 Priority=100;


### PR DESCRIPTION
Specifically, there is no such thing as ps2txt and AFAICT never has been. But debian has for some decades been providing a convenience symlink from ps2ascii so that you can invoke it as 'ps2txt' as well, resulting in much confusion from people who actually try to do so, start relying on doing so, and then get bug reports for their software from other distros where this just plain does not work.