### PR TITLE
[WIP] Arrow key navigation for preview

### DIFF
--- a/data/dbus-interfaces.xml
+++ b/data/dbus-interfaces.xml
@@ -42,4 +42,9 @@
       <arg type='s' name='DestinationDisplayName' direction='in'/>
     </method>
   </interface>
+  <interface name='org.Nemo.Preview'>
+    <signal name="SelectionEvent">
+      <arg type="q" name="direction" />
+    </signal>
+  </interface>
 </node>

--- a/libnemo-private/nemo-dbus-manager.c
+++ b/libnemo-private/nemo-dbus-manager.c
@@ -96,6 +96,15 @@ handle_copy_file (NemoDBusFileOperations *object,
 }
 
 static gboolean
+selection_event (NemoDBusFileOperations *object,
+		  GDBusMethodInvocation *invocation,
+		  const guint16 direction)
+{
+  printf("%i", direction);
+  return TRUE; /* invocation was handled */
+}
+
+static gboolean
 handle_copy_uris (NemoDBusFileOperations *object,
 		  GDBusMethodInvocation *invocation,
 		  const gchar **sources,
@@ -184,6 +193,10 @@ nemo_dbus_manager_init (NemoDBusManager *self)
   g_signal_connect (self->file_operations,
 		    "handle-empty-trash",
 		    G_CALLBACK (handle_empty_trash),
+		    self);
+  g_signal_connect (self->file_operations,
+		    "selection-event",
+		    G_CALLBACK (selection_event),
 		    self);
 
   g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (self->file_operations), connection,


### PR DESCRIPTION
- see https://github.com/linuxmint/nemo-extensions/issues/421
- counterpart to https://github.com/linuxmint/nemo-extensions/pull/427

---

what I've figured out so far:
- there's a bunch of code generated from `dbus-interfaces.xml`
- handling the signal should be as easy as registering a callback

...except this doesn't work. I can see the signal being sent (using `dbus-monitor --session 'type=signal,member=SelectionEvent'`) but nemo doesn't seem to be aware of them.

if someone could give me some guidance / hints as to how to continue, I'd be very grateful.