### PR TITLE
make nemo build under Ubuntu Noble

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nemo (6.0.2ubuntu1) virginia; urgency=medium
+
+ * Requires glib >=2.80. 
+ * Remove usr/lib/*/nemo/nemo-extensions-list from nemo.install
+
+ -- Pablo De Nápoli <pdenapo@gmail.com>  Sun, 12 May 2024 14:11:36 +0000
+
 nemo (6.0.2) virginia; urgency=medium
 
   [ Michael Webster ]

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends:
  libexif-dev (>= 0.6.20),
  libgail-3-dev,
  libgirepository1.0-dev (>= 0.9.12),
- libglib2.0-dev (>= 2.45.7),
+ libglib2.0-dev (>= 2.80),
  libglib2.0-doc,
  libgsf-1-dev,
  libgtk-3-dev (>= 3.10),

--- a/debian/nemo.install
+++ b/debian/nemo.install
@@ -1,5 +1,4 @@
 usr/bin
-usr/lib/*/nemo/nemo-extensions-list
 usr/share/applications
 usr/share/dbus-1
 usr/share/man


### PR DESCRIPTION
This PR aims to fix two issues detected when building nemo Debian package from the sources using
mk-build-deps  and then fakerrot ./debian/rules binary

1) Update glib version to 2.80 

This is required since the function

[This package cannot be built under Ubuntu jammy any more, where I got the following error message]

nemo-main-application.c:721: reference a `to_log_writer_default_set_debug_domains' undefined

This function is available since: 2.80

https://docs.gtk.org/glib/func.log_writer_default_set_debug_domains.html

2) Remove usr/lib/*/nemo/nemo-extensions-list" from debian/nemo.install

This is required to fix the following error message (since now the nemo extensions are kept in separate packages)

dh_install
dh_install: warning: Cannot find (any matches for) "usr/lib/*/nemo/nemo-extensions-list" (tried in ., debian/tmp)

dh_install: warning: nemo missing files: usr/lib/*/nemo/nemo-extensions-list
dh_install: error: missing files, aborting
make: *** [debian/rules:19: binary] Error 255




