### PR TITLE
Fix order of actions in context menu

### DIFF
--- a/libnemo-private/nemo-action-manager.c
+++ b/libnemo-private/nemo-action-manager.c
@@ -145,37 +145,13 @@ sort_file_list_cb (gconstpointer a, gconstpointer b)
     NemoFile *file_b;
     const char *s0;
     const char *s1;
-    gint r;
 
     file_a = (NemoFile *) a;
     file_b = (NemoFile *) b;
     s0 = nemo_file_peek_name (file_a);
     s1 = nemo_file_peek_name (file_b);
-    //
-    // Order alphabetically
-    // Compare ASCII values of file names char by char
-    //    < 0:  a < b
-    //   == 0:  a == b
-    //    > 0:  a > b
-    //
-    do {
-        char c0 = *s0++;
-        char c1 = *s1++;
-        if (c0 < c1) {
-            r = -1;
-            break;
-        }
-        if (c0 > c1) {
-            r = 1;
-            break;
-        }
-        if (c0 == 0) {  // Special case: Both strings are identical and we have hit the \0 char? => Return equal
-            r = 0;
-            break;
-        }
-    } while (TRUE);
 
-    return r;
+    return g_strcmp0 (s0, s1);
 }
 
 static void

--- a/libnemo-private/nemo-action-manager.c
+++ b/libnemo-private/nemo-action-manager.c
@@ -343,6 +343,8 @@ void_actions_for_directory (NemoActionManager *action_manager, NemoDirectory *di
         }
     }
 
+    new_list = g_list_reverse (new_list);
+
     g_object_unref (dir);
 
     tmp = action_manager->actions;


### PR DESCRIPTION
Opening `nemo 6.0.0` (but issue first seen about half year ago so it is not version specific), in the first tab of the first window, actions in context menu show up in reversed order. Order seems to be correct in further tabs and windows or after changing view mode (e.g. list -> icons).