### PR TITLE
search: add a PDF search helper

### DIFF
--- a/search-helpers/application-pdf.nemo_search_helper
+++ b/search-helpers/application-pdf.nemo_search_helper
@@ -1,0 +1,5 @@
+[Nemo Search Helper]
+TryExec=pdftotext
+Exec=pdftotext %s
+MimeType=application/pdf;
+Priority=100


### PR DESCRIPTION
Based on the pdftotext poppler utility.

For historical context: This arose from https://unix.stackexchange.com/questions/680655/is-it-possible-to-integrate-pdfgrep-into-nemo-search/680659 and me wanting that for a long time, too.

Signed-off-by: Marcus Müller <marcus@hostalia.de>