### PR TITLE
Port to GNotification

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Build-Depends:
  libgsf-1-dev,
  libgtk-3-dev (>= 3.10),
  libgtk-3-doc,
- libnotify-dev (>= 0.7.0),
  libpango1.0-dev,
  libx11-dev,
  libxapp-dev (>= 2.0.0),

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,6 @@ glib    = dependency('glib-2.0',                    version: glib_version)
 gmodule = dependency('gmodule-no-export-2.0',       version: glib_version)
 gobject = dependency('gobject-2.0',                 version: '>=2.0')
 go_intr = dependency('gobject-introspection-1.0',   version: '>=1.0')
-libnotif= dependency('libnotify',                   version: '>=0.7.0')
 
 cinnamon= dependency('cinnamon-desktop',            version: '>=4.8.0')
 gail    = dependency('gail-3.0')

--- a/src/meson.build
+++ b/src/meson.build
@@ -102,7 +102,7 @@ if enableEmptyView
   nemoCommon_sources += 'nemo-empty-view.c'
 endif
 
-nemo_deps = [ cinnamon, gail, glib, gtk, libnotif, libxml, math, x11,
+nemo_deps = [ cinnamon, gail, glib, gtk, libxml, math, x11,
   egg, nemo_extension, nemo_private, xapp ]
 
 if exempi_enabled

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -75,7 +75,6 @@
 #include <eel/eel-gtk-extensions.h>
 #include <eel/eel-stock-dialogs.h>
 #include <eel/eel-string.h>
-#include <libnotify/notify.h>
 #include <libxapp/xapp-favorites.h>
 
 #define GNOME_DESKTOP_USE_UNSTABLE_API
@@ -552,7 +551,6 @@ nemo_application_startup (GApplication *app)
 	init_menu_provider_callback ();
 
 	/* Initialize the UI handler singleton for file operations */
-	notify_init (GETTEXT_PACKAGE);
 	self->priv->progress_handler = nemo_progress_ui_handler_new ();
 
     self->priv->cache_problem = FALSE;

--- a/src/nemo-desktop-application.c
+++ b/src/nemo-desktop-application.c
@@ -62,7 +62,6 @@
 #include <stdlib.h>
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>
-#include <libnotify/notify.h>
 #include <gdk/gdkx.h>
 #include <X11/Xatom.h>
 

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -61,8 +61,6 @@
 #include "nemo-window.h"
 #include "nemo-window-slot.h"
 
-#include <libnotify/notify.h>
-
 #define DEBUG_FLAG NEMO_DEBUG_PLACES
 #include <libnemo-private/nemo-debug.h>
 
@@ -129,8 +127,6 @@ typedef struct {
 	gboolean mounting;
 	NemoWindowSlot *go_to_after_mount_slot;
 	NemoWindowOpenFlags go_to_after_mount_flags;
-
-    NotifyNotification *unmount_notify;
 
 	guint bookmarks_changed_id;
 
@@ -4413,7 +4409,6 @@ nemo_places_sidebar_dispose (GObject *object)
 	sidebar->uri = NULL;
 
 	free_drag_data (sidebar);
-    g_clear_object (&sidebar->unmount_notify);
 
 	if (sidebar->bookmarks_changed_id != 0) {
 		g_signal_handler_disconnect (sidebar->bookmarks,

--- a/src/nemo-progress-ui-handler.c
+++ b/src/nemo-progress-ui-handler.c
@@ -31,6 +31,7 @@
 #include "nemo-application.h"
 #include "nemo-progress-info-widget.h"
 
+#include <gio/gio.h>
 #include <glib/gi18n.h>
 
 #include <eel/eel-string.h>
@@ -38,7 +39,6 @@
 #include <libnemo-private/nemo-progress-info.h>
 #include <libnemo-private/nemo-progress-info-manager.h>
 
-#include <libnotify/notify.h>
 #include <libxapp/xapp-gtk-window.h>
 #include <libxapp/xapp-status-icon.h>
 
@@ -262,13 +262,12 @@ progress_ui_handler_add_to_window (NemoProgressUIHandler *self,
 static void
 progress_ui_handler_show_complete_notification (NemoProgressUIHandler *self)
 {
-	NotifyNotification *complete_notification;
+	GNotification *complete_notification;
 
-	complete_notification = notify_notification_new (_("File Operations"),
-							 _("All file operations have been successfully completed"),
-							 NULL);
-	notify_notification_show (complete_notification, NULL);
-
+	complete_notification = g_notification_new (_("File Operations"));
+	g_notification_set_body (complete_notification, _("All file operations have been successfully completed"));
+	
+	g_application_send_notification (G_APPLICATION (nemo_application_get_singleton ()), NULL, complete_notification);
 	g_object_unref (complete_notification);
 }
 


### PR DESCRIPTION
Replace libnotify with gio's GNotification and thus remove a dependency.

Fixes: #2931

I tested the unmount pending/done notifications, but didn't manage to get the "All file operations have been successfully completed" notification though. Wasn't able to trigger that one somehow.