### PR TITLE
tree-sidebar: Add missing properties menu item.

### DIFF
--- a/gresources/nemo-tree-sidebar-ui.xml
+++ b/gresources/nemo-tree-sidebar-ui.xml
@@ -21,5 +21,6 @@
     <menuitem name="Unmount" action="Unmount Volume"/>
     <menuitem name="Eject" action="Eject Volume"/>
     <separator name="PropertiesSeparator"/>
+    <menuitem name="Properties" action="Properties"/>
 </popup>
 </ui>


### PR DESCRIPTION
This menu item used to be there, looks like its been forgotten through the latest changes.