### PR TITLE
Fix for progress handling

### DIFF
--- a/src/nemo-progress-ui-handler.c
+++ b/src/nemo-progress-ui-handler.c
@@ -314,6 +314,9 @@ progress_info_changed_cb (NemoProgressInfo *info,
         double progress = 0.0;
         int i = 0;
         for (l = self->priv->infos; l != NULL; l = l->next) {
+            if (nemo_progress_info_get_is_finished (l->data)) {
+                continue;
+            }
             progress = (progress + nemo_progress_info_get_progress (l->data)) / (double) ++i;
         }
         if (progress > 0) {


### PR DESCRIPTION
This fixes a bug where nemo didn't notify the window manager that a progress was finished.Instead, the window thinks it's at 100% and counting until the next file operation starts and the new progress is told to the window manager.