### PR TITLE
Modified logic for detecting terminal emulators.

### DIFF
--- a/eel/eel-gnome-extensions.c
+++ b/eel/eel-gnome-extensions.c
@@ -37,7 +37,7 @@
 static const struct {
     const char *exec;
     const char *exec_arg;
-    gboolean escape_command;
+    const gboolean escape_command;
 } known_terminals[] = {
     { "alacritty", "-e", TRUE },
     { "color-xterm", "-e", TRUE },


### PR DESCRIPTION
Per the discussion in https://github.com/linuxmint/nemo/issues/3483#issuecomment-2584537661 I felt that the terminal emulator detection could use some refining. I added some additional *known terminals* and made sure that the default terminal specified though gsettings is respected. If a terminal cannot be found, an error dialog is presented to the user.

I have not compiled or tested these changes but Copilot seems to think that they look good.