### PR TITLE
Support drawing the desktop on wayland using gtk-layer-shell.

### DIFF
--- a/config.h.meson.in
+++ b/config.h.meson.in
@@ -19,6 +19,8 @@
 #mesondefine HAVE_SELINUX
 // Define to enable pango-1.44 fixes
 #mesondefine HAVE_PANGO_144
+// Define to use gtk-layer-shell
+#mesondefine HAVE_GTK_LAYER_SHELL
 
 
 

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  libgsf-1-dev,
  libgtk-3-dev (>= 3.10),
  libgtk-3-doc,
+ libgtk-layer-shell-dev,
  libpango1.0-dev,
  libx11-dev,
  libxapp-dev (>= 2.0.0),

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,8 @@ CONFIGURE_EXTRA_FLAGS = \
 	--buildtype=debugoptimized \
 	-D deprecated_warnings=false \
 	-D gtk_doc=true \
-	-D selinux=false
+	-D selinux=false \
+	-D gtk_layer_shell=true
 
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,-O1 -Wl,--as-needed
 export DEB_BUILD_MAINT_OPTIONS = hardening=+bindnow

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,12 @@ if libselinux_enabled
 endif
 conf.set('HAVE_SELINUX', libselinux_enabled)
 
+gtk_layer_shell_enabled = get_option('gtk_layer_shell')
+if gtk_layer_shell_enabled
+  gtk_layer_shell = dependency('gtk-layer-shell-0', version: '>=0.8')
+endif
+conf.set('HAVE_GTK_LAYER_SHELL', gtk_layer_shell_enabled)
+
 # make sure pango development files are installed
 pango = dependency('pango', version: '>=1.40.0')
 # check for newer pango for necessary workarounds

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,5 @@ option('empty_view', type : 'boolean', value : false,
        description: 'Enable empty view')
 option('tracker',type : 'combo', choices : ['true', 'false', 'auto'], value : 'false',
        description: 'Tracker support')
+option('gtk_layer_shell', type : 'boolean', value : false,
+       description: 'Use gtk-layer-shell to draw desktop on wayland')

--- a/src/meson.build
+++ b/src/meson.build
@@ -113,6 +113,10 @@ if libexif_enabled
   nemo_deps += libexif
 endif
 
+if gtk_layer_shell_enabled
+  nemo_deps += gtk_layer_shell
+endif
+
 nemo = executable('nemo',
   nemoCommon_sources + nemoWindow_sources,
   include_directories: [ rootInclude ],

--- a/src/nemo-desktop-main.c
+++ b/src/nemo-desktop-main.c
@@ -89,7 +89,13 @@ main (int argc, char *argv[])
 
 	g_set_prgname ("nemo-desktop");
 
-	gdk_set_allowed_backends ("x11");
+#ifdef HAVE_GTK_LAYER_SHELL
+	if (gtk_layer_is_supported())
+		gdk_set_allowed_backends ("wayland");
+	else
+#else
+		gdk_set_allowed_backends ("x11");
+#endif
 
 #ifdef HAVE_EXEMPI
 	xmp_init();

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -77,6 +77,10 @@
 #include <math.h>
 #include <sys/time.h>
 
+#ifdef HAVE_GTK_LAYER_SHELL
+#include <gtk-layer-shell/gtk-layer-shell.h>
+#endif
+
 #define MAX_TITLE_LENGTH 180
 
 /* Forward and back buttons on the mouse */
@@ -618,6 +622,18 @@ nemo_window_constructed (GObject *self)
 
 	window = NEMO_WINDOW (self);
 	application = nemo_application_get_singleton ();
+
+#ifdef HAVE_GTK_LAYER_SHELL
+	if (gtk_layer_is_supported() && window->details->disable_chrome) {
+		gtk_layer_init_for_window(GTK_WINDOW(window));
+		gtk_layer_set_namespace(GTK_WINDOW(window), _("Nemo"));
+		gtk_layer_set_layer(GTK_WINDOW(window), GTK_LAYER_SHELL_LAYER_BOTTOM);
+		gtk_layer_set_margin(GTK_WINDOW(window), GTK_LAYER_SHELL_EDGE_TOP, 0);
+		for (int anchor = 0; anchor < 4; anchor++) {
+			gtk_layer_set_anchor(GTK_WINDOW(window), anchor, 1);
+		}
+	}
+#endif
 
 	G_OBJECT_CLASS (nemo_window_parent_class)->constructed (self);
 	gtk_window_set_application (GTK_WINDOW (window), GTK_APPLICATION (application));


### PR DESCRIPTION
This PR allows nemo-desktop to display desktop icons on wayland compositors that support the [layer-shell](https://wayland.app/protocols/wlr-layer-shell-unstable-v1) protocol.  It adds an optional dependency on gtk-layer-shell, which supports wlroots-based compositors such as sway, wayfire etc. If the dependency is found, then nemo will run natively on wayland.

I have been using it on [wayfire](https://wayfire.org/) and it works well.

The change is very simple and should be easy to maintain even if Wayland is not yet officially supported.