### PR TITLE
nemo-desktop: use app_id as .desktop file name

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -18,7 +18,7 @@ desktopFiles = [
 
   configure_file(
     input : 'nemo.desktop.in',
-    output: 'nemo.desktop',
+    output: 'org.Nemo.desktop',
     configuration: dataConf,
   )
 ]


### PR DESCRIPTION
This is suggested in the [xdg-shell spec](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/463d5cfaf37c8276826cdda48df336b9d2511ed0/stable/xdg-shell/xdg-shell.xml#L651) and makes finding the `.desktop` file from an application easier.
