### PR TITLE
[Next] Port to tracker-sparql 3 (#2834)

### DIFF
--- a/libnemo-private/nemo-search-engine-tracker.c
+++ b/libnemo-private/nemo-search-engine-tracker.c
@@ -362,21 +362,5 @@ nemo_search_engine_tracker_init (NemoSearchEngineTracker *engine)
 NemoSearchEngine *
 nemo_search_engine_tracker_new (void)
 {
-	NemoSearchEngineTracker *engine;
-	TrackerSparqlConnection *connection;
-	GError *error = NULL;
-
-	connection = tracker_sparql_connection_get (NULL, &error);
-
-	if (error) {
-		g_warning ("Could not establish a connection to Tracker: %s", error->message);
-		g_error_free (error);
-		return NULL;
-	}
-
-	engine = g_object_new (NEMO_TYPE_SEARCH_ENGINE_TRACKER, NULL);
-	engine->details->connection = connection;
-	engine->details->cancellable = g_cancellable_new ();
-
-	return NEMO_SEARCH_ENGINE (engine);
+	return (NEMO_TYPE_SEARCH_ENGINE_TRACKER, NULL);
 }

--- a/meson.build
+++ b/meson.build
@@ -90,7 +90,10 @@ tracker_enabled = false
 if trackerChoice != 'false'
   trackerRequired = (trackerChoice == 'true')
   # Check all the possible versions
+    tracker_sparql = dependency('tracker-sparql-3.0',  required: false)
+  if not tracker_sparql.found()
     tracker_sparql = dependency('tracker-sparql-2.0',  required: false)
+  endif
   if not tracker_sparql.found()
     tracker_sparql = dependency('tracker-sparql-1.0',  required: false)
   endif


### PR DESCRIPTION
Mint 21 is now based on Ubuntu 22.04, and it contains sparql 3

We basically don't need it's only usage of the removed function. I did what GNOME did: https://github.com/GNOME/nautilus/blob/master/src/nautilus-search-engine-tracker.c