### PR TITLE
eel-gtk-extensions.c: (Wayland) Fix menu popup positioning, menu closing issues.

### DIFF
--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -44,7 +44,8 @@ char *                eel_gtk_window_get_geometry_string              (GtkWindow
 
 /* GtkMenu and GtkMenuItem */
 void                  eel_pop_up_context_menu                         (GtkMenu              *menu,
-								       GdkEventButton       *event);
+                                                                       GdkEvent             *event,
+                                                                       GtkWidget            *widget);
 GtkMenuItem *         eel_gtk_menu_append_separator                   (GtkMenu              *menu);
 GtkMenuItem *         eel_gtk_menu_insert_separator                   (GtkMenu              *menu,
 								       int                   index);

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ glib_version = '>=2.45.7'
 math    = cc.find_library('m', required: true)
 
 gtk     = dependency('gtk+-3.0',                    version: '>=3.10.0')
+gtk_wl  = dependency('gtk+-wayland-3.0',            version: '>=3.10.0')
 gio     = dependency('gio-2.0',                     version: glib_version)
 gio_unix= dependency('gio-unix-2.0',                version: glib_version)
 glib    = dependency('glib-2.0',                    version: glib_version)

--- a/src/nemo-blank-desktop-window.c
+++ b/src/nemo-blank-desktop-window.c
@@ -168,7 +168,8 @@ do_popup_menu (NemoBlankDesktopWindow *window, GdkEventButton *event)
     }
 
     eel_pop_up_context_menu (GTK_MENU(window->details->popup_menu),
-                             event);
+                             (GdkEvent *) event,
+                             GTK_WIDGET (window));
 }
 
 static gboolean

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -3689,9 +3689,10 @@ static void
 bookmarks_popup_menu (NemoPlacesSidebar *sidebar,
 		      GdkEventButton        *event)
 {
-	bookmarks_update_popup_menu (sidebar);
-	eel_pop_up_context_menu (GTK_MENU(sidebar->popup_menu),
-				 event);
+    bookmarks_update_popup_menu (sidebar);
+    eel_pop_up_context_menu (GTK_MENU(sidebar->popup_menu),
+                             (GdkEvent *) event,
+                             GTK_WIDGET (sidebar));
 }
 
 /* Callback used for the GtkWidget::popup-menu signal of the shortcuts list */

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -10117,9 +10117,9 @@ nemo_view_pop_up_selection_context_menu  (NemoView *view,
     nemo_view_update_actions_and_extensions (view);
     update_context_menu_position_from_event (view, event);
 
-	eel_pop_up_context_menu (create_popup_menu
-				 (view, NEMO_VIEW_POPUP_PATH_SELECTION),
-				 event);
+    eel_pop_up_context_menu (create_popup_menu (view, NEMO_VIEW_POPUP_PATH_SELECTION),
+                             (GdkEvent *) event,
+                             GTK_WIDGET (view));
 }
 
 /**
@@ -10145,7 +10145,8 @@ nemo_view_pop_up_background_context_menu (NemoView *view,
 
 	eel_pop_up_context_menu (create_popup_menu
 				 (view, NEMO_VIEW_POPUP_PATH_BACKGROUND),
-				 event);
+				 (GdkEvent *) event,
+                 GTK_WIDGET (view));
 }
 
 static void
@@ -10158,7 +10159,8 @@ real_pop_up_location_context_menu (NemoView *view)
 
 	eel_pop_up_context_menu (create_popup_menu
 				 (view, NEMO_VIEW_POPUP_PATH_LOCATION),
-				 view->details->location_popup_event);
+				 (GdkEvent *) view->details->location_popup_event,
+                 GTK_WIDGET (view));
 }
 
 static void


### PR DESCRIPTION
When opening the menu without the mouse (shift-F10, keyboard context  menu key) gtk_menu_popup complains about not having a parent, and pops up in the wrong location.

Using gtk_menu_popup_at_rect() with a fabricated rectangle based on the pointer location works instead.

A pleasant side effect of this is that it works around another bug where clicking off the left side of a popup fails to close the menu or change focus at all. The menu now closes fine, regardless of where the user clicks.

In X11 sessions gtk_menu_popup_at_pointer() is still used.

Fixes #3218

ref: https://bugs.kde.org/show_bug.cgi?id=453532