### PR TITLE
Added new "Keep both files" conflict handling option

### DIFF
--- a/libnemo-private/nemo-file-conflict-dialog.c
+++ b/libnemo-private/nemo-file-conflict-dialog.c
@@ -57,6 +57,7 @@ struct _NemoFileConflictDialogDetails
 	GtkWidget *checkbox;
 	GtkWidget *rename_button;
 	GtkWidget *replace_button;
+	GtkWidget *auto_rename_button;
 	GtkWidget *dest_image;
 	GtkWidget *src_image;
 };
@@ -546,6 +547,12 @@ nemo_file_conflict_dialog_init (NemoFileConflictDialog *fcd)
 				_("_Skip"),
 				CONFLICT_RESPONSE_SKIP,
 				NULL);
+
+	details->auto_rename_button =
+		gtk_dialog_add_button (dialog,
+					   _("Auto_rename"),
+					   CONFLICT_RESPONSE_AUTO_RENAME);
+
 	details->rename_button =
 		gtk_dialog_add_button (dialog,
 				       _("Re_name"),

--- a/libnemo-private/nemo-file-conflict-dialog.h
+++ b/libnemo-private/nemo-file-conflict-dialog.h
@@ -62,8 +62,9 @@ struct _NemoFileConflictDialogClass {
 enum
 {
 	CONFLICT_RESPONSE_SKIP = 1,
-	CONFLICT_RESPONSE_REPLACE = 2,
-	CONFLICT_RESPONSE_RENAME = 3,
+	CONFLICT_RESPONSE_AUTO_RENAME = 2,
+	CONFLICT_RESPONSE_REPLACE = 3,
+	CONFLICT_RESPONSE_RENAME = 4
 };
 
 GType nemo_file_conflict_dialog_get_type (void) G_GNUC_CONST;

--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -98,6 +98,7 @@ typedef struct {
 	gboolean skip_all_error;
 	gboolean skip_all_conflict;
 	gboolean merge_all;
+	gboolean auto_rename_all;
 	gboolean replace_all;
 	gboolean delete_all;
 } CommonJob;
@@ -4535,7 +4536,7 @@ copy_move_file (CopyMoveJob *copy_job,
 
 		g_error_free (error);
 
-		if (unique_names) {
+		if (unique_names || job->auto_rename_all) {
 			g_object_unref (dest);
 			dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, unique_name_nr++);
 			goto retry;
@@ -4583,6 +4584,13 @@ copy_move_file (CopyMoveJob *copy_job,
 			g_object_unref (dest);
 			dest = get_target_file_for_display_name (dest_dir,
 								 resp->new_name);
+			conflict_response_data_free (resp);
+			goto retry;
+		} else if (resp->id == CONFLICT_RESPONSE_AUTO_RENAME) {
+			if (resp->apply_to_all) {
+				job->auto_rename_all = TRUE;
+			}
+			unique_names = TRUE;
 			conflict_response_data_free (resp);
 			goto retry;
 		} else {
@@ -5049,6 +5057,7 @@ move_file_prepare (CopyMoveJob *move_job,
 	GError *error;
 	CommonJob *job;
 	gboolean overwrite;
+	gboolean auto_rename;
 	char *primary, *secondary, *details;
 	int response;
 	GFileCopyFlags flags;
@@ -5184,6 +5193,12 @@ move_file_prepare (CopyMoveJob *move_job,
 			goto retry;
 		}
 
+		if (job->auto_rename_all || auto_rename) {
+			g_object_unref (dest);
+			dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, 1);
+			goto retry;
+		}
+
 		if (job->skip_all_conflict) {
 			goto out;
 		}
@@ -5214,6 +5229,13 @@ move_file_prepare (CopyMoveJob *move_job,
 			g_object_unref (dest);
 			dest = get_target_file_for_display_name (dest_dir,
 								 resp->new_name);
+			conflict_response_data_free (resp);
+			goto retry;
+		} else if (resp->id == CONFLICT_RESPONSE_AUTO_RENAME) {
+			if (resp->apply_to_all) {
+				job->auto_rename_all = TRUE;
+			}
+			auto_rename = TRUE;
 			conflict_response_data_free (resp);
 			goto retry;
 		} else {


### PR DESCRIPTION
## Description
This feature appears in the GUI as a new button "Autorename" added to all the different conflict dialogs
This uses the already implemented "unique name" policy that allows copying/moving a file/folder with the same name than another in destination folder by renaming it automatically in this fashion:
"example file (copy).txt" "example file (another copy).txt" "example file (3rd copy).txt" etc.
The main interest of this new feature is its cumulation with the "apply to all" checkbox, allowing automatic renaming for all conflicts.

## Bugs
No bug were found upon testing all relevant use cases

## Feature notes
Only the functioning feature was implemented. Translation is left to the maintainers / other contributors.

## Pull request notes
This addition is originally intended to be merged to the maintenance branch of the 4.4 version, as it was the only version I could personally test on my Ubuntu 20.04 machine; however it shouldn't conflict with any other version and is strongly encouraged to be merged to the latest versions, as it's a logical feature that is showcased in any classical file browser e.g. Windows Explorer
This closes the issue #2352, as well as some others treating of this subject that may or may not have been mentioning the issue I just linked.

## General notes
I profit of this merge pull to make a small complaint: such a small feature with a very few lines of code took a considerable time (around a week of evenings) to implement because of the lack of clear documentation of this repository. Despite the code being, I admit it, very clear and concise, I'd humbly ask some maintainers to write at least a small documentation that would help new contributors find themselves in this codebase