### PR TITLE
Fix issue when generating video thumbnails from network shares

### DIFF
--- a/libnemo-private/nemo-thumbnails.c
+++ b/libnemo-private/nemo-thumbnails.c
@@ -318,6 +318,8 @@ thumbnail_thread (gpointer data,
     NemoThumbnailInfo *info = (NemoThumbnailInfo *) data;
     GdkPixbuf *pixbuf;
     time_t current_time;
+    char *image_uri = info->image_uri;
+    gboolean image_uri_ptr_changed = FALSE;
 
     if (g_cancellable_is_cancelled (cancellable) || info->cancelled) {
         DEBUG ("Skipping cancelled file: %s", info->image_uri);
@@ -343,9 +345,37 @@ thumbnail_thread (gpointer data,
     /* Create the thumbnail. */
     DEBUG ("(Thumbnail Thread) Creating thumbnail: %s", info->image_uri);
 
+    if(eel_uri_is_network(info->image_uri)) {
+        GFile *file = g_file_new_for_uri(info->image_uri);
+        GError *err = NULL;
+        char *local_filepath = g_file_get_path(file);
+
+        image_uri = g_filename_to_uri(local_filepath, NULL, &err);
+        image_uri_ptr_changed = !err;
+
+        if(err) {
+            DEBUG("(Thumbnail Thread) Failed to convert local_filepath to uri: %s", err->message);
+            g_free(err);
+            
+            image_uri = info->image_uri; // revert back to our original image_uri
+        }
+
+        g_free(local_filepath);
+
+        g_object_unref(file);
+    }
+
+    /**
+     * the following function internally uses g_filename_to_uri whenever it finds a %i in the thumbnailer config file
+     * because of that we have to convert our path from the network URI to a local file:// URI or else any
+     * thumbnailers that use %i wont generate thumbnails correctly
+     */
     pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail (thumbnail_factory,
-                                                                 info->image_uri,
+                                                                 image_uri,
                                                                  info->mime_type);
+
+    if(image_uri_ptr_changed)
+        g_free(image_uri);
 
     if (pixbuf) {
         gnome_desktop_thumbnail_factory_save_thumbnail (thumbnail_factory,


### PR DESCRIPTION
I've found that Nemo wasn´t generating video thumbnails whenever I was in a network share (I was using the default ffmpegthumbnailer). I was finding it weird because image thumbnails were fine.

Digging into the code I've found that we are passing the smb:// file uri to the gnome_desktop_thumbnail_factory_generate_thumbnail cinnamon-desktop function, and that in turn is calling g_filename_to_uri whenever it finds a %i in a thumbnailer. 

That was exactly the case with ffmpegthumbnailer. Image thumbnailers normally don't use the %i format, but %u instead.

Since g_filename_to_uri doesn´t support anything else than local file:// uri, I've added this code to take care of that and fix the thumbnail generation.