### PR TITLE
Update rules: Disable gtk layer shell

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Build-Depends:
  libgsf-1-dev,
  libgtk-3-dev (>= 3.10),
  libgtk-3-doc,
- libgtk-layer-shell-dev,
  libjson-glib-dev (>= 1.6),
  libpango1.0-dev,
  libx11-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ CONFIGURE_EXTRA_FLAGS = \
 	-D deprecated_warnings=false \
 	-D gtk_doc=true \
 	-D selinux=false \
-	-D gtk_layer_shell=true
+	-D gtk_layer_shell=false
 
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,-O1 -Wl,--as-needed
 export DEB_BUILD_MAINT_OPTIONS = hardening=+bindnow


### PR DESCRIPTION
Disable gtk layer shell as it is rubbish and causes more issues than is solves.

1: It doesn't respect cinnamon panel height.
2: It's unreliable, see https://github.com/linuxmint/wayland/issues/102