### PR TITLE
libnemo-private: add missing gio-unix-2.0 dependency

### DIFF
--- a/libnemo-private/meson.build
+++ b/libnemo-private/meson.build
@@ -83,7 +83,7 @@ nemo_private_sources = [
 ]
 
 nemo_private_deps = [
-  cinnamon, eel, gail, glib, gmodule, gtk, libxml, math, nemo_extension, x11, xapp
+  cinnamon, eel, gail, gio_unix, glib, gmodule, gtk, libxml, math, nemo_extension, x11, xapp
 ]
 
 if libexif_enabled


### PR DESCRIPTION
The Nix package manager used by NixOS (and available on all unix systems), uses a sandboxed environment where it is not possible to have global building dependencies. Without this change the build with fails with:

```
[43/274] Compiling C object libnemo-private/libnemo-private.a.p/meson-generated_.._nemo-generated.c.o
FAILED: libnemo-private/libnemo-private.a.p/meson-generated_.._nemo-generated.c.o 
gcc -Ilibnemo-private/libnemo-private.a.p -Ilibnemo-private -I../libnemo-private -I. -I.. -Ieel -I../eel -Ilibnemo-extension -I../libnemo-extension -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/fv80fbb38zy7p2x1xbhsmqakfiyjqkjh-cinnamon-desktop-5.4.1-dev/include/cinnamon-desktop -I/nix/store/0q3r8l0b865ddkng17mspsr13w01pa3d-libxml2-2.9.14-dev/include/libxml2 -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gail-3.0 -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/250jx90qsk319x97a4af0jglh9qdv2w4-xapps-2.2.13-dev/include/xapp -I/nix/store/jdvysi7p5rkr04cg57cg2knyvlwdz2c0-libexif-0.6.24/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS -fPIC -pthread '-DNEMO_DATADIR="/nix/store/hjd09z8c61787qzqa8nykcvphihxw15b-nemo-5.4.1/share/nemo"' '-DNEMO_EXTENSIONDIR="/nix/store/hjd09z8c61787qzqa8nykcvphihxw15b-nemo-5.4.1/lib/nemo/extensions-3.0"' '-DLIBEXECDIR="/nix/store/hjd09z8c61787qzqa8nykcvphihxw15b-nemo-5.4.1/libexec"' -MD -MQ libnemo-private/libnemo-private.a.p/meson-generated_.._nemo-generated.c.o -MF libnemo-private/libnemo-private.a.p/meson-generated_.._nemo-generated.c.o.d -o libnemo-private/libnemo-private.a.p/meson-generated_.._nemo-generated.c.o -c libnemo-private/nemo-generated.c
libnemo-private/nemo-generated.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
[44/274] Linking target libnemo-extension/libnemo-extension.so.1.4.0
[45/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-action-manager.c.o
[46/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-cell-renderer-disk.c.o
[47/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-clipboard.c.o
[48/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-centered-placement-grid.c.o
[49/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-bookmark.c.o
[50/274] Compiling C object libnemo-private/libnemo-private.a.p/nemo-action.c.o
ninja: build stopped: subcommand failed.
```

See also 

- https://github.com/NixOS/nixpkgs/issues/36468

Thanks for reviewing this :-)