### PR TITLE
Actions: Escape tabs, newlines and backslashes

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -106,7 +106,7 @@ eel_str_escape_spaces (const char *string)
 char *
 eel_str_escape_non_space_special_characters (const char *string)
 {
-    int quotes_and_tabs;
+    int quotes_tabs_and_backslashes;
     int newlines;
     const char *p;
     char *q;
@@ -116,20 +116,20 @@ eel_str_escape_non_space_special_characters (const char *string)
         return NULL;
     }
 
-    quotes_and_tabs = 0;
+    quotes_tabs_and_backslashes = 0;
     newlines = 0;
     for (p = string; *p != '\0'; p++) {
-        quotes_and_tabs += (*p == '\'') || (*p == '\"') || (*p == '\t');
+        quotes_tabs_and_backslashes += (*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\');
         newlines += (*p == '\n');
     }
 
-    if (quotes_and_tabs + newlines == 0) {
+    if (quotes_tabs_and_backslashes + newlines == 0) {
         return g_strdup (string);
     }
 
-    escaped = g_new (char, strlen (string) + quotes_and_tabs + newlines * 2 + 1);
+    escaped = g_new (char, strlen (string) + quotes_tabs_and_backslashes + newlines * 2 + 1);
     for (p = string, q = escaped; *p != '\0'; p++, q++) {
-        if ((*p == '\'') || (*p == '\"') || (*p == '\t')) {
+        if ((*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\')) {
             *q++ = '\\';
         } else if (*p == '\n') {
             *q++ = '\'';

--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -104,9 +104,10 @@ eel_str_escape_spaces (const char *string)
 }
 
 char *
-eel_str_escape_quotes (const char *string)
+eel_str_escape_non_space_special_characters (const char *string)
 {
-    int quotes;
+    int quotes_and_tabs;
+    int newlines;
     const char *p;
     char *q;
     char *escaped;
@@ -115,19 +116,26 @@ eel_str_escape_quotes (const char *string)
         return NULL;
     }
 
-    quotes = 0;
+    quotes_and_tabs = 0;
+    newlines = 0;
     for (p = string; *p != '\0'; p++) {
-        quotes += (*p == '\'') || (*p == '\"');
+        quotes_and_tabs += (*p == '\'') || (*p == '\"') || (*p == '\t');
+        newlines += (*p == '\n');
     }
 
-    if (quotes == 0) {
+    if (quotes_and_tabs + newlines == 0) {
         return g_strdup (string);
     }
 
-    escaped = g_new (char, strlen (string) + quotes + 1);
+    escaped = g_new (char, strlen (string) + quotes_and_tabs + newlines * 2 + 1);
     for (p = string, q = escaped; *p != '\0'; p++, q++) {
-        if ((*p == '\'') || (*p == '\"')) {
+        if ((*p == '\'') || (*p == '\"') || (*p == '\t')) {
             *q++ = '\\';
+        } else if (*p == '\n') {
+            *q++ = '\'';
+            *q++ = *p;
+            *q = '\'';
+            continue;
         }
         *q = *p;
     }

--- a/eel/eel-string.h
+++ b/eel/eel-string.h
@@ -39,30 +39,30 @@
 /* NULL is allowed for all the str parameters to these functions. */
 
 /* Escape function for '_' character. */
-char *   eel_str_double_underscores        (const char    *str);
+char *   eel_str_double_underscores                  (const char    *str);
 /* Escape function for spaces */
-char *   eel_str_escape_spaces             (const char    *str);
-/* Escape function for quotes */
-char *   eel_str_escape_quotes             (const char    *str);
+char *   eel_str_escape_spaces                       (const char    *str);
+/* Escape function for non-space special characters in a shell context. */
+char *   eel_str_escape_non_space_special_characters (const char    *str);
 /* Capitalize a string */
-char *   eel_str_capitalize                (const char    *str);
+char *   eel_str_capitalize                          (const char    *str);
 
 /* Middle truncate a string to a maximum of truncate_length characters.
  * The resulting string will be truncated in the middle with a "..."
  * delimiter.
  */
-char *   eel_str_middle_truncate           (const char    *str,
-					    guint          truncate_length);
+char *   eel_str_middle_truncate                     (const char    *str,
+						      guint          truncate_length);
 
 
 /* Remove all characters after the passed-in substring. */
-char *   eel_str_strip_substring_and_after (const char    *str,
-					    const char    *substring);
+char *   eel_str_strip_substring_and_after           (const char    *str,
+						      const char    *substring);
 
 /* Replace all occurrences of substring with replacement. */
-char *   eel_str_replace_substring         (const char    *str,
-					    const char    *substring,
-					    const char    *replacement);
+char *   eel_str_replace_substring                   (const char    *str,
+						      const char    *substring,
+						      const char    *replacement);
 
 typedef char * eel_ref_str;
 

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1213,25 +1213,25 @@ find_token_type (const gchar *str, TokenType *token_type)
 static gchar *
 get_path (NemoAction *action, NemoFile *file)
 {
-    gchar *ret, *quote_escaped, *orig;
+    gchar *ret, *escaped, *orig;
 
     orig = nemo_file_get_path (file);
 
     if (action->quote_type != QUOTE_TYPE_DOUBLE && action->quote_type != QUOTE_TYPE_SINGLE)
-        quote_escaped = eel_str_escape_quotes (orig);
+        escaped = eel_str_escape_non_space_special_characters (orig);
     else
-        quote_escaped = orig;
+        escaped = orig;
 
     if (action->escape_space) {
-        ret = eel_str_escape_spaces (quote_escaped);
+        ret = eel_str_escape_spaces (escaped);
     } else {
-        ret = g_strdup (quote_escaped);
+        ret = g_strdup (escaped);
     }
 
     g_free (orig);
 
-    if (quote_escaped != orig)
-        g_free (quote_escaped);
+    if (escaped != orig)
+        g_free (escaped);
 
     return ret;
 }


### PR DESCRIPTION
Fixes #3011 and #3012. Tabs, newlines and backslashes is set to have addition processing if the path is not quoted at all.