### PR TITLE
Fix drag and drop from inactive panels

### DIFF
--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -1120,7 +1120,6 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
     if (!nemo_view_get_active (NEMO_VIEW (view))) {
         NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
         nemo_window_slot_make_hosting_pane_active (slot);
-        return TRUE;
     }
 
 	nemo_list_model_set_drag_view


### PR DESCRIPTION
**Problem Description**

When using "Extra Pane" mode (two panels), users cannot drag files from an inactive panel to an active one. The issue occurs because:

1. **File selection is blocked** - clicking on files in inactive panels doesn't select them
2. **Drag and drop is prevented** - drag operations can only start from active panels
3. **Poor UX** - users must first click on the inactive panel to activate it, then click again to select files

**Root Cause Analysis**
The problem was in the button_press_callback function in [src/nemo-list-view.c at line 1123](https://github.com/linuxmint/nemo/blob/5e4e84bc29e83e19f45bc0b6057edde4cb37cb0e/src/nemo-list-view.c#L1123). When a user clicked on an inactive panel:

```c
if (!nemo_view_get_active (NEMO_VIEW (view))) {
    NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
    nemo_window_slot_make_hosting_pane_active (slot);
    return TRUE;  // ← This was the problem.
}
```

The `return TRUE;` statement immediately terminated the button press event processing, preventing:

- File selection
- Drag state initialization (drag_button setting)
- Subsequent drag and drop operations

**What This Fix Achieves**

1. **Panel Activation** - The inactive panel becomes active when clicked (as before).
2. **Event Continuation** - Button press processing continues normally
3. **File Selection** - Files can now be selected in previously inactive panels
5. **Cross-Panel Operations** - Users can drag files between panels without extra clicks

**DEMO**

<details>

<summary>Before</summary>

https://github.com/user-attachments/assets/56d45ee7-834b-4b61-9cb6-3feba8ac3e70

</details>


<details>

<summary>After</summary>

https://github.com/user-attachments/assets/e5494e8f-8bef-4c0b-926d-be0c39f915dd

</details>





