### PR TITLE
toolbar/terminal: Open in selected sub-folder, in expanded list-view

### DIFF
--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -1357,7 +1357,7 @@ action_open_terminal_callback(GtkAction *action, gpointer callback_data)
     view = get_current_view (window);
 
     gchar *path;
-    gchar *uri = nemo_view_get_uri (view);
+    gchar *uri = nemo_view_get_backing_uri (view);
     GFile *gfile = g_file_new_for_uri (uri);
     path = g_file_get_path (gfile);
     open_in_terminal_other (path);


### PR DESCRIPTION
Hi,

In the list view, you can expand folders to view their content without actually navigating into them, potentially multiple levels deep at once. The `Open Terminal in the active folder` button on the toolbar does not work well in such situations, as it always opens the terminal in the top/root folder, even if a folder deep down in the expanded hierarchy is selected.

This PR proposes and implements a change in this behaviour, making the terminal toolbar button work the same way as the `Create a new folder` button, which does take into account the currently selected folder in the hierarchy.

- If no folder is selected, opens terminal in the top-most folder.
- If a non-expanded folder or a file is selected, opens terminal in its parent's directory.
- If an expanded folder is selected, opens terminal in the selected folder.

I was inspired to use `nemo_view_get_backing_uri()` from `nemo_view_new_folder()`. Tested on 6.4.5.