### PR TITLE
nemo-action: readlink before populate

### DIFF
--- a/libnemo-private/nemo-action-manager.c
+++ b/libnemo-private/nemo-action-manager.c
@@ -146,7 +146,7 @@ set_up_actions_directories (NemoActionManager *action_manager)
     data_dirs = (gchar **) g_get_system_data_dirs ();
 
     for (i = 0; i < g_strv_length (data_dirs); i++) {
-        path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+        path = nemo_action_manager_get_system_directory_path (data_dirs[i]);
         uri = g_filename_to_uri (path, NULL, NULL);
 
         dir = nemo_directory_get_by_uri (uri);
@@ -411,6 +411,24 @@ GList *
 nemo_action_manager_list_actions (NemoActionManager *action_manager)
 {
     return action_manager->action_list_dirty ? NULL : action_manager->actions;
+}
+
+gchar *
+nemo_action_manager_get_system_directory_path (const gchar *data_dir)
+{
+    const gchar *nemo_path, *target;
+
+    nemo_path = g_build_filename (data_dir, "nemo", NULL);
+
+    // For symbolic links, we try to figure out its actual path
+    // to prevent possible duplicate right-click menu items.
+    target = g_file_read_link (nemo_path, NULL);
+
+    if (target) {
+        return g_build_filename (target, "actions", NULL);
+    } else {
+        return g_build_filename (nemo_path, "actions", NULL);
+    }
 }
 
 gchar *

--- a/libnemo-private/nemo-action-manager.h
+++ b/libnemo-private/nemo-action-manager.h
@@ -53,6 +53,7 @@ struct _NemoActionManagerClass {
 GType         nemo_action_manager_get_type             (void);
 NemoActionManager   *nemo_action_manager_new           (void);
 GList *       nemo_action_manager_list_actions (NemoActionManager *action_manager);
+gchar *       nemo_action_manager_get_system_directory_path (const gchar *data_dir);
 gchar *       nemo_action_manager_get_user_directory_path (void);
 
 #endif /* NEMO_ACTION_MANAGER_H */

--- a/src/nemo-action-config-widget.c
+++ b/src/nemo-action-config-widget.c
@@ -221,7 +221,7 @@ refresh_widget (NemoActionConfigWidget *widget)
     data_dirs = (gchar **) g_get_system_data_dirs ();
 
     for (i = 0; i < g_strv_length (data_dirs); i++) {
-        path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+        path = nemo_action_manager_get_system_directory_path (data_dirs[i]);
         populate_from_directory (widget, path);
         g_clear_pointer (&path, g_free);
     }
@@ -390,7 +390,7 @@ static void setup_dir_monitors (NemoActionConfigWidget *widget)
 
     guint i;
     for (i = 0; i < g_strv_length (data_dirs); i++) {
-        gchar *path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+        gchar *path = nemo_action_manager_get_system_directory_path (data_dirs[i]);
         try_monitor_path (widget, path);
         g_free (path);
     }

--- a/src/nemo-script-config-widget.c
+++ b/src/nemo-script-config-widget.c
@@ -11,7 +11,6 @@
 #include "nemo-file.h"
 #include "nemo-global-preferences.h"
 #include <libnemo-private/nemo-file-utilities.h>
-#include <libnemo-private/nemo-action-manager.h>
 
 #include <glib.h>
 
@@ -285,16 +284,7 @@ static void setup_dir_monitors (NemoScriptConfigWidget *widget)
 {
     widget->dir_monitors = NULL;
 
-    gchar **data_dirs = (gchar **) g_get_system_data_dirs ();
-
-    guint i;
-    for (i = 0; i < g_strv_length (data_dirs); i++) {
-        gchar *path = nemo_action_manager_get_system_directory_path (data_dirs[i]);
-        try_monitor_path (widget, path);
-        g_free (path);
-    }
-
-    gchar *path = nemo_action_manager_get_user_directory_path ();
+    gchar *path = nemo_get_scripts_directory_path ();
     try_monitor_path (widget, path);
     g_free (path);
 }

--- a/src/nemo-script-config-widget.c
+++ b/src/nemo-script-config-widget.c
@@ -11,6 +11,7 @@
 #include "nemo-file.h"
 #include "nemo-global-preferences.h"
 #include <libnemo-private/nemo-file-utilities.h>
+#include <libnemo-private/nemo-action-manager.h>
 
 #include <glib.h>
 
@@ -288,12 +289,12 @@ static void setup_dir_monitors (NemoScriptConfigWidget *widget)
 
     guint i;
     for (i = 0; i < g_strv_length (data_dirs); i++) {
-        gchar *path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+        gchar *path = nemo_action_manager_get_system_directory_path (data_dirs[i]);
         try_monitor_path (widget, path);
         g_free (path);
     }
 
-    gchar *path = g_build_filename (g_get_user_data_dir (), "nemo", "actions", NULL);
+    gchar *path = nemo_action_manager_get_user_directory_path ();
     try_monitor_path (widget, path);
     g_free (path);
 }


### PR DESCRIPTION
This is really a NixOS specific issue, I guess we are the only few distributions that can make data dir as link farm :upside_down_face: I guess I will still PR this to see if I can get some review, though TBH this PR do look dirty to me :hankey: 

Sometimes `$datadir/nemo` can be a symbolic link, this can cause menu items loaded multiple times on systems like NixOS because they are populated twice when nemo iterates `XDG_DATA_DIRS`.

- https://github.com/NixOS/nixpkgs/issues/190781

---

More context: while NixOS installs everything in their own immutable prefix, it still creates symbolic links to combine the "activated" packages together in `/run/current-system/sw/share`, and that path is also added to `XDG_DATA_DIRS`:

```
$ readlink /run/current-system/sw/share/nemo
/nix/store/3b65cq94mfp0mv13m79fkbxdnd10w66z-nemo-5.6.0/share/nemo
```

So now you have a very long list of `XDG_DATA_DIRS`. Here is the output of <code>echo $XDG_DATA_DIRS | sed 's/:/\n/g'</code> in my gnome-terminal (since binaries are commonly wrapped with scripts that prefixes more paths to `XDG_DATA_DIRS` in NixOS, the list can be even longer when actually using nemo)

<details>

```
$ echo $XDG_DATA_DIRS | sed 's/:/\n/g'
/nix/store/fb6w5hwzipnqz6x33xlkirr9s25blmv5-gnome-terminal-3.47.0/share
/nix/store/2j2znigd8ak37rlwh9khz0ry3clqlw1l-gtk+3-3.24.34/share/gsettings-schemas/gtk+3-3.24.34
/nix/store/vgq2vs7gzgilihfpvqri8ifvn06y0jx9-gsettings-desktop-schemas-43.0/share/gsettings-schemas/gsettings-desktop-schemas-43.0
/nix/store/a3szv8nhhjf351dl2ixf143ai82kyh28-gtk4-4.8.2/share/gsettings-schemas/gtk4-4.8.2
/nix/store/1w46ybd37ycy5y1xg6a5zgs8nz2v891s-nautilus-43.0/share/gsettings-schemas/nautilus-43.0
/nix/store/fb6w5hwzipnqz6x33xlkirr9s25blmv5-gnome-terminal-3.47.0/share/gsettings-schemas/gnome-terminal-3.47.0
/nix/store/3b65cq94mfp0mv13m79fkbxdnd10w66z-nemo-5.6.0/share
/nix/store/2j2znigd8ak37rlwh9khz0ry3clqlw1l-gtk+3-3.24.34/share/gsettings-schemas/gtk+3-3.24.34
/nix/store/vgq2vs7gzgilihfpvqri8ifvn06y0jx9-gsettings-desktop-schemas-43.0/share/gsettings-schemas/gsettings-desktop-schemas-43.0
/nix/store/bvihhgw8bh6cqqlj0d4s8cvmm4mqmzfc-pulseaudio-16.1/share/gsettings-schemas/pulseaudio-16.1
/nix/store/csqxspwbf6k5wp3dxa93s5lfw3gsh04p-cinnamon-desktop-5.6.0/share/gsettings-schemas/cinnamon-desktop-5.6.0
/nix/store/bc77g4a0k51c6cjqcd7wkpnn0r57b6f0-xapp-2.4.2/share/gsettings-schemas/xapp-2.4.2
/nix/store/8881pcyqifj1z14lp7i8yppcjxkj1kz3-gvfs-1.50.2/share/gsettings-schemas/gvfs-1.50.2
/nix/store/3b65cq94mfp0mv13m79fkbxdnd10w66z-nemo-5.6.0/share/gsettings-schemas/nemo-5.6.0
/nix/store/wkhzzhgf0wqy3w2fgk5fv0fvmkxwl3s2-caribou-0.4.21/share
/nix/store/dr2i09cka8f7k3xbmw2x6pa5j2pqbv76-cinnamon-common-5.6.4/share
/nix/store/2j2znigd8ak37rlwh9khz0ry3clqlw1l-gtk+3-3.24.34/share/gsettings-schemas/gtk+3-3.24.34
/nix/store/iaa22lld318wcr34f9bn54g6w7d994x2-cinnamon-control-center-5.6.0/share/gsettings-schemas/cinnamon-control-center-5.6.0
/nix/store/vgq2vs7gzgilihfpvqri8ifvn06y0jx9-gsettings-desktop-schemas-43.0/share/gsettings-schemas/gsettings-desktop-schemas-43.0
/nix/store/bvihhgw8bh6cqqlj0d4s8cvmm4mqmzfc-pulseaudio-16.1/share/gsettings-schemas/pulseaudio-16.1
/nix/store/csqxspwbf6k5wp3dxa93s5lfw3gsh04p-cinnamon-desktop-5.6.0/share/gsettings-schemas/cinnamon-desktop-5.6.0
/nix/store/lixw343z066i2cj6xmz57kwp6rqq6s6l-cjs-5.6.1/share/gsettings-schemas/cjs-5.6.1
/nix/store/m5kzri6k9m518jm1h8lklim6wvdmhy9m-muffin-5.6.1/share/gsettings-schemas/muffin-5.6.1
/nix/store/8ysjv6gngp7qznf17i0g1rpajr635hzp-libgnomekbd-3.28.1/share/gsettings-schemas/libgnomekbd-3.28.1
/nix/store/wkhzzhgf0wqy3w2fgk5fv0fvmkxwl3s2-caribou-0.4.21/share/gsettings-schemas/caribou-0.4.21
/nix/store/bc77g4a0k51c6cjqcd7wkpnn0r57b6f0-xapp-2.4.2/share/gsettings-schemas/xapp-2.4.2
/nix/store/3b65cq94mfp0mv13m79fkbxdnd10w66z-nemo-5.6.0/share/gsettings-schemas/nemo-5.6.0
/nix/store/mhbb2f8dvrq69frjq0imdh174083ix0y-libnma-1.10.2/share/gsettings-schemas/libnma-1.10.2
/nix/store/850znqhggpn5rwbx3l6w4zs7anvif7ns-gnome-online-accounts-3.46.0/share/gsettings-schemas/gnome-online-accounts-3.46.0
/nix/store/dr2i09cka8f7k3xbmw2x6pa5j2pqbv76-cinnamon-common-5.6.4/share/gsettings-schemas/cinnamon-common-5.6.4
/nix/store/csqxspwbf6k5wp3dxa93s5lfw3gsh04p-cinnamon-desktop-5.6.0/share
/nix/store/1848m89azcb1qw12zp8y9hp7n43wm1ll-cinnamon-session-5.6.0/share
/nix/store/rzap1szdfjh4a0pbvhll8jhip37b76wg-cinnamon-settings-daemon-5.6.0/share/gsettings-schemas/cinnamon-settings-daemon-5.6.0
/nix/store/1848m89azcb1qw12zp8y9hp7n43wm1ll-cinnamon-session-5.6.0/share/gsettings-schemas/cinnamon-session-5.6.0
/nix/store/2j2znigd8ak37rlwh9khz0ry3clqlw1l-gtk+3-3.24.34/share/gsettings-schemas/gtk+3-3.24.34
/nix/store/vgq2vs7gzgilihfpvqri8ifvn06y0jx9-gsettings-desktop-schemas-43.0/share/gsettings-schemas/gsettings-desktop-schemas-43.0
/nix/store/bvihhgw8bh6cqqlj0d4s8cvmm4mqmzfc-pulseaudio-16.1/share/gsettings-schemas/pulseaudio-16.1
/nix/store/csqxspwbf6k5wp3dxa93s5lfw3gsh04p-cinnamon-desktop-5.6.0/share/gsettings-schemas/cinnamon-desktop-5.6.0
/nix/store/bc77g4a0k51c6cjqcd7wkpnn0r57b6f0-xapp-2.4.2/share/gsettings-schemas/xapp-2.4.2
/nix/store/xkiilcriyk048m5jrpxa353a1hkfvn3g-desktops/share
/home/bobby285271/.local/share/flatpak/exports/share
/var/lib/flatpak/exports/share
/home/bobby285271/.nix-profile/share
/etc/profiles/per-user/bobby285271/share
/nix/var/nix/profiles/default/share
/run/current-system/sw/share
```

</details>

And by doing `readlink`, it will resolves the issue because in `add_directory_to_directory_list`, you check whether the path is already added before:

https://github.com/linuxmint/nemo/blob/4bc5c6c888b176d4a79c582414c55981c47b51fb/libnemo-private/nemo-action-manager.c#L82