### PR TITLE
Update nemo-convert-metadata.c - Fix missing include for newer libxml

### DIFF
--- a/src/nemo-convert-metadata.c
+++ b/src/nemo-convert-metadata.c
@@ -30,6 +30,7 @@
 #include <glib/gi18n.h>
 #include <string.h>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 
 #include <libnemo-private/nemo-metadata.h>
 


### PR DESCRIPTION
Fix missing include for newer libxml