### PR TITLE
Actions: Escape number signs (#)

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -106,7 +106,7 @@ eel_str_escape_spaces (const char *string)
 char *
 eel_str_escape_non_space_special_characters (const char *string)
 {
-    int quotes_tabs_and_backslashes;
+    int special_characters;
     int newlines;
     const char *p;
     char *q;
@@ -116,20 +116,20 @@ eel_str_escape_non_space_special_characters (const char *string)
         return NULL;
     }
 
-    quotes_tabs_and_backslashes = 0;
+    special_characters = 0;
     newlines = 0;
     for (p = string; *p != '\0'; p++) {
-        quotes_tabs_and_backslashes += (*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\');
+        special_characters += (*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\') || (*p == '#') ;
         newlines += (*p == '\n');
     }
 
-    if (quotes_tabs_and_backslashes + newlines == 0) {
+    if (special_characters + newlines == 0) {
         return g_strdup (string);
     }
 
-    escaped = g_new (char, strlen (string) + quotes_tabs_and_backslashes + newlines * 2 + 1);
+    escaped = g_new (char, strlen (string) + special_characters + newlines * 2 + 1);
     for (p = string, q = escaped; *p != '\0'; p++, q++) {
-        if ((*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\')) {
+        if ((*p == '\'') || (*p == '\"') || (*p == '\t') || (*p == '\\') || (*p == '#')) {
             *q++ = '\\';
         } else if (*p == '\n') {
             *q++ = '\'';

--- a/eel/eel-string.h
+++ b/eel/eel-string.h
@@ -42,7 +42,7 @@
 char *   eel_str_double_underscores                  (const char    *str);
 /* Escape function for spaces */
 char *   eel_str_escape_spaces                       (const char    *str);
-/* Escape function for non-space special characters in a shell context. */
+/* Escape function for non-space special characters in a GLib shell context. */
 char *   eel_str_escape_non_space_special_characters (const char    *str);
 /* Capitalize a string */
 char *   eel_str_capitalize                          (const char    *str);


### PR DESCRIPTION
I checked the GLib source code for `g_shell_parse_argv` and noticed that in addition to quotes, spaces, tabs, newlines and backslashes, number signs are also specially handled. They will truncate the Exec command line when handling paths that contain a space followed by a number sign. Thus number signs in paths also need escaping when unquoted.

I believe that is all the characters in paths that need escaping, but they aren't explicitly mentioned in the GLib documentation, and might change in the future. Maybe that's why I should try resolve the issues with quotes in paths when quoting is turned on? (The one in #3011 > Other information)