### PR TITLE
Use `activation_uri` as a second choice in `nemo_file_get_local_uri`

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -1642,12 +1642,8 @@ nemo_file_get_local_uri (NemoFile *file)
 
 	g_return_val_if_fail (NEMO_IS_FILE (file), NULL);
 
-    if (NEMO_IS_DESKTOP_ICON_FILE (file)) {
-        return nemo_file_get_uri (file);
-    }
-
-	if (file->details->activation_uri != NULL) {
-		return g_strdup (file->details->activation_uri);
+	if (NEMO_IS_DESKTOP_ICON_FILE (file)) {
+		return nemo_file_get_uri (file);
 	}
 
 	loc = nemo_file_get_location (file);
@@ -1655,6 +1651,9 @@ nemo_file_get_local_uri (NemoFile *file)
 	g_object_unref (loc);
 
 	if (path == NULL) {
+		if (file->details->activation_uri != NULL) {
+			return g_strdup (file->details->activation_uri);
+		}
 		return nemo_file_get_uri (file);
 	}
 


### PR DESCRIPTION
Using `activation_uri` can be problematic with links.

I can't test the "desktop" behavior, but maybe with this change the `NEMO_IS_DESKTOP_ICON_FILE` isn't needed anymore.

Ref: https://github.com/linuxmint/nemo/commit/84b6062319f4029e0e99b9eb28c77e22c2bf9bb8#r122103578