### PR TITLE
nemo-view.c: fix crash after some shortcuts

### DIFF
--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -7208,6 +7208,12 @@ action_follow_symlink_callback (GtkAction *action,
 
     view = NEMO_VIEW (callback_data);
     selection = nemo_view_get_selection (view);
+
+    if (g_list_length (selection) != 1) {
+        nemo_file_list_free (selection);
+        return;
+    }
+
     if (nemo_file_is_symbolic_link (selection->data)) {
         gchar *uri = nemo_file_get_symbolic_link_target_uri (selection->data);
         gchar *view_uri = nemo_view_get_uri (view);
@@ -7252,6 +7258,11 @@ action_open_containing_folder_callback (GtkAction *action,
 
     view = NEMO_VIEW (callback_data);
     selection = nemo_view_get_selection (view);
+
+    if (g_list_length (selection) != 1) {
+        nemo_file_list_free (selection);
+        return;
+    }
 
     item = NEMO_FILE (selection->data);
     activation_location = nemo_file_get_activation_location (item);


### PR DESCRIPTION
On `action_follow_symlink_callback()` and
`action_open_containing_folder_callback()` we now confirm that exactly one thing is selected.  Previously, if zero things were selected, we would segfault.