### PR TITLE
[WIP] Remote terminal nemo action

### DIFF
--- a/files/usr/share/nemo/actions/remote_terminal.nemo_action
+++ b/files/usr/share/nemo/actions/remote_terminal.nemo_action
@@ -1,0 +1,10 @@
+[Nemo Action]
+Name=Open in Remote Terminal
+Comment=Open a remote terminal in the active remote folder
+Exec=<remote_terminal.py %F>
+Icon-Name=utilities-terminal-symbolic
+Selection=any
+Extensions=dir;
+# conditions=exec <remote_terminal.py %U>;
+Dependencies=ssh;
+UriScheme=sftp

--- a/files/usr/share/nemo/actions/remote_terminal.py
+++ b/files/usr/share/nemo/actions/remote_terminal.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# On linux-systems, root of an sftp location is usually mounted at:
+# /run/user/<uid>/gvfs/sftp:host=<host-ip>
+
+import os
+import sys
+import subprocess
+print("")
+
+def call_remote(uri):
+    remote_address = uri.split('sftp:', 1)[1]
+    # print(remote_address)
+
+    if "," in remote_address:
+        # in case "/run/user/<uid>/gvfs/sftp:host=<ip>,user=<username>/path"
+        # is passed
+        remote_host, sep, remote_userpath = remote_address.partition(',')
+        # print(remote_address.partition(','))
+
+        # remote path
+        remote_user, sep, remote_path = remote_userpath.partition('/')
+        # print(remote_userpath.partition('/'))
+
+        # remote user
+        # print(remote_user.partition('='))
+        key, sep, remote_user = remote_user.partition('=')
+
+        # remote ip
+        key, sep, remote_ip = remote_host.partition('=')
+        # print(remote_host.partition('='))
+    else:
+        # in case "/run/user/<uid>/gvfs/sftp:host=<ip>/path" is passed
+        # remote path
+        remote_host, sep, remote_path = remote_address.partition('/')
+        # print(remote_address.partition('/'))
+
+        # remote user
+        remote_user = os.environ['USER']
+
+        # remote ip
+        key, sep, remote_ip = remote_host.partition('=')
+        # print(remote_host.partition('='))
+
+    ssh_args = {}
+    ssh_args['remote_user'] = remote_user
+    ssh_args['remote_ip'] = remote_ip
+    ssh_args['remote_path'] = remote_path
+
+    # run ssh command
+    remote_cmd = [terminal, '-e',
+        'ssh %(remote_user)s@%(remote_ip)s -t "cd /%(remote_path)s; $SHELL"' % ssh_args]
+    subprocess.call(remote_cmd)
+
+
+# terminal application
+terminal="x-terminal-emulator"
+
+# remote uri
+uris = sys.argv[1:]
+# print(uris)
+for uri in uris:
+    # print(uri)
+    call_remote(uri)


### PR DESCRIPTION
"Open in remote terminal" option was missing in nemo context menu.
Added the option by creating a new in-built action  in `/usr/share/nemo/actions` which runs a python script to invoke ssh in
terminal. More detailed benefits can be found in #2824

@mtwebster Do you think it will be useful?
NB: I'll append `closes #2824` in final commit message and mark this as ready for review.