### PR TITLE
Remove usr/lib/*/nemo/nemo-extensions-list from nemo.install

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nemo (6.0.2ubuntu1) virginia; urgency=medium
+ 
+  [ Pablo De Napoli] 
+  * Requires glib >=2.80. 
+  * Remove usr/lib/*/nemo/nemo-extensions-list from nemo.install
+
+ -- Pablo De Napoli <pdenapo@gmail.com>  Sun, 12 May 2024 14:11:36 +0000
+
 nemo (6.0.2) virginia; urgency=medium
 
   [ Michael Webster ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,6 @@
 nemo (6.0.2ubuntu1) virginia; urgency=medium
  
   [ Pablo De Napoli] 
-  * Requires glib >=2.80. 
   * Remove usr/lib/*/nemo/nemo-extensions-list from nemo.install
 
  -- Pablo De Napoli <pdenapo@gmail.com>  Sun, 12 May 2024 14:11:36 +0000

--- a/debian/nemo.install
+++ b/debian/nemo.install
@@ -1,5 +1,4 @@
 usr/bin
-usr/lib/*/nemo/nemo-extensions-list
 usr/share/applications
 usr/share/dbus-1
 usr/share/man


### PR DESCRIPTION
This is  a followup of my previous PR #3400 

In order to successfully build the .deb packages for nemo from the sources (using fakeroot ./debian/rules binary)
this other change is requiered, since otherwise one gets the following error message (aborting the building process)

dh_install
dh_install: warning: Cannot find (any matches for) "usr/lib/*/nemo/nemo-extensions-list" (tried in ., debian/tmp)

dh_install: warning: nemo missing files: usr/lib/*/nemo/nemo-extensions-list
dh_install: error: missing files, aborting
make: *** [debian/rules:19: binary] Error 255

This is so, because now the extensions are kept in a separate repository with their own .deb packages

https://github.com/linuxmint/nemo-extensions


