### PR TITLE
Add !NEMO_IS_DESKTOP_WINDOW() guards to callbacks

### DIFF
--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -307,9 +307,11 @@ action_plugins_callback (GtkAction *action,
 {
     GtkWindow *window;
 
-    window = GTK_WINDOW (user_data);
+    if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+        window = GTK_WINDOW (user_data);
 
-    nemo_file_management_properties_dialog_show (window, "plugins");
+        nemo_file_management_properties_dialog_show (window, "plugins");
+    }
 }
 
 static void
@@ -525,7 +527,9 @@ static void
 action_close_all_windows_callback (GtkAction *action,
 				   gpointer user_data)
 {
-	nemo_application_close_all_windows (nemo_application_get_singleton ());
+	if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+		nemo_application_close_all_windows (nemo_application_get_singleton ());
+	}
 }
 
 static void
@@ -579,12 +583,14 @@ action_show_hide_sidebar_callback (GtkAction *action,
 {
 	NemoWindow *window;
 
-	window = NEMO_WINDOW (user_data);
+	if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+		window = NEMO_WINDOW (user_data);
 
-	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
-		nemo_window_show_sidebar (window);
-	} else {
-		nemo_window_hide_sidebar (window);
+		if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
+			nemo_window_show_sidebar (window);
+		} else {
+			nemo_window_hide_sidebar (window);
+		}
 	}
 }
 
@@ -770,14 +776,18 @@ static void
 action_add_bookmark_callback (GtkAction *action,
 			      gpointer user_data)
 {
+    if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
         nemo_window_add_bookmark_for_current_location (NEMO_WINDOW (user_data));
+    }
 }
 
 static void
 action_edit_bookmarks_callback (GtkAction *action,
 				gpointer user_data)
 {
+    if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
         nemo_window_edit_bookmarks (NEMO_WINDOW (user_data));
+    }
 }
 
 static void
@@ -935,8 +945,10 @@ action_menu_edit_location_callback (GtkAction *action,
 	NemoWindow *window = user_data;
 	NemoWindowPane *pane;
 
-    pane = nemo_window_get_active_pane (window);
-    toggle_location_entry_setting(window, pane, TRUE);
+    if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+        pane = nemo_window_get_active_pane (window);
+        toggle_location_entry_setting(window, pane, TRUE);
+    }
 }
 
 static void

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -34,6 +34,7 @@
 #include "nemo-actions.h"
 #include "nemo-application.h"
 #include "nemo-bookmarks-window.h"
+#include "nemo-desktop-window.h"
 #include "nemo-location-bar.h"
 #include "nemo-mime-actions.h"
 #include "nemo-notebook.h"
@@ -308,11 +309,13 @@ nemo_window_prompt_for_location (NemoWindow *window,
 
 	g_return_if_fail (NEMO_IS_WINDOW (window));
 
-	if (initial) {
-		nemo_window_show_location_entry(window);
-		pane = window->details->active_pane;
-		nemo_location_bar_set_location (NEMO_LOCATION_BAR (pane->location_bar),
-						    initial);
+	if (!NEMO_IS_DESKTOP_WINDOW (window)) {
+		if (initial) {
+			nemo_window_show_location_entry(window);
+			pane = window->details->active_pane;
+			nemo_location_bar_set_location (NEMO_LOCATION_BAR (pane->location_bar),
+							    initial);
+		}
 	}
 }
 
@@ -2270,11 +2273,13 @@ void
 nemo_window_set_show_sidebar (NemoWindow *window,
                               gboolean show)
 {
-    window->details->show_sidebar = show;
+    if (!NEMO_IS_DESKTOP_WINDOW (window)) {
+        window->details->show_sidebar = show;
 
-    g_settings_set_boolean (nemo_window_state, NEMO_WINDOW_STATE_START_WITH_SIDEBAR, show);
+        g_settings_set_boolean (nemo_window_state, NEMO_WINDOW_STATE_START_WITH_SIDEBAR, show);
 
-    g_object_notify_by_pspec (G_OBJECT (window), properties[PROP_SHOW_SIDEBAR]);
+        g_object_notify_by_pspec (G_OBJECT (window), properties[PROP_SHOW_SIDEBAR]);
+    }
 }
 
 gboolean


### PR DESCRIPTION
Fixes #2921.

Some action callbacks are already guarded with !NEMO_IS_DESKTOP_WINDOW() checks, but not enough unfortunately.  Guards are added to these callbacks for the following justifications:

- CTRL+Q: action_close_all_windows_callback (segfaults)
- CTRL+L: action_menu_edit_location_callback (does nothing but print nonfatal assertion failures)
- CTRL+D: action_add_bookmark_callback (adds bogus bookmark)
- CTRL+B: action_edit_bookmarks_callback (crashes nemo-desktop with fatal assertion failure)
- ALT+P: action_plugins_callback (fails to load extensions)
- F9: action_show_hide_sidebar_callback/nemo_window_get_sidebar_id (silently changes global sidebar preference even though desktop has no sidebar)
- / or ~: nemo_window_prompt_for_location (does nothing but print nonfatal assertion failures)