### PR TITLE
[WIP] Changes the memory allocator to use jemalloc to address memory leak issues

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  libgsf-1-dev,
  libgtk-3-dev (>= 3.10),
  libgtk-3-doc,
+ libjemalloc2-dev,
  libjson-glib-dev (>= 1.6),
  libpango1.0-dev,
  libx11-dev,

--- a/debian/control
+++ b/debian/control
@@ -88,6 +88,7 @@ Depends:
  gsettings-desktop-schemas,
  gvfs (>= 1.3.2),
  libglib2.0-data,
+ libjemalloc2,
  libnemo-extension1 (= ${binary:Version}),
  nemo-data (= ${source:Version}),
  shared-mime-info (>= 0.50),

--- a/meson.build
+++ b/meson.build
@@ -84,7 +84,10 @@ x11     = dependency('x11')
 xapp    = dependency('xapp',                        version: '>=2.0.0')
 
 jemalloc_opt = get_option('jemalloc')
-if jemalloc_opt
+if jemalloc_opt == 'true'
+  jemalloc = dependency('jemalloc', required: true)
+  use_jemalloc = true
+elif jemalloc_opt == 'auto'
   jemalloc = dependency('jemalloc', required: false)
   use_jemalloc = jemalloc.found()
 else

--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,15 @@ cinnamon= dependency('cinnamon-desktop',            version: '>=4.8.0')
 gail    = dependency('gail-3.0')
 x11     = dependency('x11')
 xapp    = dependency('xapp',                        version: '>=2.0.0')
-jemalloc = dependency('jemalloc', required: true)
+
+jemalloc_opt = get_option('jemalloc')
+if jemalloc_opt
+  jemalloc = dependency('jemalloc', required: false)
+  use_jemalloc = jemalloc.found()
+else
+  jemalloc = dependency('', required: false)
+  use_jemalloc = false
+endif
 
 # Facultative dependencies
 
@@ -173,8 +181,10 @@ nemo_definitions =  [
   '-DNEMO_EXTENSIONDIR="@0@"'.format(nemoExtensionPath),
   '-DLIBEXECDIR="@0@"'.format(libExecPath),
   '-DG_LOG_DOMAIN="Nemo"',
-  '-DUSE_JEMALLOC'
 ]
+if use_jemalloc
+  nemo_definitions += '-DUSE_JEMALLOC'
+endif
 
 po_subdir = join_paths(meson.project_source_root(), 'po')
 
@@ -203,6 +213,7 @@ message('\n'.join(['',
 '    exempi  support:        @0@'.format(exempi_enabled),
 '    Tracker support:        @0@'.format(tracker_enabled),
 '    Wayland support:        @0@'.format(cc.has_header('gdk/gdkwayland.h', dependencies: gtk)),
+'    Jemalloc support:       @0@'.format(use_jemalloc),
 '',
 '    nemo-extension documentation: @0@'.format(gtkdoc_enabled),
 '    nemo-extension introspection: @0@'.format(true),

--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ cinnamon= dependency('cinnamon-desktop',            version: '>=4.8.0')
 gail    = dependency('gail-3.0')
 x11     = dependency('x11')
 xapp    = dependency('xapp',                        version: '>=2.0.0')
+jemalloc = dependency('jemalloc', required: true)
 
 # Facultative dependencies
 
@@ -171,7 +172,8 @@ nemo_definitions =  [
   '-DNEMO_DATADIR="@0@"'.format(nemoDataPath),
   '-DNEMO_EXTENSIONDIR="@0@"'.format(nemoExtensionPath),
   '-DLIBEXECDIR="@0@"'.format(libExecPath),
-  '-DG_LOG_DOMAIN="Nemo"'
+  '-DG_LOG_DOMAIN="Nemo"',
+  '-DUSE_JEMALLOC'
 ]
 
 po_subdir = join_paths(meson.project_source_root(), 'po')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,5 +12,5 @@ option('empty_view', type : 'boolean', value : false,
        description: 'Enable empty view')
 option('tracker',type : 'combo', choices : ['true', 'false', 'auto'], value : 'false',
        description: 'Tracker support')
-option('jemalloc', type : 'boolean', value : false,
-       description: 'Use jemalloc memory allocator if available')
+option('jemalloc', type : 'combo', choices : ['true', 'false', 'auto'], value : 'auto',
+       description: 'Use jemalloc memory allocator if available (auto = enable if found)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,5 @@ option('empty_view', type : 'boolean', value : false,
        description: 'Enable empty view')
 option('tracker',type : 'combo', choices : ['true', 'false', 'auto'], value : 'false',
        description: 'Tracker support')
+option('jemalloc', type : 'boolean', value : false,
+       description: 'Use jemalloc memory allocator if available')

--- a/src/meson.build
+++ b/src/meson.build
@@ -103,7 +103,10 @@ if enableEmptyView
 endif
 
 nemo_deps = [ cinnamon, gail, glib, gtk, math,
-  egg, nemo_extension, nemo_private, xapp, jemalloc ]
+  egg, nemo_extension, nemo_private, xapp ]
+if use_jemalloc
+  nemo_deps += jemalloc
+endif
 
 if exempi_enabled
   nemo_deps += exempi
@@ -113,29 +116,45 @@ if libexif_enabled
   nemo_deps += libexif
 endif
 
+
+nemo_link_args = []
+if use_jemalloc
+  nemo_link_args += ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed']
+endif
 nemo = executable('nemo',
   nemoCommon_sources + nemoWindow_sources,
   include_directories: [ rootInclude ],
   c_args: nemo_definitions,
   dependencies: nemo_deps,
-  link_args: ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed'],
+  link_args: nemo_link_args,
   install: true
 )
 
+
+nemoDesktop_link_args = []
+if use_jemalloc
+  nemoDesktop_link_args += ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed']
+endif
 nemoDesktop = executable('nemo-desktop',
   nemoCommon_sources + nemoDesktop_sources,
   include_directories: [ rootInclude],
   c_args: nemo_definitions,
   dependencies: nemo_deps,
-  link_args: ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed'],
+  link_args: nemoDesktop_link_args,
   install: true
 )
 
+
+nemo_autorun_software_link_args = []
+if use_jemalloc
+  nemo_autorun_software_link_args += ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed']
+endif
 nemo_autorun_software = executable('nemo-autorun-software',
   [ 'nemo-autorun-software.c' ],
   include_directories: [ rootInclude, ],
   c_args: nemo_definitions,
   dependencies: nemo_deps,
+  link_args: nemo_autorun_software_link_args,
   install: true
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -103,7 +103,7 @@ if enableEmptyView
 endif
 
 nemo_deps = [ cinnamon, gail, glib, gtk, math,
-  egg, nemo_extension, nemo_private, xapp ]
+  egg, nemo_extension, nemo_private, xapp, jemalloc ]
 
 if exempi_enabled
   nemo_deps += exempi
@@ -118,6 +118,7 @@ nemo = executable('nemo',
   include_directories: [ rootInclude ],
   c_args: nemo_definitions,
   dependencies: nemo_deps,
+  link_args: ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed'],
   install: true
 )
 
@@ -126,6 +127,7 @@ nemoDesktop = executable('nemo-desktop',
   include_directories: [ rootInclude],
   c_args: nemo_definitions,
   dependencies: nemo_deps,
+  link_args: ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed'],
   install: true
 )
 

--- a/src/nemo-main.c
+++ b/src/nemo-main.c
@@ -53,6 +53,20 @@
 #include <exempi/xmp.h>
 #endif
 
+#ifdef USE_JEMALLOC
+	static void
+	nemo_jemalloc_configure(void) __attribute__((constructor));
+
+	static void
+	nemo_jemalloc_configure(void)
+	{
+		if (getenv("MALLOC_CONF") != NULL)
+			return;
+		const char *conf = "narenas:1,metadata_thp:auto,percpu_arena:phycpu";
+		setenv("MALLOC_CONF", conf, 0);
+	}
+#endif
+
 int
 main (int argc, char *argv[])
 {


### PR DESCRIPTION
In the past few days, I tried several approaches to resolve memory leak issues in Nemo. I have a folder with 29,000 subfolders that I was using for testing. Scrolling quickly through this folder causes memory usage to exceed 1 GB.

Even after leaving the folder, the memory consumption remains high. However, when using jemalloc, switching to another folder brings memory usage back to normal, around 50 MB.

I used this folder with a huge number of subfolders to make testing easier, but folders with a thousand files are already sufficient to identify the issue.