### PR TITLE
mount-archive.nemo_action: Use gvfsd-archive instead of gnome-disk-image-mounter

### DIFF
--- a/data/nemo-actions/mount-archive.nemo_action.in
+++ b/data/nemo-actions/mount-archive.nemo_action.in
@@ -4,7 +4,7 @@ Name=Mount archive
 
 Comment=Mount %f to browse its contents
 
-Exec=gnome-disk-image-mounter %U
+Exec=/usr/libexec/gvfsd-archive file="%U"
 
 Selection=s
 

--- a/files/usr/share/nemo/actions/mount-archive.nemo_action
+++ b/files/usr/share/nemo/actions/mount-archive.nemo_action
@@ -4,7 +4,7 @@ Name=Mount archive
 
 Comment=Mount %f to browse its contents
 
-Exec=gnome-disk-image-mounter %U
+Exec=/usr/libexec/gvfsd-archive file="%U"
 
 Selection=s
 


### PR DESCRIPTION
Fixes #3231
Regression introduced in b7bd80d.
#2811 stays fixed as we use /usr/libexec/gvfsd-archive instead of /usr/lib/gvfs/gvfsd-archive now.