### PR TITLE
Use local URIs for drag&drop, copy/paste operations

### DIFF
--- a/libnemo-private/nemo-clipboard-monitor.c
+++ b/libnemo-private/nemo-clipboard-monitor.c
@@ -233,7 +233,7 @@ convert_file_list_to_string (NemoClipboardInfo *info,
 	}
 
         for (i = 0, l = info->files; l != NULL; l = l->next, i++) {
-		uri = nemo_file_get_uri (l->data);
+		uri = nemo_file_get_local_uri (l->data);
 
 		if (format_for_text) {
 			f = g_file_new_for_uri (uri);
@@ -285,7 +285,7 @@ nemo_get_clipboard_callback (GtkClipboard     *clipboard,
 		i = 0;
 
 		for (l = clipboard_info->files; l != NULL; l = l->next) {
-			uris[i] = nemo_file_get_uri (l->data);
+			uris[i] = nemo_file_get_local_uri (l->data);
 			i++;
 		}
 

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -1640,6 +1640,37 @@ nemo_file_get_uri (NemoFile *file)
 	return uri;
 }
 
+
+/* Return the local uri associated with the passed-in file.
+ * If the local uri can't be resolved, the uri from nemo_file_get_uri
+ * is returned instead.
+ */
+char *
+nemo_file_get_local_uri (NemoFile *file)
+{
+	char *uri, *path;
+	GFile *loc;
+
+	g_return_val_if_fail (NEMO_IS_FILE (file), NULL);
+
+	if (file->details->activation_uri != NULL) {
+		return g_strdup (file->details->activation_uri);
+	}
+
+	loc = nemo_file_get_location (file);
+	path = g_file_get_path (loc);
+	g_object_unref (loc);
+
+	if (path == NULL) {
+		return nemo_file_get_uri (file);
+	}
+
+	uri = g_filename_to_uri (path, NULL, NULL);
+	g_free (path);
+
+	return uri;
+}
+
 /* Return the actual path associated with the passed-in file. */
 char *
 nemo_file_get_path (NemoFile *file)

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -194,6 +194,7 @@ const char *            nemo_file_peek_name                         (NemoFile   
 GFile *                 nemo_file_get_location                      (NemoFile                   *file);
 char *			 nemo_file_get_description			 (NemoFile			 *file);
 char *                  nemo_file_get_uri                           (NemoFile                   *file);
+char *                  nemo_file_get_local_uri                     (NemoFile                   *file);
 char *                  nemo_file_get_path                          (NemoFile                   *file);
 char *                  nemo_file_get_uri_scheme                    (NemoFile                   *file);
 gboolean                nemo_file_has_uri_scheme                    (NemoFile *file, const gchar *scheme);

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -1999,7 +1999,7 @@ get_icon_uri_callback (NemoIconContainer *container,
 	g_assert (NEMO_IS_FILE (file));
 	g_assert (NEMO_IS_ICON_VIEW (icon_view));
 
-	return nemo_file_get_uri (file);
+	return nemo_file_get_local_uri (file);
 }
 
 static char *

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -913,7 +913,7 @@ each_path_get_data_binder (NemoDragEachSelectedItemDataGet data_get,
 				 column,
 				 &cell_area);
 
-			uri = nemo_file_get_uri (file);
+			uri = nemo_file_get_local_uri (file);
 
 			(*data_get) (uri,
 				     0,


### PR DESCRIPTION
This is done to accommodate applications that don't support parsing special URIs.

This converts paths like `sftp://...` into their local equivalent, like `file:///run/user/1000/gvfs/sftp:...`.