### PR TITLE
Actions: Escape quoted content in paths

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -145,6 +145,39 @@ eel_str_escape_non_space_special_characters (const char *string)
 }
 
 char *
+eel_str_escape_double_quoted_content (const char *string)
+{
+    int double_quotes_and_backslashes;
+    const char *p;
+    char *q;
+    char *escaped;
+
+    if (string == NULL) {
+        return NULL;
+    }
+
+    double_quotes_and_backslashes = 0;
+    for (p = string; *p != '\0'; p++) {
+        double_quotes_and_backslashes += (*p == '\"') || (*p == '\\');
+    }
+
+    if (double_quotes_and_backslashes == 0) {
+        return g_strdup (string);
+    }
+
+    escaped = g_new (char, strlen (string) + double_quotes_and_backslashes + 1);
+    for (p = string, q = escaped; *p != '\0'; p++, q++) {
+        if ((*p == '\"') || (*p == '\\')) {
+            *q++ = '\\';
+        }
+        *q = *p;
+    }
+    *q = '\0';
+
+    return escaped;
+}
+
+char *
 eel_str_capitalize (const char *string)
 {
 	char *capitalized;

--- a/eel/eel-string.h
+++ b/eel/eel-string.h
@@ -44,6 +44,8 @@ char *   eel_str_double_underscores                  (const char    *str);
 char *   eel_str_escape_spaces                       (const char    *str);
 /* Escape function for non-space special characters in a GLib shell context. */
 char *   eel_str_escape_non_space_special_characters (const char    *str);
+/* Escape function for content within double quotes in a GLib shell context. */
+char *   eel_str_escape_double_quoted_content        (const char    *str);
 /* Capitalize a string */
 char *   eel_str_capitalize                          (const char    *str);
 

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1217,21 +1217,26 @@ get_path (NemoAction *action, NemoFile *file)
 
     orig = nemo_file_get_path (file);
 
-    if (action->quote_type != QUOTE_TYPE_DOUBLE && action->quote_type != QUOTE_TYPE_SINGLE)
+    if (action->quote_type == QUOTE_TYPE_DOUBLE) {
+        escaped = eel_str_escape_double_quoted_content (orig);
+    } else if (action->quote_type == QUOTE_TYPE_SINGLE) {
+        // Replace literal ' with a close ', a \', and an open '
+        escaped = eel_str_replace_substring (orig, "'", "'\\''");
+    } else {
         escaped = eel_str_escape_non_space_special_characters (orig);
-    else
-        escaped = orig;
+    }
 
     if (action->escape_space) {
         ret = eel_str_escape_spaces (escaped);
     } else {
-        ret = g_strdup (escaped);
+        ret = escaped;
     }
 
     g_free (orig);
 
-    if (escaped != orig)
+    if (ret != escaped) {
         g_free (escaped);
+    }
 
     return ret;
 }


### PR DESCRIPTION
In actions, when quoting is enabled, the quotes in paths, double or single, were not handled at all. This led to incorrect handling for paths with quotes and/or backslashes.

For instance, if `Quote=single` is in the actions file, and the target file path contains a `'` character, then the command parsing becomes incorrect starting at where that quote is.

Actioning on a file `/home/veractor/Pictures/Katie's tree.jpg`, an exec line:

    test.sh %F

becomes

    test.sh '/home/veractor/Pictures/Katie's tree.jpg'

Which would be interpreted as 3 arguments, `test.sh`, `/home/veractor/Pictures/Katies`, and `tree.jpg'`, where the trailing quote causes the command to not run at all.