### PR TITLE
Remove unused libxml headers.

### DIFF
--- a/libnemo-private/nemo-directory-async.c
+++ b/libnemo-private/nemo-directory-async.c
@@ -34,7 +34,6 @@
 #include "nemo-link.h"
 #include <eel/eel-glib-extensions.h>
 #include <gtk/gtk.h>
-#include <libxml/parser.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <libxapp/xapp-favorites.h>

--- a/libnemo-private/nemo-directory-private.h
+++ b/libnemo-private/nemo-directory-private.h
@@ -29,7 +29,6 @@
 #include <libnemo-private/nemo-file.h>
 #include <libnemo-private/nemo-monitor.h>
 #include <libnemo-extension/nemo-info-provider.h>
-#include <libxml/tree.h>
 
 typedef struct LinkInfoReadState LinkInfoReadState;
 typedef struct FileMonitors FileMonitors;

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -63,7 +63,6 @@
 #include <libnemo-extension/nemo-file-info.h>
 #include <libnemo-extension/nemo-extension-private.h>
 #include <libxapp/xapp-favorites.h>
-#include <libxml/parser.h>
 #include <pwd.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/src/nemo-desktop-main.c
+++ b/src/nemo-desktop-main.c
@@ -39,8 +39,6 @@
 #include <gtk/gtk.h>
 #include <gio/gdesktopappinfo.h>
 
-#include <libxml/parser.h>
-
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
 #endif

--- a/src/nemo-main.c
+++ b/src/nemo-main.c
@@ -39,8 +39,6 @@
 #include <gtk/gtk.h>
 #include <gio/gdesktopappinfo.h>
 
-#include <libxml/parser.h>
-
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
 #endif


### PR DESCRIPTION
Fixes fa76d529 ("Remove obsolete libxml dependency").

This fixes building on NixOS with failures like `../src/nemo-main.c:42:10: fatal error: libxml/parser.h: No such file or directory`.