### PR TITLE
icon-container: Don't free a pointer after it has already been freed

### DIFF
--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -2783,8 +2783,8 @@ finalize (GObject *object)
 
     g_slice_free (NemoViewLayoutConstants, details->view_constants);
 
-	g_free (details);
     g_list_free (details->current_selection);
+    g_free(details);
 
 	G_OBJECT_CLASS (nemo_icon_container_parent_class)->finalize (object);
 }


### PR DESCRIPTION
The details pointer was freed before g_list_free was called on
details->current_section. Freeing details also got rid of it, so
swap the order so both are freed in proper order.

Fixes https://bugs.launchpad.net/ubuntu/+source/nemo/+bug/1945903

---
I do not know what caused this bug for the user in the first place. It looked like he was DE hopping; I even applied the Breeze theme which was shown in some warnings but still couldn't reproduce it. If anything this'd be stability fix