### PR TITLE
nemo-file.c: Update hard-coded value for size of thumbnails.

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4943,10 +4943,8 @@ nemo_file_get_icon (NemoFile *file,
 			g_object_unref (raw_pixbuf);
 
 			/* Don't scale up if more than 25%, then read the original
-			   image instead. We don't want to compare to exactly 100%,
-			   since the zoom level 150% gives thumbnails at 144, which is
-			   ok to scale up from 128. */
-			if (modified_size > 128 * 1.25 * scale &&
+			   image instead. */
+			if (modified_size > 256 * 1.25 * scale &&
 			    !file->details->thumbnail_wants_original &&
 			    nemo_can_thumbnail_internally (file)) {
 				/* Invalidate if we resize upward */


### PR DESCRIPTION
Fixes #3268 

### Why the bug happens

The commit https://github.com/linuxmint/nemo/commit/dedd5f8eeb7a7bfea9de94caf7875146b941f849 increased the thumbnail size from 128 to 256px, but a hard-coded value (updated in this PR) wasn't updated. 

The hard-coded value is in an if statement that decides if the original file (e.g. an image) should be used instead of the thumbnail, in order to avoid the thumbnail being scaled up too much. At max zoom level, the icon size is 256px, and so the if statement was checking `256 > 128 * 1.25 * scale` and then using the original image, which could be very small (as mentioned in the issue).

### Alternative solution

Somehow check whether the original file is too small, and if so never replace the thumbnail with it. This would be tricky to implement from my understanding of the code.

### Testing

I've manually tested the following on both UI 100% and UI 200%. They are most of the use cases of the code that I changed, and they're all okay/unaffected:

- compact view
- icon view
- list view
- sidebar in tree mode
- file conflict dialog
- file property dialog

### Extra things

- "... Normal thumbnails are up to 128×128 pixels, whereas large thumbnails are up to 256×256 pixels. ..." - [gnome thumbnailer](https://gitlab.gnome.org/GNOME/gnome-desktop/-/blob/master/libgnome-desktop/gnome-desktop-thumbnail.c).
- `scale` in the if statement is 1 if UI Scaling in Display settings is 100%, or 2 if 200%.
