### PR TITLE
Icon frame only for non-transparent icons that are large enough

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4885,8 +4885,8 @@ nemo_file_get_icon (NemoFile *file,
                                                      MAX (h * thumb_scale, 1),
                                                      GDK_INTERP_BILINEAR);
 
-            /* We don't want frames around small icons */
-            if (!gdk_pixbuf_get_has_alpha (raw_pixbuf) || s >= 128 * scale) {
+            /* Only apply frame if icon has no transparency, and is large enough */
+            if (!gdk_pixbuf_get_has_alpha (raw_pixbuf) && s >= 128 * scale) {
                 nemo_thumbnail_frame_image (&scaled_pixbuf);
             }
 


### PR DESCRIPTION
I'm not 100% certain that my interpretation of this behavior was the software-intended behavior - if this is incorrect, let me know:

**Current behavior:** If the image doesn't have transparency, **or** if the image is large enough, render a frame around it.

- This means that a large-sized image with transparency will be rendered with a border - this can be very unattractive.
- This also means that a very tiny image with no transparency will have a border - I believe this is also not intended.

**Behavior with change:**

- A frame will only be applied if the image doesn't have transparency (regardless of size),
- and also won't apply the frame to tiny images, even if they don't have transparency.
- The comment was tweaked to be clear about the intended behavior (if this is correct).
