### PR TITLE
Make wayland dependency optional

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -38,7 +38,9 @@
 #include <X11/Xatom.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkprivate.h>
+#ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>
+#endif
 #include <gtk/gtk.h>
 #include <glib/gi18n-lib.h>
 #include <math.h>
@@ -253,6 +255,7 @@ gboolean
 eel_check_is_wayland (void)
 {
     static gboolean using_wayland = FALSE;
+#ifdef GDK_WINDOWING_WAYLAND
     static gsize once_init = 0;
 
     if (g_once_init_enter (&once_init)) {
@@ -260,7 +263,7 @@ eel_check_is_wayland (void)
 
         g_once_init_leave (&once_init, 1);
     }
-
+#endif
     return using_wayland;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,6 @@ glib_version = '>=2.45.7'
 math    = cc.find_library('m', required: true)
 
 gtk     = dependency('gtk+-3.0',                    version: '>=3.10.0')
-gtk_wl  = dependency('gtk+-wayland-3.0',            version: '>=3.10.0')
 gio     = dependency('gio-2.0',                     version: glib_version)
 gio_unix= dependency('gio-unix-2.0',                version: glib_version)
 glib    = dependency('glib-2.0',                    version: glib_version)
@@ -201,6 +200,7 @@ message('\n'.join(['',
 '    libexif support:        @0@'.format(libexif_enabled),
 '    exempi  support:        @0@'.format(exempi_enabled),
 '    Tracker support:        @0@'.format(tracker_enabled),
+'    Wayland support:        @0@'.format(cc.has_header('gdk/gdkwayland.h', dependencies: gtk)),
 '',
 '    nemo-extension documentation: @0@'.format(gtkdoc_enabled),
 '    nemo-extension introspection: @0@'.format(true),


### PR DESCRIPTION
Add `GDK_WINDOWING_WAYLAND` checks to fix compatibility with gtk+ built without wayland support.