### PR TITLE
file: default to not being able to trash

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -2396,8 +2396,8 @@ update_info_internal (NemoFile *file,
 	can_write = TRUE;
 	can_execute = TRUE;
 	can_delete = TRUE;
-	can_trash = TRUE;
 	can_rename = TRUE;
+	can_trash = FALSE;
 	can_mount = FALSE;
 	can_unmount = FALSE;
 	can_eject = FALSE;


### PR DESCRIPTION
Based on:  https://github.com/GNOME/nautilus/commit/45a5c5a40e32960e82d208f9885405213cf67ddb

We were using as default that we can trash files, and after
we only set the if it is possible to trash or not if the filesystem
reports that has the info.
In most of schemes that the trash is not supported, the filesystem
actually don't have that info, making can_trash true and providing
the option on nautilus context menu, which does nothing.
Default to not being able to trash to avoid this situation.