### PR TITLE
add --select compatibility flag

### DIFF
--- a/src/nemo-main-application.c
+++ b/src/nemo-main-application.c
@@ -656,6 +656,7 @@ nemo_main_application_local_command_line (GApplication *application,
 	gboolean kill_shell = FALSE;
 	gboolean no_default_window = FALSE;
     gboolean no_desktop_ignored = FALSE;
+    gboolean select_ignored = FALSE;
 	gboolean fix_cache = FALSE;
     gboolean debug = FALSE;
 	gchar **remaining = NULL;
@@ -678,6 +679,8 @@ nemo_main_application_local_command_line (GApplication *application,
 		{ "no-default-window", 'n', 0, G_OPTION_ARG_NONE, &no_default_window,
 		  N_("Only create windows for explicitly specified URIs."), NULL },
         { "no-desktop", '\0', 0, G_OPTION_ARG_NONE, &no_desktop_ignored,
+          N_("Ignored argument - left for compatibility only."), NULL },
+        { "select", 's', 0, G_OPTION_ARG_NONE, &select_ignored,
           N_("Ignored argument - left for compatibility only."), NULL },
 		{ "tabs", 't', 0, G_OPTION_ARG_NONE, &open_in_tabs,
 		  N_("Open URIs in tabs."), NULL },


### PR DESCRIPTION
Some scripts rely on the `--select` flag to highlight files in file managers. While `caja`, `dolphin`, and `nautilus` support this flag, `nemo` currently does not.

This simple PR adds support for the `--select` flag in `nemo`. Although `nemo` already supports selecting files by default, passing `--select` currently triggers an argument parser error.

With this change, `--select` will be accepted by `nemo` without errors, improving compatibility with scripts expecting this flag.
