### PR TITLE
Fix trying the same filename when moving a file with duplicate name

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -5157,6 +5157,7 @@ move_file_prepare (CopyMoveJob *move_job,
 	MoveFileCopyFallback *fallback;
 	gboolean handled_invalid_filename;
     gboolean target_is_desktop, source_is_desktop;
+	int unique_name_nr = 1;
 
     target_is_desktop = (move_job->desktop_location != NULL &&
                          g_file_equal (move_job->desktop_location, dest_dir));
@@ -5300,7 +5301,7 @@ move_file_prepare (CopyMoveJob *move_job,
 
 		if (job->auto_rename_all || auto_rename) {
 			g_object_unref (dest);
-			dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, 1);
+			dest = get_unique_target_file (src, dest_dir, same_fs, *dest_fs_type, unique_name_nr++);
 			goto retry;
 		}
 


### PR DESCRIPTION
fix https://github.com/linuxmint/nemo/issues/3152
So basically the count it was trying for was hardcoded to one, meaning it will always try the "filename (copy)" filename instead of incrementing, never completing and waiting forever, PR makes it so that it will actually track how many times it failed and try the next iteration of names, tried to make it just like the other operations