### PR TITLE
Places sidebar, allow users to set custom icons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Nemo also manages the Cinnamon desktop.
 Since Cinnamon 6.0 (Mint 21.3), users can enhance their own Nemo with Spices named Actions.
 
 Forked Changes: Allows setting of icons in places-sidebar but you must allow it via gsettings.schema
+
+The option appears in the right-click context menu. Enjoy.
 ```
 sudo cp ~/Documents/nemo-master/libnemo-private/org.nemo.gschema.xml /usr/share/glib-2.0/schemas/
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ gsettings set org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons true
 gsettings get org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons
 ```
 
-[![Screenshot from 2025-07-08 13-39-09](https://i.ibb.co/2Y7M0M4Z/Screenshot-from-2025-07-08-13-39-09.png)](https://ibb.co/zHh2W2v6)
-
 [![Screenshot from 2025-07-08 13-38-59](https://i.ibb.co/RG7HCLWj/Screenshot-from-2025-07-08-13-38-59.png)](https://ibb.co/CpW0nxFP)
 
+[![Screenshot from 2025-07-08 13-39-09](https://i.ibb.co/2Y7M0M4Z/Screenshot-from-2025-07-08-13-39-09.png)](https://ibb.co/zHh2W2v6)
 
 
 History

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ gsettings set org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons true
 gsettings get org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons
 ```
 
+[![Screenshot from 2025-07-08 13-39-09](https://i.ibb.co/2Y7M0M4Z/Screenshot-from-2025-07-08-13-39-09.png)](https://ibb.co/zHh2W2v6)
+
+[![Screenshot from 2025-07-08 13-38-59](https://i.ibb.co/RG7HCLWj/Screenshot-from-2025-07-08-13-38-59.png)](https://ibb.co/CpW0nxFP)
+
+
 
 History
 ====

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ It is a fork of GNOME Files (formerly named Nautilus).
 Nemo also manages the Cinnamon desktop.
 Since Cinnamon 6.0 (Mint 21.3), users can enhance their own Nemo with Spices named Actions.
 
+Forked Changes: Allows setting of icons in places-sidebar but you must allow it via gsettings.schema
+```
+sudo cp ~/Documents/nemo-master/libnemo-private/org.nemo.gschema.xml /usr/share/glib-2.0/schemas/
+
+sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+
+gsettings set org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons true
+
+gsettings get org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons
+```
+
 
 History
 ====

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ gsettings set org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons true
 
 gsettings get org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons
 ```
+[![Screenshot from 2025-07-08 21-51-07](https://i.ibb.co/Lzf0kKwB/Screenshot-from-2025-07-08-21-51-07.png)](https://ibb.co/1fx0vcVB)
 
 [![Screenshot from 2025-07-08 13-38-59](https://i.ibb.co/RG7HCLWj/Screenshot-from-2025-07-08-13-38-59.png)](https://ibb.co/CpW0nxFP)
 

--- a/gresources/nemo-places-sidebar-ui.xml
+++ b/gresources/nemo-places-sidebar-ui.xml
@@ -7,6 +7,7 @@
     <menuitem name="AddBookmark" action="Add Bookmark"/>
     <menuitem name="Remove" action="Remove Bookmark"/>
     <menuitem name="Rename" action="Rename"/>
+    <menuitem name="SetCustomIcon" action="Set Custom Icon"/>
     <separator name="PreActionsSeparator"/>
     <placeholder name="PlacesSidebarActionsPlaceholder"/>
     <separator name="PostActionsSeparator"/>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -541,6 +541,23 @@
     </key>
   </schema>
 
+  <schema id="org.nemo.sidebar-panels.custom-icons" path="/org/nemo/sidebar-panels/custom-icons/">
+    <key name="use-custom-sidebar-icons" type="b">
+      <default>false</default>
+      <summary>Enable custom icons for sidebar items</summary>
+      <description>
+        If true, Nemo will allow custom icons to be assigned to sidebar entries.
+      </description>
+    </key>
+    <key name="custom-sidebar-icons" type="a{ss}">
+      <default>{}</default>
+      <summary>Sidebar icon overrides</summary>
+      <description>
+        A mapping of sidebar bookmark URIs to icon names.
+      </description>
+    </key>
+  </schema>
+
   <schema id="org.nemo.desktop" path="/org/nemo/desktop/" gettext-domain="nemo">
     <key name="font" type="s">
       <default l10n="messages" context="desktop-font">'Noto Sans 10'</default>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build file
 
 # https://github.com/linuxmint/nemo
-project('nemo', 'c', version : '6.4.5', meson_version : '>=0.56.0')
+project('nemo', 'c', version : '6.4.6', meson_version : '>=0.56.0')
 
 # 1. If the library code has changed at all since last release, then increment revision.
 # 2. If any interfaces have been added, then increment current and set revision to 0.

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,7 @@ nemoCommon_sources = [
   'nemo-notebook.c',
   'nemo-pathbar.c',
   'nemo-places-sidebar.c',
+  'nemo-places-sidebar-custom-icons.c',
   'nemo-plugin-manager.c',
   'nemo-previewer.c',
   'nemo-progress-info-widget.c',

--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -95,6 +95,7 @@
 #define NEMO_ACTION_MOVE_TO_MENU "MoveToMenu"
 #define NEMO_ACTION_LOCATION_PASTE_FILES_INTO "LocationPasteFilesInto"
 #define NEMO_ACTION_RENAME "Rename"
+#define NEMO_ACTION_SET_CUSTOM_ICON "Set Custom Icon"
 #define NEMO_ACTION_DUPLICATE "Duplicate"
 #define NEMO_ACTION_CREATE_LINK "Create Link"
 #define NEMO_ACTION_SELECT_ALL "Select All"

--- a/src/nemo-places-sidebar-custom-icons.c
+++ b/src/nemo-places-sidebar-custom-icons.c
@@ -1,0 +1,83 @@
+#include "nemo-places-sidebar-custom-icons.h"
+#include <gio/gio.h>
+
+#define SETTINGS_SCHEMA "org.nemo.sidebar-panels.custom-icons"
+#define KEY_ENABLED     "use-custom-sidebar-icons"
+#define KEY_ICON_MAP    "custom-sidebar-icons"
+
+static GSettings *settings = NULL;
+
+void nemo_sidebar_custom_icons_init(void) {
+    if (!settings)
+        settings = g_settings_new(SETTINGS_SCHEMA);
+}
+
+gboolean nemo_sidebar_custom_icons_enabled(void) {
+    if (!settings)
+        nemo_sidebar_custom_icons_init();
+    return g_settings_get_boolean(settings, KEY_ENABLED);
+}
+
+gchar *nemo_sidebar_get_custom_icon_for_uri(const gchar *uri) {
+    if (!settings)
+        nemo_sidebar_custom_icons_init();
+
+    GVariant *map = g_settings_get_value(settings, KEY_ICON_MAP);
+    gchar *icon_name = NULL;
+
+    if (g_variant_lookup(map, uri, "s", &icon_name)) {
+        g_variant_unref(map);
+        return icon_name;
+    }
+
+    g_variant_unref(map);
+    return NULL;
+}
+
+void nemo_sidebar_set_custom_icon_for_uri(const gchar *uri, const gchar *icon_name) {
+    if (!settings)
+        nemo_sidebar_custom_icons_init();
+
+    GVariant *map = g_settings_get_value(settings, KEY_ICON_MAP);
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a{ss}"));
+
+    // Rebuild the dict with updated key
+    GVariantIter iter;
+    gchar *key, *value;
+    g_variant_iter_init(&iter, map);
+    while (g_variant_iter_next(&iter, "{ss}", &key, &value)) {
+        if (g_strcmp0(key, uri) != 0)
+            g_variant_builder_add(&builder, "{ss}", key, value);
+        g_free(key);
+        g_free(value);
+    }
+    g_variant_unref(map);
+
+    // Add or update this entry
+    g_variant_builder_add(&builder, "{ss}", uri, icon_name);
+    g_settings_set_value(settings, KEY_ICON_MAP, g_variant_builder_end(&builder));
+}
+
+void nemo_sidebar_clear_custom_icon_for_uri(const gchar *uri) {
+    if (!settings)
+        nemo_sidebar_custom_icons_init();
+
+    GVariant *map = g_settings_get_value(settings, KEY_ICON_MAP);
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a{ss}"));
+
+    // Copy everything except the URI to remove
+    GVariantIter iter;
+    gchar *key, *value;
+    g_variant_iter_init(&iter, map);
+    while (g_variant_iter_next(&iter, "{ss}", &key, &value)) {
+        if (g_strcmp0(key, uri) != 0)
+            g_variant_builder_add(&builder, "{ss}", key, value);
+        g_free(key);
+        g_free(value);
+    }
+    g_variant_unref(map);
+
+    g_settings_set_value(settings, KEY_ICON_MAP, g_variant_builder_end(&builder));
+}

--- a/src/nemo-places-sidebar-custom-icons.h
+++ b/src/nemo-places-sidebar-custom-icons.h
@@ -1,0 +1,25 @@
+#ifndef NEMO_PLACES_SIDEBAR_CUSTOM_ICONS_H
+#define NEMO_PLACES_SIDEBAR_CUSTOM_ICONS_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+// Check if custom sidebar icons feature is enabled via GSettings
+gboolean nemo_sidebar_custom_icons_enabled(void);
+
+// Get a custom icon name for a given URI, or NULL if none set
+gchar *nemo_sidebar_get_custom_icon_for_uri(const gchar *uri);
+
+// Set a custom icon for a given URI
+void nemo_sidebar_set_custom_icon_for_uri(const gchar *uri, const gchar *icon_name);
+
+// Clear custom icon for a given URI
+void nemo_sidebar_clear_custom_icon_for_uri(const gchar *uri);
+
+// Called during Nemo startup to initialize icon mapping
+void nemo_sidebar_custom_icons_init(void);
+
+G_END_DECLS
+
+#endif /* NEMO_PLACES_SIDEBAR_CUSTOM_ICONS_H */

--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -772,6 +772,19 @@ update_places (NemoPlacesSidebar *sidebar)
     /* home folder */
     mount_uri = nemo_get_home_directory_uri ();
     icon = get_icon_name (mount_uri); // Get default icon name
+        // --- Start of custom icon logic ---
+        gchar *custom_icon_name = NULL;
+        if (nemo_sidebar_custom_icons_enabled()) {
+            custom_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+        }
+
+        const gchar *icon_to_use = NULL;
+        if (custom_icon_name != NULL && *custom_icon_name != '\0') {
+            icon_to_use = custom_icon_name; // Use custom themed icon name
+        } else {
+            icon_to_use = get_icon_name (mount_uri); // Fallback to default bookmark icon name
+        }
+        // --- End of custom icon logic ---
 
     df_file = g_file_new_for_uri (mount_uri);
     full = get_disk_full (df_file, &tooltip_info);
@@ -781,7 +794,7 @@ update_places (NemoPlacesSidebar *sidebar)
     g_free (tooltip_info);
     cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                            SECTION_COMPUTER,
-                           _("Home"), icon, // Pass default icon name
+                           _("Home"), icon_to_use, // Pass default icon name
                            mount_uri, NULL, NULL, NULL, 0,
                            tooltip,
                            full, home_on_different_fs (mount_uri) && full > -1,
@@ -796,9 +809,22 @@ update_places (NemoPlacesSidebar *sidebar)
         desktop_path = nemo_get_desktop_directory ();
         mount_uri = g_filename_to_uri (desktop_path, NULL, NULL);
         icon = get_icon_name (mount_uri); // Get default icon name
+        // --- Start of custom icon logic ---
+        gchar *custom_icon_name = NULL;
+        if (nemo_sidebar_custom_icons_enabled()) {
+            custom_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+        }
+
+        const gchar *icon_to_use = NULL;
+        if (custom_icon_name != NULL && *custom_icon_name != '\0') {
+            icon_to_use = custom_icon_name; // Use custom themed icon name
+        } else {
+            icon_to_use = get_icon_name (mount_uri); // Fallback to default bookmark icon name
+        }
+        // --- End of custom icon logic ---
         cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                                SECTION_COMPUTER,
-                               _("Desktop"), icon, // Pass default icon name
+                               _("Desktop"), icon_to_use, // Pass default icon name
                                mount_uri, NULL, NULL, NULL, 0,
                                _("Open the contents of your desktop in a folder"), 0, FALSE,
                                cat_iter);
@@ -865,9 +891,22 @@ update_places (NemoPlacesSidebar *sidebar)
         if (n > 0) {
             mount_uri = (char *)"favorites:///"; /* No need to strdup */
             icon = "xapp-user-favorites-symbolic"; // Default icon name
+            // --- Start of custom icon logic ---
+            gchar *custom_icon_name = NULL;
+            if (nemo_sidebar_custom_icons_enabled()) {
+                custom_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+            }
+
+            const gchar *icon_to_use = NULL;
+            if (custom_icon_name != NULL && *custom_icon_name != '\0') {
+                icon_to_use = custom_icon_name; // Use custom themed icon name
+            } else {
+                icon_to_use = "xapp-user-favorites-symbolic"; // Fallback to default bookmark icon name
+            }
+            // --- End of custom icon logic ---
             cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                                   SECTION_COMPUTER,
-                                  _("Favorites"), icon, mount_uri, // Pass default icon name
+                                  _("Favorites"), icon_to_use, mount_uri, // Pass default icon name
                                   NULL, NULL, NULL, 0,
                                   _("Favorite files"), 0, FALSE, cat_iter);
 
@@ -882,9 +921,22 @@ update_places (NemoPlacesSidebar *sidebar)
     if (recent_enabled && eel_vfs_supports_uri_scheme ("recent")) {
         mount_uri = (char *)"recent:///"; /* No need to strdup */
         icon = NEMO_ICON_SYMBOLIC_FOLDER_RECENT; // Default icon name
+        // --- Start of custom icon logic ---
+        gchar *custom_icon_name = NULL;
+        if (nemo_sidebar_custom_icons_enabled()) {
+            custom_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+        }
+
+        const gchar *icon_to_use = NULL;
+        if (custom_icon_name != NULL && *custom_icon_name != '\0') {
+            icon_to_use = custom_icon_name; // Use custom themed icon name
+        } else {
+            icon_to_use = NEMO_ICON_SYMBOLIC_FOLDER_RECENT; // Fallback to default bookmark icon name
+        }
+        // --- End of custom icon logic ---
         cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                               SECTION_COMPUTER,
-                              _("Recent"), icon, mount_uri, // Pass default icon name
+                              _("Recent"), icon_to_use, mount_uri, // Pass default icon name
                               NULL, NULL, NULL, 0,
                               _("Recent files"), 0, FALSE, cat_iter);
 
@@ -896,7 +948,19 @@ update_places (NemoPlacesSidebar *sidebar)
     /* file system root */
     mount_uri = (char *)"file:///"; /* No need to strdup */
     icon = NEMO_ICON_SYMBOLIC_FILESYSTEM; // Default icon name
+    // --- Start of custom icon logic ---
+        gchar *custom_system_icon_name = NULL;
+        if (nemo_sidebar_custom_icons_enabled()) {
+            custom_system_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+        }
 
+        const gchar *system_icon_to_use = NULL;
+        if (custom_system_icon_name != NULL && *custom_system_icon_name != '\0') {
+            system_icon_to_use = custom_system_icon_name; // Use custom themed icon name
+        } else {
+            system_icon_to_use = NEMO_ICON_SYMBOLIC_FILESYSTEM; // Fallback to default bookmark icon name
+        }
+    // --- End of custom icon logic ---
     df_file = g_file_new_for_uri (mount_uri);
     full = get_disk_full (df_file, &tooltip_info);
     g_clear_object (&df_file);
@@ -905,7 +969,7 @@ update_places (NemoPlacesSidebar *sidebar)
     g_free (tooltip_info);
     cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                            SECTION_COMPUTER,
-                           _("File System"), icon, // Pass default icon name
+                           _("File System"), system_icon_to_use, // Pass default icon name
                            mount_uri, NULL, NULL, NULL, 0,
                            tooltip,
                            full, full > -1,
@@ -919,13 +983,27 @@ update_places (NemoPlacesSidebar *sidebar)
     if (eel_vfs_supports_uri_scheme("trash")) {
         mount_uri = (char *)"trash:///"; /* No need to strdup */
         icon = nemo_trash_monitor_get_symbolic_icon_name (); // Default icon name
+        // --- Start of custom icon logic ---
+        gchar *custom_icon_name = NULL;
+        if (nemo_sidebar_custom_icons_enabled()) {
+            custom_icon_name = nemo_sidebar_get_custom_icon_for_uri(mount_uri);
+        }
+
+        const gchar *icon_to_use = NULL;
+        if (custom_icon_name != NULL && *custom_icon_name != '\0') {
+            icon_to_use = custom_icon_name; // Use custom themed icon name
+        } else {
+            icon_to_use = nemo_trash_monitor_get_symbolic_icon_name (); // Fallback to default bookmark icon name
+        }
+        // --- End of custom icon logic ---
         cat_iter = add_place (sidebar, PLACES_BUILT_IN,
                                SECTION_COMPUTER,
-                               _("Trash"), icon, mount_uri, // Pass default icon name
+                               _("Trash"), icon_to_use, mount_uri, // Pass default icon name
                                NULL, NULL, NULL, 0,
                                _("Open the trash"), 0, FALSE,
                                cat_iter);
         g_free (icon);
+        g_free (custom_icon_name); // Free custom_icon_name if it was allocated
     }
 
     cat_iter = add_heading (sidebar, SECTION_BOOKMARKS,
@@ -2310,7 +2388,7 @@ update_menu_states (NemoPlacesSidebar *sidebar)
 	gboolean show_properties;
 	char *uri = NULL;
 
-	type = PLACES_BUILT_IN;
+	type = PLACES_BUILT_IN; // Initialize to a default type
 
 	if (sidebar->popup_menu == NULL) {
 		return;
@@ -2346,8 +2424,11 @@ update_menu_states (NemoPlacesSidebar *sidebar)
     set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_ADD_BOOKMARK, (type == PLACES_MOUNTED_VOLUME));
     set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_SIDEBAR_REMOVE, (type == PLACES_BOOKMARK));
     set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_RENAME, (type == PLACES_BOOKMARK));
-    // Add this line to make the "Set Custom Icon" action visible for bookmarks
-    set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_SET_CUSTOM_ICON, (type == PLACES_BOOKMARK));
+
+    // MODIFIED LINE: Make "Set Custom Icon" visible for Bookmarks AND Built-In places
+    set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_SET_CUSTOM_ICON,
+                        (type == PLACES_BOOKMARK || type == PLACES_BUILT_IN));
+
     set_action_visible (sidebar->bookmark_action_group, NEMO_ACTION_EMPTY_TRASH_CONDITIONAL, !nemo_trash_monitor_is_empty ());
 
  	check_visibility (mount, volume, drive,
@@ -2422,6 +2503,7 @@ update_menu_states (NemoPlacesSidebar *sidebar)
     g_clear_object (&volume);
     g_clear_object (&mount);
 }
+
 
 
 /* Callback used when the selection in the shortcuts tree changes */


### PR DESCRIPTION
[![Screenshot from 2025-07-08 21-51-07](https://i.ibb.co/Lzf0kKwB/Screenshot-from-2025-07-08-21-51-07.png)](https://ibb.co/1fx0vcVB)

[![Screenshot from 2025-07-08 13-38-59](https://i.ibb.co/RG7HCLWj/Screenshot-from-2025-07-08-13-38-59.png)](https://ibb.co/CpW0nxFP)

[![Screenshot from 2025-07-08 13-39-09](https://i.ibb.co/2Y7M0M4Z/Screenshot-from-2025-07-08-13-39-09.png)](https://ibb.co/zHh2W2v6)

I do not expect this PR to be accepted directly. You may view the new files, and changes via diff. This is more for getting views for consideration of such an update. If you would consider this PR, I can finish removing some of the fluff and no longer used "icon=","g_free(icon)" and finish with the rest as needed.

Opt-in to enable, otherwise defaults to normal nemo standard places icons.

To enable use: gsettings set org.nemo.sidebar-panels.custom-icons use-custom-sidebar-icons true
with the updated nemo gschema.

To disable and return to standard nemo symbolic places icons simply set back to false.

New files, 
/src/nemo-places-sidebar-custom-icons.h
/src/nemo-places-sidebar-custom-icons.c

Updates to: 
org.nemo.gschema.xml
nemo-places-sidebar.c
/src/meson.build
nemo-places-sidebar-ui.xml
nemo-actions.h

I think that's it! Thanks. 

My fork has minor details in the readme/a version 6.4.6 bump that definitely don't need to be merged either. Let me know if you like the thought/idea and you can reject this PR, then I can fix it up proper. Do as you wish.

