### PR TITLE
Enable 'Make Link' by default in a file/folder right click menu

### DIFF
--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -733,7 +733,7 @@
       <summary>Show the selection context menu's Favorite/Unfavorite item.</summary>
     </key>
     <key name="selection-menu-make-link" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Show the selection context menu's Create Link item.</summary>
     </key>
     <key name="selection-menu-rename" type="b">


### PR DESCRIPTION
FIX https://github.com/linuxmint/nemo/issues/2883

This PR enables 'Make Link' by default in the file/folder right-click menu in the File Manager. The lack of 'Make Link' by default is criticism highlighted during Part 3 of the LinusTechTips Linux Challenge by Luke, as well as being something users have been requesting in the above issue.

The only change made is that 'Make Link' is now in the menu without the user needing to initially enable the option.