### PR TITLE
Fix for List View thumbnail scaling at HiDPI (issue #3185)

### DIFF
--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -388,7 +388,7 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
                 g_object_unref (gicon);
             }
 
-			icon = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size);
+			icon = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size * icon_scale);
 
 			nemo_icon_info_unref (icon_info);
 


### PR DESCRIPTION
I believe this single line is the source of issue #3185 - after a thumbnail icon is correctly processed at the correct scale and resolution in the chain, just before being used it's accidentally resized at this line, with only baseline icon resolution without accounting for scale.

The scale multiplier appears in the Icon View code used in the same way in this PR - as Icon Mode displays without issue, I believe this was the originally intended design.

`nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size * icon_scale)`

Edit: Noting it fixes #3185 to link the PR to the bug