### PR TITLE
eel-gnome-extensions.c: Set GNOME Terminal to FALSE

### DIFF
--- a/eel/eel-gnome-extensions.c
+++ b/eel/eel-gnome-extensions.c
@@ -42,7 +42,7 @@ static const struct {
     { "color-xterm", "-e", TRUE },
     { "dtterm", "-e", TRUE },
     { "foot", "--", FALSE },
-    { "gnome-terminal", "--", TRUE },
+    { "gnome-terminal", "--", FALSE },
     { "kgx", "-e", TRUE },
     { "kitty", "--", FALSE },
     { "konsole", "-e", TRUE },


### PR DESCRIPTION
This ensures that paths are not escaped when the "Run in Terminal" option is selected.

Fixes #3420