### PR TITLE
Add shadows to the desktop icon labels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+nemo (5.6.4) vera; urgency=medium
+
+  [ Michael Webster ]
+  * nemo-view-dnd.c: Fix the check for a web link's title, and use the url if it's missing.
+  * nemo-mime-actions.c: Prioritize an http link to open in a browser, regardless of the mimetype of the link's target.
+
+  [ kain ]
+  * Fix for List View thumbnail scaling at HiDPI (#3187)
+
+  [ Michael Webster ]
+  * list-view: Scale the thumbnail correctly when applying emblems, and fix the emblem sanity checks everywhere.
+  * file info: Use generic methods for attributes that aren't guaranteed to be supported by the filesystem.
+
+ -- Clement Lefebvre <root@linuxmint.com>  Thu, 16 Mar 2023 13:58:16 +0000
+
 nemo (5.6.3) vera; urgency=medium
 
   [ Michael Webster ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nemo (5.6.5) vera; urgency=medium
+
+  [ Michael Webster ]
+  * Fix some more GFileInfo getter problems.
+
+ -- Clement Lefebvre <root@linuxmint.com>  Tue, 28 Mar 2023 17:59:50 +0100
+
 nemo (5.6.4) vera; urgency=medium
 
   [ Michael Webster ]

--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -824,6 +824,7 @@ static gboolean
 should_skip_file (NemoDirectory *directory, GFileInfo *info)
 {
 	static gboolean show_hidden_files_changed_callback_installed = FALSE;
+    gboolean is_hidden;
 
 	/* Add the callback once for the life of our process */
 	if (!show_hidden_files_changed_callback_installed) {
@@ -838,13 +839,14 @@ should_skip_file (NemoDirectory *directory, GFileInfo *info)
 		show_hidden_files_changed_callback (NULL);
 	}
 
-	if (!show_hidden_files &&
-	    (g_file_info_get_is_hidden (info) ||
-	     g_file_info_get_is_backup (info))) {
-		return TRUE;
-	}
+    is_hidden = g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) ||
+                g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP);
 
-	return FALSE;
+    if (!show_hidden_files && is_hidden) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 static void
@@ -915,7 +917,8 @@ dequeue_pending_idle_callback (gpointer callback_data)
 			dir_load_state->load_file_count += 1;
 
 			/* Add the MIME type to the set. */
-			mimetype = g_file_info_get_content_type (file_info);
+            mimetype = g_file_info_get_attribute_string (file_info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE);
+
 			if (mimetype != NULL) {
 				istr_set_insert (dir_load_state->load_mime_list_hash,
 						 mimetype);
@@ -2961,7 +2964,8 @@ mime_list_one (MimeListState *state,
 		return;
 	}
 
-	mime_type = g_file_info_get_content_type (info);
+    mime_type = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE);
+
 	if (mime_type != NULL) {
 		istr_set_insert (state->mime_list_hash, mime_type);
 	}

--- a/libnemo-private/nemo-file-utilities.c
+++ b/libnemo-private/nemo-file-utilities.c
@@ -1714,7 +1714,7 @@ nemo_get_best_guess_file_mimetype (const gchar *filename,
 
     if (size > 0) {
         /* Default behavior */
-        mime_type = eel_ref_str_get_unique (g_file_info_get_content_type (info));
+        mime_type = eel_ref_str_get_unique (g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE));
     } else {
         gboolean uncertain;
         gchar *guessed_type = NULL;
@@ -1730,7 +1730,7 @@ nemo_get_best_guess_file_mimetype (const gchar *filename,
         if (!uncertain) {
             mime_type = eel_ref_str_get_unique (guessed_type);
         } else {
-            mime_type = eel_ref_str_get_unique (g_file_info_get_content_type (info));
+            mime_type = eel_ref_str_get_unique (g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE));
         }
 
         g_free (guessed_type);

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -2274,6 +2274,7 @@ update_info_internal (NemoFile *file,
 	const char *trash_orig_path;
 	const char *group, *owner, *owner_real;
 	gboolean free_owner, free_group;
+    const char *edit_name;
 
 	if (file->details->is_gone) {
 		return FALSE;
@@ -2304,9 +2305,11 @@ update_info_internal (NemoFile *file,
 	}
 	file->details->got_file_info = TRUE;
 
+    edit_name = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_EDIT_NAME);
+
 	changed |= nemo_file_set_display_name (file,
 						  g_file_info_get_display_name (info),
-						  g_file_info_get_edit_name (info),
+						  edit_name,
 						  FALSE);
 
 	file_type = g_file_info_get_file_type (info);
@@ -2339,13 +2342,15 @@ update_info_internal (NemoFile *file,
 		}
 	}
 
-	is_symlink = g_file_info_get_is_symlink (info);
+    is_symlink = g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK);
 	if (file->details->is_symlink != is_symlink) {
 		changed = TRUE;
 	}
 	file->details->is_symlink = is_symlink;
 
-	is_hidden = g_file_info_get_is_hidden (info) || g_file_info_get_is_backup (info);
+    is_hidden = g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) ||
+                g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP);
+
 	if (file->details->is_hidden != is_hidden) {
 		changed = TRUE;
 	}
@@ -2541,7 +2546,8 @@ update_info_internal (NemoFile *file,
 	}
 	file->details->size = size;
 
-	sort_order = g_file_info_get_sort_order (info);
+    sort_order = g_file_info_get_attribute_int32 (info, G_FILE_ATTRIBUTE_STANDARD_SORT_ORDER);
+
 	if (file->details->sort_order != sort_order) {
 		changed = TRUE;
 	}
@@ -2603,9 +2609,8 @@ update_info_internal (NemoFile *file,
 		file->details->thumbnailing_failed = thumbnailing_failed;
 	}
 
-	symlink_name = is_symlink ?
-		g_file_info_get_symlink_target (info) :
-		NULL;
+    symlink_name = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET);
+
 	if (g_strcmp0 (file->details->symlink_name, symlink_name) != 0) {
 		changed = TRUE;
 		g_free (file->details->symlink_name);

--- a/libnemo-private/nemo-link.c
+++ b/libnemo-private/nemo-link.c
@@ -73,7 +73,7 @@ is_local_file_a_link (const char *uri)
 				  G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
 				  0, NULL, &error);
 	if (info) {
-		link = is_link_mime_type (g_file_info_get_content_type (info));
+		link = is_link_mime_type (g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE));
 		g_object_unref (info);
 	}
 	else {

--- a/libnemo-private/nemo-search-engine-advanced.c
+++ b/libnemo-private/nemo-search-engine-advanced.c
@@ -910,7 +910,7 @@ visit_directory (GFile *dir, SearchThreadData *data)
 	}
 
 	while ((info = g_file_enumerator_next_file (enumerator, data->cancellable, NULL)) != NULL) {
-		if (g_file_info_get_is_hidden (info) && !data->show_hidden) {
+		if (g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) && !data->show_hidden) {
 			goto next;
 		}
 
@@ -946,7 +946,7 @@ visit_directory (GFile *dir, SearchThreadData *data)
 
 		child = g_file_get_child (dir, g_file_info_get_name (info));
         if (hit) {
-            mime_type = g_file_info_get_content_type (info);
+            mime_type = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE);
 
             // Our helpers don't currently support uris, so we shouldn't at all -
             // probably best, as search would transfer the contents of every file

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build file
 
 # https://github.com/linuxmint/nemo
-project('nemo', 'c', version: '5.6.4',
+project('nemo', 'c', version: '5.6.5',
   meson_version: '>=0.41.0'
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build file
 
 # https://github.com/linuxmint/nemo
-project('nemo', 'c', version: '5.6.3',
+project('nemo', 'c', version: '5.6.4',
   meson_version: '>=0.41.0'
 )
 

--- a/src/nemo-icon-view-container.c
+++ b/src/nemo-icon-view-container.c
@@ -139,8 +139,8 @@ nemo_icon_view_container_get_icon_images (NemoIconContainer *container,
         if (s < size)
             size = s;
 
-        bad_ratio = (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > w ||
-                    (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > h;
+        bad_ratio = (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > (int)(w * 0.75) ||
+                    (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > (int)(h * 0.75);
 
         if (bad_ratio)
             goto skip_emblem; /* Would prefer to not use goto, but

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -116,8 +116,8 @@ nemo_icon_view_grid_container_get_icon_images (NemoIconContainer *container,
         if (s < size)
             size = s;
 
-        bad_ratio = (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > w ||
-                    (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > h;
+        bad_ratio = (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > (int)(w * 0.75) ||
+                    (int)nemo_icon_get_emblem_size_for_icon_size (size) * scale > (int)(h * 0.75);
 
         if (bad_ratio)
             goto skip_emblem; /* Would prefer to not use goto, but

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -354,7 +354,7 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
                 gint w, h, s;
                 gboolean bad_ratio;
 
-                initial_pixbuf = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size);
+                initial_pixbuf = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size * icon_scale);
 
                 w = gdk_pixbuf_get_width (initial_pixbuf);
                 h = gdk_pixbuf_get_height (initial_pixbuf);
@@ -363,8 +363,8 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
                 if (s < icon_size)
                     icon_size = s;
 
-                bad_ratio = (int)(nemo_icon_get_emblem_size_for_icon_size (icon_size) * icon_scale) > w ||
-                            (int)(nemo_icon_get_emblem_size_for_icon_size (icon_size) * icon_scale) > h;
+                bad_ratio = (int)(nemo_icon_get_emblem_size_for_icon_size (icon_size) * icon_scale) > (int)(w * 0.75) ||
+                            (int)(nemo_icon_get_emblem_size_for_icon_size (icon_size) * icon_scale) > (int)(h * 0.75);
 
                 gicon = G_ICON (initial_pixbuf);
 

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -388,7 +388,7 @@ nemo_list_model_get_value (GtkTreeModel *tree_model, GtkTreeIter *iter, int colu
                 g_object_unref (gicon);
             }
 
-			icon = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size);
+			icon = nemo_icon_info_get_pixbuf_at_size (icon_info, icon_size * icon_scale);
 
 			nemo_icon_info_unref (icon_info);
 

--- a/src/nemo-mime-actions.c
+++ b/src/nemo-mime-actions.c
@@ -335,7 +335,7 @@ file_has_local_path (NemoFile *file)
 GAppInfo *
 nemo_mime_get_default_application_for_file (NemoFile *file)
 {
-	GAppInfo *app;
+	GAppInfo *app = NULL;
 	char *mime_type;
 	char *uri_scheme;
 
@@ -345,17 +345,21 @@ nemo_mime_get_default_application_for_file (NemoFile *file)
         }
 	}
 
-	mime_type = nemo_file_get_mime_type (file);
-	app = g_app_info_get_default_for_type (mime_type, !file_has_local_path (file));
-	g_free (mime_type);
+    uri_scheme = nemo_file_get_uri_scheme (file);
+
+    if (!g_str_has_prefix (uri_scheme, "http")) {
+        mime_type = nemo_file_get_mime_type (file);
+        app = g_app_info_get_default_for_type (mime_type, !file_has_local_path (file));
+        g_free (mime_type);
+    }
 
 	if (app == NULL) {
-		uri_scheme = nemo_file_get_uri_scheme (file);
 		if (uri_scheme != NULL) {
 			app = g_app_info_get_default_for_uri_scheme (uri_scheme);
-			g_free (uri_scheme);
 		}
 	}
+
+    g_free (uri_scheme);
 
 	return app;
 }

--- a/src/nemo-view-dnd.c
+++ b/src/nemo-view-dnd.c
@@ -211,8 +211,8 @@ nemo_view_handle_netscape_url_drop (NemoView  *view,
 	}
 
 	if (action == GDK_ACTION_LINK) {
-		if (g_strcmp0 (title, NULL) == 0) {
-			link_name = g_file_get_basename (f);
+		if (g_strcmp0 (title, NULL) == 0 || strlen (title) == 0) {
+			link_name = g_strdup (url);
 		} else {
 			link_name = g_strdup (title);
 		}


### PR DESCRIPTION
By default the text under desktop icons is nearly unreadable if the wallpaper is bright. It needs shadow.

Many desktop environments already come with this feature. Best example is KDE. And I know you can enable this feature by creating a gtk.css in home/username/.config/gtk-3.0 with the following text (numbers may be altered): 
`.nemo-desktop.nemo-canvas-item {
    color: #fff;
    text-shadow: 1px 1px 2px #000, 1px 1px #000, 1px 1px #000, 1px 1px #000,  2px 2px 3px #000;
}
.nemo-desktop.nemo-canvas-item:hover {
    background-color: alpha(@theme_selected_bg_color, 0.33);
    background-image: none;
}
.nemo-desktop.nemo-canvas-item:selected {
    background-color: u/theme_selected_bg_color;
    background-image: none;
    color: u/theme_selected_fg_color;
    text-shadow: none;
}`

Why couldn't this file be included by default? I don't see any downsides to having shadows. Also, you can do the same for Mate, just changing "nemo" to "caja" in the code. I've attached a screenshot for demonstration.
![Screenshot from 2023-05-10 18-53-57](https://github.com/linuxmint/nemo/assets/68343381/8839fc5d-9872-4855-acf8-353335e92dd8)
