### PR TITLE
nemo-style-fallback-mandatory.css: Fix styling on inactive pane

### DIFF
--- a/gresources/nemo-style-fallback-mandatory.css
+++ b/gresources/nemo-style-fallback-mandatory.css
@@ -3,7 +3,7 @@
 
 /* Inactive F3 pane shading */
 
-.nemo-window .nemo-inactive-pane .view, .nemo-window .nemo-inactive-pane iconview {
+.nemo-window .nemo-inactive-pane .view:not(:selected), .nemo-window .nemo-inactive-pane iconview {
     background-color: @theme_unfocused_bg_color;
 }
 


### PR DESCRIPTION
Fixes the problem raised in this github discussion: [How to change contrast of selected items](https://github.com/orgs/linuxmint/discussions/46).

It only occurs with the non-mint themes (Adwaita, Adwaita-dark and HighContrast), i.e. when `nemo-style-fallback-mandatory.css` is used. The selector `.nemo-window .nemo-inactive-pane .view` incorrectly includes the background color (usually blue) of the file name of what is selected.

#### Why I only changed the `.view` part and not the `iconview` part
Adding it to the `iconview` part makes no difference, even when using the icon view in nemo.

For example, if I add to my `~/.config/gtk-3.0/gtk.css` file `iconview { background-color: #ff0000; }` I can't see a difference (even with icon view), but I can see a difference with `label { background-color: #ff0000; }`. I don't know why this is, but it's why I only changed the `.view` part.