### PR TITLE
Add Matcha to Supported Theme Hints

### DIFF
--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -243,7 +243,8 @@ out:
 static const char *supported_theme_hints[] = {
         "mint",
         "arc",
-        "numix"
+        "numix",
+        "matcha"
 };
 
 static gboolean


### PR DESCRIPTION
Matcha has theming specifically for nemo, so adding it to the supported themes list!

https://vinceliuice.github.io/theme-matcha.html