### PR TITLE
nemo-dnd: Have the drag and drop text data not be uris but plain paths.

### DIFF
--- a/libnemo-private/nemo-dnd.c
+++ b/libnemo-private/nemo-dnd.c
@@ -662,7 +662,7 @@ nemo_drag_default_drop_action_for_uri_list (GdkDragContext *context,
    the location and size of each icon relative to the cursor.
 */
 static void
-add_one_gnome_icon (const char *uri, int x, int y, int w, int h, 
+add_one_gnome_icon (const char *uri, const char *path_str, int x, int y, int w, int h,
 		    gpointer data)
 {
 	GString *result;
@@ -747,7 +747,7 @@ add_one_compatible_uri (const char *uri, int x, int y, int w, int h, gpointer da
 #endif
 
 static void
-add_one_uri (const char *uri, int x, int y, int w, int h, gpointer data)
+add_one_uri (const char *uri, const char *path_str, int x, int y, int w, int h, gpointer data)
 {
 	GString *result;
 	
@@ -755,6 +755,17 @@ add_one_uri (const char *uri, int x, int y, int w, int h, gpointer data)
 
 	g_string_append (result, uri);
 	g_string_append (result, "\r\n");
+}
+
+static void
+add_one_path (const char *uri, const char *path_str, int x, int y, int w, int h, gpointer data)
+{
+    GString *result;
+
+    result = (GString *) data;
+
+    g_string_append (result, path_str);
+    g_string_append (result, "\r\n");
 }
 
 /* Common function for drag_data_get_callback calls.
@@ -777,11 +788,13 @@ nemo_drag_drag_data_get (GtkWidget *widget,
 		break;
 		
 	case NEMO_ICON_DND_URI_LIST:
-	case NEMO_ICON_DND_TEXT:
 		result = g_string_new (NULL);
 		(* each_selected_item_iterator) (add_one_uri, container_context, result);
 		break;
-
+    case NEMO_ICON_DND_TEXT:
+        result = g_string_new (NULL);
+        (* each_selected_item_iterator) (add_one_path, container_context, result);
+        break;
 	default:
 		return FALSE;
 	}

--- a/libnemo-private/nemo-dnd.h
+++ b/libnemo-private/nemo-dnd.h
@@ -98,7 +98,8 @@ typedef struct {
 
 } NemoDragInfo;
 
-typedef void		(* NemoDragEachSelectedItemDataGet)	(const char *url, 
+typedef void		(* NemoDragEachSelectedItemDataGet)	(const char *url,
+                                 const char *path_str,
 								 int x, int y, int w, int h, 
 								 gpointer data);
 typedef void		(* NemoDragEachSelectedItemIterator)	(NemoDragEachSelectedItemDataGet iteratee, 

--- a/libnemo-private/nemo-icon-dnd.c
+++ b/libnemo-private/nemo-icon-dnd.c
@@ -283,6 +283,7 @@ icon_get_data_binder (NemoIcon *icon, gpointer data)
 	EelDRect world_rect;
 	EelIRect widget_rect;
 	char *uri;
+	char *path_str;
 	NemoIconContainer *container;
 
 	context = (IconGetDataBinderContext *)data;
@@ -300,6 +301,7 @@ icon_get_data_binder (NemoIcon *icon, gpointer data)
 		g_warning ("no URI for one of the iterated icons");
 		return TRUE;
 	}
+	path_str = nemo_file_get_path (NEMO_FILE (icon->data));
 
 	widget_rect = eel_irect_offset_by (widget_rect,
 		- container->details->dnd_info->drag_info.start_x,
@@ -310,6 +312,7 @@ icon_get_data_binder (NemoIcon *icon, gpointer data)
 
 	/* pass the uri, mouse-relative x/y and icon width/height */
 	context->iteratee (uri,
+               path_str,
 			   (int) widget_rect.x0,
 			   (int) widget_rect.y0,
 			   widget_rect.x1 - widget_rect.x0,

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -892,6 +892,7 @@ each_path_get_data_binder (NemoDragEachSelectedItemDataGet data_get,
 	GtkTreeRowReference *row;
 	GtkTreePath *path;
 	char *uri;
+	char *path_str;
 	GdkRectangle cell_area;
 	GtkTreeViewColumn *column;
 
@@ -914,8 +915,10 @@ each_path_get_data_binder (NemoDragEachSelectedItemDataGet data_get,
 				 &cell_area);
 
 			uri = nemo_file_get_local_uri (file);
+			path_str = nemo_file_get_path (file);
 
 			(*data_get) (uri,
+					 path_str,
 				     0,
 				     cell_area.y - info->model->details->drag_begin_y,
 				     cell_area.width, cell_area.height,


### PR DESCRIPTION
Fixes https://github.com/linuxmint/nemo/issues/3354 

New drag and drop data returned:
|                              | **Before**                       | **After**                   |
|------------------------------|--------------------------------|--------------------------------|
| **text/uri-list**            | `file:///path.ext\r\n` | `file:///path.ext\r\n` |
| **text/plain**               | `file:///path.ext\r\n` |  `/path.ext\r\n`                             |
| **text/plain;charset=utf-8** | `file:///path.ext\r\n` | `/path.ext\r\n`            |

I did not see any regression with other apps I tested this on.

Apps I tested were: discord (wayland), chromium (wayland), firefox (wayland), gajim (wayland), CLion (XWayland), discord (XWayland), nemo to nemo, gedit, gnome console.