### PR TITLE
nemo-file-utilities.c: Move directory lookup after special case returns

### DIFF
--- a/libnemo-private/nemo-file-utilities.c
+++ b/libnemo-private/nemo-file-utilities.c
@@ -479,11 +479,6 @@ nemo_get_xdg_dir (const char *type)
 		update_xdg_dir_cache ();
 	}
 
-	for (i = 0 ; cached_xdg_dirs != NULL && cached_xdg_dirs[i].type != NULL; i++) {
-		if (strcmp (cached_xdg_dirs[i].type, type) == 0) {
-			return g_strdup (cached_xdg_dirs[i].path);
-		}
-	}
 	if (strcmp ("DESKTOP", type) == 0) {
 		return g_build_filename (g_get_home_dir (), DESKTOP_DIRECTORY_NAME, NULL);
 	}
@@ -491,6 +486,11 @@ nemo_get_xdg_dir (const char *type)
 		return g_build_filename (g_get_home_dir (), "Templates", NULL);
 	}
 
+	for (i = 0 ; cached_xdg_dirs != NULL && cached_xdg_dirs[i].type != NULL; i++) {
+		if (strcmp (cached_xdg_dirs[i].type, type) == 0) {
+			return g_strdup (cached_xdg_dirs[i].path);
+		}
+	}
 	return g_strdup (g_get_home_dir ());
 }
 


### PR DESCRIPTION
Without this, the function will return early with the home directory as the value before executing the additional conditionals.