### PR TITLE
Add option to disable or enable content type detection of mounted media.

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1494,6 +1494,22 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="position">3</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="media_detect_content_checkbutton">
+                                            <property name="label" translatable="yes">Detect content of media and suggest application to open</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -226,9 +226,10 @@ typedef enum
 
 /* media handling */
 
-#define GNOME_DESKTOP_MEDIA_HANDLING_AUTOMOUNT      "automount"
-#define GNOME_DESKTOP_MEDIA_HANDLING_AUTOMOUNT_OPEN "automount-open"
-#define GNOME_DESKTOP_MEDIA_HANDLING_AUTORUN        "autorun-never"
+#define GNOME_DESKTOP_MEDIA_HANDLING_AUTOMOUNT            "automount"
+#define GNOME_DESKTOP_MEDIA_HANDLING_AUTOMOUNT_OPEN       "automount-open"
+#define GNOME_DESKTOP_MEDIA_HANDLING_AUTORUN              "autorun-never"
+#define NEMO_PREFERENCES_MEDIA_HANDLING_DETECT_CONTENT    "detect-content"
 
 /* Terminal */
 #define GNOME_DESKTOP_TERMINAL_EXEC        "exec"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -415,6 +415,10 @@
       <default>false</default>
       <summary>Suppress any safeguards when running nemo/nemo-desktop as the root user. For some systems there is only a root user.</summary>
     </key>
+    <key name="detect-content" type="b">
+      <default>true</default>
+      <summary>If true, enable detection of the type of content of a mounted media and display a suggested application to open the media.</summary>
+    </key>
   </schema>
 
   <schema id="org.nemo.icon-view" path="/org/nemo/icon-view/" gettext-domain="nemo">

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -91,6 +91,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTOMOUNT_MEDIA_WIDGET "media_automount_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTOOPEN_MEDIA_WIDGET "media_autoopen_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_AUTORUN_MEDIA_WIDGET "media_autorun_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DETECT_CONTENT_MEDIA_WIDGET "media_detect_content_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ADVANCED_PERMISSIONS_WIDGET "show_advanced_permissions_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET "start_with_dual_pane_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
@@ -984,6 +985,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool_inverted (builder, gnome_media_handling_preferences,
                NEMO_FILE_MANAGEMENT_PROPERTIES_AUTORUN_MEDIA_WIDGET,
                GNOME_DESKTOP_MEDIA_HANDLING_AUTORUN);
+
+    bind_builder_bool (builder, nemo_preferences,
+               NEMO_FILE_MANAGEMENT_PROPERTIES_DETECT_CONTENT_MEDIA_WIDGET,
+               NEMO_PREFERENCES_MEDIA_HANDLING_DETECT_CONTENT);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_CLOSE_DEVICE_VIEW_ON_EJECT_WIDGET,

--- a/src/nemo-window-manage-views.c
+++ b/src/nemo-window-manage-views.c
@@ -1432,10 +1432,14 @@ found_mount_cb (GObject *source_object,
 						    NULL);
 	if (mount != NULL) {
 		data->mount = mount;
-		nemo_get_x_content_types_for_mount_async (mount,
-							      found_content_type_cb,
-							      data->cancellable,
-							      data);
+		
+		if (g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_MEDIA_HANDLING_DETECT_CONTENT)) {
+			nemo_get_x_content_types_for_mount_async (mount,
+											found_content_type_cb,
+											data->cancellable,
+											data);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Reasons to add this option: I don't need that functionality, it is wasted cycles and it takes too much space away from the file list.

I added the option in the media handling section, although it is a nemo specific option but is very much a media handling option, is it ok?