### PR TITLE
Actions: Deprecate the EscapeSpaces field

### DIFF
--- a/eel/eel-string.h
+++ b/eel/eel-string.h
@@ -39,32 +39,30 @@
 /* NULL is allowed for all the str parameters to these functions. */
 
 /* Escape function for '_' character. */
-char *   eel_str_double_underscores                  (const char    *str);
-/* Escape function for spaces */
-char *   eel_str_escape_spaces                       (const char    *str);
-/* Escape function for non-space special characters in a GLib shell context. */
-char *   eel_str_escape_non_space_special_characters (const char    *str);
+char *   eel_str_double_underscores           (const char    *str);
+/* Escape function for special characters in a GLib shell context. */
+char *   eel_str_escape_shell_characters      (const char    *str);
 /* Escape function for content within double quotes in a GLib shell context. */
-char *   eel_str_escape_double_quoted_content        (const char    *str);
+char *   eel_str_escape_double_quoted_content (const char    *str);
 /* Capitalize a string */
-char *   eel_str_capitalize                          (const char    *str);
+char *   eel_str_capitalize                   (const char    *str);
 
 /* Middle truncate a string to a maximum of truncate_length characters.
  * The resulting string will be truncated in the middle with a "..."
  * delimiter.
  */
-char *   eel_str_middle_truncate                     (const char    *str,
-						      guint          truncate_length);
+char *   eel_str_middle_truncate              (const char    *str,
+					       guint          truncate_length);
 
 
 /* Remove all characters after the passed-in substring. */
-char *   eel_str_strip_substring_and_after           (const char    *str,
-						      const char    *substring);
+char *   eel_str_strip_substring_and_after    (const char    *str,
+					       const char    *substring);
 
 /* Replace all occurrences of substring with replacement. */
-char *   eel_str_replace_substring                   (const char    *str,
-						      const char    *substring,
-						      const char    *replacement);
+char *   eel_str_replace_substring            (const char    *str,
+					       const char    *substring,
+					       const char    *replacement);
 
 typedef char * eel_ref_str;
 

--- a/files/usr/share/nemo/actions/sample.nemo_action
+++ b/files/usr/share/nemo/actions/sample.nemo_action
@@ -96,14 +96,14 @@ Extensions=any;
 
 #Conditions=desktop;
 
-# Escape Spaces - set to true to escape spaces in filenames and uris ($U, $F, $P, $D)
+# Escape Spaces (deprecated)
 #
-# Sometimes this may be preferred to getting raw filenames that must be enclosed in
-# quotes.
+# This field is deprecated and does nothing - paths with spaces, as well as other special
+# shell characters, will now be passed on correctly no matter what, even when Quote is not set.
 #
 # Optional - by default this is false
 
-EscapeSpaces=true
+#EscapeSpaces=true
 
 # Run in terminal - set to true to execute the Exec line in a spawned terminal window.
 #

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1213,30 +1213,22 @@ find_token_type (const gchar *str, TokenType *token_type)
 static gchar *
 get_path (NemoAction *action, NemoFile *file)
 {
-    gchar *ret, *escaped, *orig;
+    gchar *ret, *orig;
 
     orig = nemo_file_get_path (file);
 
     if (action->quote_type == QUOTE_TYPE_DOUBLE) {
-        escaped = eel_str_escape_double_quoted_content (orig);
+        ret = eel_str_escape_double_quoted_content (orig);
     } else if (action->quote_type == QUOTE_TYPE_SINGLE) {
         // Replace literal ' with a close ', a \', and an open '
-        escaped = eel_str_replace_substring (orig, "'", "'\\''");
+        ret = eel_str_replace_substring (orig, "'", "'\\''");
     } else {
         escaped = eel_str_escape_non_space_special_characters (orig);
-    }
-
-    if (action->escape_space) {
         ret = eel_str_escape_spaces (escaped);
-    } else {
-        ret = escaped;
+        g_free (escaped);
     }
 
     g_free (orig);
-
-    if (ret != escaped) {
-        g_free (escaped);
-    }
 
     return ret;
 }
@@ -1300,22 +1292,17 @@ get_device_path (NemoAction *action, NemoFile *file)
     id = g_volume_get_identifier (volume, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
 
     if (action->quote_type == QUOTE_TYPE_DOUBLE) {
-        escaped = eel_str_escape_double_quoted_content (id);
+        ret = eel_str_escape_double_quoted_content (id);
     } else if (action->quote_type == QUOTE_TYPE_SINGLE) {
         // Replace literal ' with a close ', a \', and an open '
-        escaped = eel_str_replace_substring (id, "'", "'\\''");
+        ret = eel_str_replace_substring (id, "'", "'\\''");
     } else {
         escaped = eel_str_escape_non_space_special_characters (id);
+        ret = eel_str_escape_spaces (escaped);
+        g_free (escaped);
     }
 
     g_free (id);
-
-    if (action->escape_space) {
-        ret = eel_str_escape_spaces (escaped);
-        g_free (escaped);
-    } else {
-        ret = escaped;
-    }
 
     g_object_unref (mount);
     g_object_unref (volume);

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -1223,9 +1223,7 @@ get_path (NemoAction *action, NemoFile *file)
         // Replace literal ' with a close ', a \', and an open '
         ret = eel_str_replace_substring (orig, "'", "'\\''");
     } else {
-        escaped = eel_str_escape_non_space_special_characters (orig);
-        ret = eel_str_escape_spaces (escaped);
-        g_free (escaped);
+        ret = eel_str_escape_shell_characters (orig);
     }
 
     g_free (orig);
@@ -1287,7 +1285,7 @@ get_device_path (NemoAction *action, NemoFile *file)
     g_return_val_if_fail (mount != NULL, NULL);
 
     GVolume *volume = g_mount_get_volume (mount);
-    gchar *ret, *escaped, *id;
+    gchar *ret, *id;
 
     id = g_volume_get_identifier (volume, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
 
@@ -1297,9 +1295,7 @@ get_device_path (NemoAction *action, NemoFile *file)
         // Replace literal ' with a close ', a \', and an open '
         ret = eel_str_replace_substring (id, "'", "'\\''");
     } else {
-        escaped = eel_str_escape_non_space_special_characters (id);
-        ret = eel_str_escape_spaces (escaped);
-        g_free (escaped);
+        ret = eel_str_escape_shell_characters (id);
     }
 
     g_free (id);


### PR DESCRIPTION
Since spaces are only one of many to-be-escaped characters for passing on to the shell, it makes little sense to single them out. Escape them when the `Quote` field is not set to `single` or `double`, and deprecate the `EscapeSpaces` field and make it do nothing. See #3059.