### PR TITLE
Restore Last Window Tabs on Startup

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1257,6 +1257,23 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="restore_tabs_on_startup_checkbutton">
+                                            <property name="label" translatable="yes">Restore last window tabs on startup</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="padding">3</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="expand_row_on_dnd_dwell_checkbutton">
                                             <property name="label" translatable="yes">Automatically expand rows during drag-and-drop</property>
                                             <property name="visible">True</property>
@@ -1269,7 +1286,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">4</property>
+                                            <property name="position">5</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -144,6 +144,7 @@ typedef enum
 #define NEMO_PREFERENCES_CLOSE_DEVICE_VIEW_ON_EJECT "close-device-view-on-device-eject"
 
 #define NEMO_PREFERENCES_START_WITH_DUAL_PANE "start-with-dual-pane"
+#define NEMO_PREFERENCES_RESTORE_TABS_ON_STARTUP "restore-tabs-on-startup"
 #define NEMO_PREFERENCES_IGNORE_VIEW_METADATA "ignore-view-metadata"
 #define NEMO_PREFERENCES_SHOW_BOOKMARKS_IN_TO_MENUS "show-bookmarks-in-to-menus"
 #define NEMO_PREFERENCES_SHOW_PLACES_IN_TO_MENUS "show-places-in-to-menus"

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -122,6 +122,13 @@ typedef enum
 #define NEMO_WINDOW_STATE_DEVICES_EXPANDED      "devices-expanded"
 #define NEMO_WINDOW_STATE_NETWORK_EXPANDED      "network-expanded"
 
+/* Saved session (last closed window) */
+#define NEMO_WINDOW_STATE_SAVED_SPLIT_VIEW      "saved-split-view"
+#define NEMO_WINDOW_STATE_SAVED_TABS_LEFT       "saved-tabs-left"
+#define NEMO_WINDOW_STATE_SAVED_TABS_RIGHT      "saved-tabs-right"
+#define NEMO_WINDOW_STATE_SAVED_ACTIVE_TAB_LEFT "saved-active-tab-left"
+#define NEMO_WINDOW_STATE_SAVED_ACTIVE_TAB_RIGHT "saved-active-tab-right"
+
 /* Sorting order */
 #define NEMO_PREFERENCES_SORT_DIRECTORIES_FIRST		"sort-directories-first"
 #define NEMO_PREFERENCES_SORT_FAVORITES_FIRST		"sort-favorites-first"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -346,6 +346,11 @@
       <summary>Whether to default to showing dual-pane view when a new window is opened</summary>
       <description>If set to true, new Nemo windows will default to showing two panes</description>
     </key>
+    <key name="restore-tabs-on-startup" type="b">
+      <default>false</default>
+      <summary>Restore the previous window tabs on startup</summary>
+      <description>If set to true, Nemo will restore the last saved window tab state when launched without explicit locations.</description>
+    </key>
     <key name="ignore-view-metadata" type="b">
       <default>false</default>
       <summary>Whether to ignore folder metadata for view zoom levels and layouts</summary>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -702,6 +702,33 @@
       <summary>Side pane view</summary>
       <description>The side pane view to show in newly opened windows.</description>
     </key>
+
+    <!-- Saved session (last closed window) -->
+    <key name="saved-split-view" type="b">
+      <default>false</default>
+      <summary>Whether split view was enabled when the last window was closed</summary>
+      <description>Internal setting used to restore the last closed window's split view and tabs.</description>
+    </key>
+    <key name="saved-tabs-left" type="as">
+      <default>[]</default>
+      <summary>Saved tab URIs for the left pane</summary>
+      <description>Internal setting used to restore the last closed window's tabs for the left pane.</description>
+    </key>
+    <key name="saved-tabs-right" type="as">
+      <default>[]</default>
+      <summary>Saved tab URIs for the right pane</summary>
+      <description>Internal setting used to restore the last closed window's tabs for the right pane.</description>
+    </key>
+    <key name="saved-active-tab-left" type="i">
+      <default>0</default>
+      <summary>Index of the active tab in the left pane</summary>
+      <description>Internal setting used to restore which tab was active in the left pane.</description>
+    </key>
+    <key name="saved-active-tab-right" type="i">
+      <default>0</default>
+      <summary>Index of the active tab in the right pane</summary>
+      <description>Internal setting used to restore which tab was active in the right pane.</description>
+    </key>
   </schema>
 
   <schema id="org.nemo.plugins" path="/org/nemo/plugins/" gettext-domain="nemo">

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -534,6 +534,17 @@ nemo_application_quit (NemoApplication *self)
 	GList *windows;
 
 	windows = gtk_application_get_windows (GTK_APPLICATION (app));
+
+	/* Save session state once, based on the active Nemo window, before we
+	 * destroy all windows. Destroying multiple windows can otherwise overwrite
+	 * the stored state with an arbitrary last-destroyed window. */
+	{
+		GtkWindow *active = gtk_application_get_active_window (GTK_APPLICATION (app));
+		if (active != NULL && NEMO_IS_WINDOW (active)) {
+			nemo_window_save_session_state_for_quit (NEMO_WINDOW (active));
+		}
+	}
+
 	g_list_foreach (windows, (GFunc) gtk_widget_destroy, NULL);
 
     /* we have been asked to force quit */

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -555,11 +555,17 @@ nemo_application_quit (NemoApplication *self)
 		for (GList *l = windows; l != NULL; l = l->next) {
 			GtkWindow *w = GTK_WINDOW (l->data);
 
-			if (!NEMO_IS_WINDOW (w) || NEMO_IS_DESKTOP_WINDOW (w)) {
+			if (!NEMO_IS_WINDOW (w)) {
 				continue;
 			}
 
 			NemoWindow *nw = NEMO_WINDOW (w);
+
+			/* Avoid saving the desktop window */
+			if (nw->details != NULL && nw->details->disable_chrome) {
+				continue;
+			}
+
 			gint pane_count = g_list_length (nw->details->panes);
 			gint tab_count = 0;
 

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -566,12 +566,26 @@ nemo_application_quit (NemoApplication *self)
 				continue;
 			}
 
-			gint pane_count = g_list_length (nw->details->panes);
+			/* Prefer windows that are actually in split view and have more tabs. */
+			GtkPaned *paned = GTK_PANED (nw->details->split_view_hpane);
+			GtkWidget *child1 = gtk_paned_get_child1 (paned);
+			GtkWidget *child2 = gtk_paned_get_child2 (paned);
+
+			gint pane_count = 0;
 			gint tab_count = 0;
 
-			for (GList *p = nw->details->panes; p != NULL; p = p->next) {
-				NemoWindowPane *pane = p->data;
-				if (pane != NULL && pane->notebook != NULL) {
+			if (child1 != NULL) {
+				NemoWindowPane *pane = NEMO_WINDOW_PANE (child1);
+				pane_count++;
+				if (pane->notebook != NULL) {
+					tab_count += gtk_notebook_get_n_pages (GTK_NOTEBOOK (pane->notebook));
+				}
+			}
+
+			if (child2 != NULL) {
+				NemoWindowPane *pane = NEMO_WINDOW_PANE (child2);
+				pane_count++;
+				if (pane->notebook != NULL) {
 					tab_count += gtk_notebook_get_n_pages (GTK_NOTEBOOK (pane->notebook));
 				}
 			}

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -586,7 +586,7 @@ nemo_application_quit (NemoApplication *self)
 		}
 
 		if (best != NULL) {
-			nemo_window_save_session_state_for_quit (best);
+			nemo_window_save_session_state (best);
 		}
 	}
 

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -30,6 +30,8 @@
 
 #include "nemo-application.h"
 
+#include "nemo-desktop-window.h"
+
 #if (defined(ENABLE_EMPTY_VIEW) && ENABLE_EMPTY_VIEW)
 #include "nemo-empty-view.h"
 #endif /* ENABLE_EMPTY_VIEW */
@@ -547,14 +549,13 @@ nemo_application_quit (NemoApplication *self)
 				continue;
 			}
 
-			NemoWindow *nw = NEMO_WINDOW (w);
-
 			/* Avoid saving the desktop window */
-			if (nw->details != NULL && nw->details->disable_chrome) {
+			if (NEMO_IS_DESKTOP_WINDOW (w)) {
 				continue;
 			}
 
-			last_window = nw;
+			last_window = NEMO_WINDOW (w);
+			break;
 		}
 
 		if (last_window != NULL) {

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -99,6 +99,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_DETECT_CONTENT_MEDIA_WIDGET "media_detect_content_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_ADVANCED_PERMISSIONS_WIDGET "show_advanced_permissions_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET "start_with_dual_pane_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_RESTORE_TABS_ON_STARTUP_WIDGET "restore_tabs_on_startup_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_IN_TO_MENUS_WIDGET "places_in_to_checkbutton"
@@ -1066,6 +1067,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET,
                        NEMO_PREFERENCES_START_WITH_DUAL_PANE);
+
+    bind_builder_bool (builder, nemo_preferences,
+                       NEMO_FILE_MANAGEMENT_PROPERTIES_RESTORE_TABS_ON_STARTUP_WIDGET,
+                       NEMO_PREFERENCES_RESTORE_TABS_ON_STARTUP);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET,

--- a/src/nemo-main-application.c
+++ b/src/nemo-main-application.c
@@ -477,6 +477,7 @@ open_windows (NemoMainApplication *application,
 		/* No explicit locations requested: try restoring the last session. */
 		NemoWindow *window;
 		gboolean have_geometry;
+		gboolean do_restore;
 
 		window = nemo_main_application_create_window (NEMO_APPLICATION (application), screen);
 
@@ -493,7 +494,9 @@ open_windows (NemoMainApplication *application,
 									 FALSE);
 		}
 
-		if (!nemo_window_restore_saved_tabs (window)) {
+		do_restore = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_RESTORE_TABS_ON_STARTUP);
+
+		if (!do_restore || !nemo_window_restore_saved_tabs (window)) {
 			/* Fall back to a safe default location */
 			GFile *home = g_file_new_for_path (g_get_home_dir ());
 			nemo_window_go_to (window, home);

--- a/src/nemo-window-private.h
+++ b/src/nemo-window-private.h
@@ -155,6 +155,7 @@ void                 nemo_window_set_active_pane                     (NemoWindow
 NemoWindowPane * nemo_window_get_active_pane                     (NemoWindow *window);
 
 gboolean nemo_window_restore_saved_tabs                              (NemoWindow *window);
+void nemo_window_save_session_state_for_quit                         (NemoWindow *window);
 
 
 /* sync window GUI with current slot. Used when changing slots,

--- a/src/nemo-window-private.h
+++ b/src/nemo-window-private.h
@@ -155,7 +155,7 @@ void                 nemo_window_set_active_pane                     (NemoWindow
 NemoWindowPane * nemo_window_get_active_pane                     (NemoWindow *window);
 
 gboolean nemo_window_restore_saved_tabs                              (NemoWindow *window);
-void nemo_window_save_session_state_for_quit                         (NemoWindow *window);
+void nemo_window_save_session_state                                  (NemoWindow *window);
 
 
 /* sync window GUI with current slot. Used when changing slots,

--- a/src/nemo-window-private.h
+++ b/src/nemo-window-private.h
@@ -154,6 +154,8 @@ void                 nemo_window_set_active_pane                     (NemoWindow
                                                                           NemoWindowPane *new_pane);
 NemoWindowPane * nemo_window_get_active_pane                     (NemoWindow *window);
 
+gboolean nemo_window_restore_saved_tabs                              (NemoWindow *window);
+
 
 /* sync window GUI with current slot. Used when changing slots,
  * and when updating the slot state.

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -837,6 +837,10 @@ nemo_window_destroy (GtkWidget *object)
 
 	DEBUG ("Destroying window");
 
+	/* Ensure session state is saved even when the application quits by
+	 * destroying windows directly (bypassing delete-event/close). */
+	nemo_window_save_session_state (window);
+
 	/* close the sidebar first */
 	nemo_window_tear_down_sidebar (window);
 

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -837,10 +837,6 @@ nemo_window_destroy (GtkWidget *object)
 
 	DEBUG ("Destroying window");
 
-	/* Ensure session state is saved even when the application quits by
-	 * destroying windows directly (bypassing delete-event/close). */
-	nemo_window_save_session_state (window);
-
 	/* close the sidebar first */
 	nemo_window_tear_down_sidebar (window);
 
@@ -2143,6 +2139,12 @@ nemo_window_save_session_state (NemoWindow *window)
 
 	g_strfreev (left_uris);
 	g_strfreev (right_uris);
+}
+
+void
+nemo_window_save_session_state_for_quit (NemoWindow *window)
+{
+	nemo_window_save_session_state (window);
 }
 
 static void

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -2185,14 +2185,11 @@ clear_pane_to_single_slot (NemoWindowPane *pane)
 static void
 open_uri_list_in_pane (NemoWindowPane *pane, char **uris)
 {
-	NemoWindow *window;
 	int i;
 
 	if (pane == NULL) {
 		return;
 	}
-
-	window = pane->window;
 
 	/* If no URIs were saved for this pane, leave its first tab alone */
 	if (uris == NULL || uris[0] == NULL) {
@@ -2227,11 +2224,6 @@ open_uri_list_in_pane (NemoWindowPane *pane, char **uris)
 		location = g_file_new_for_uri (uris[i]);
 		nemo_window_slot_open_location (slot, location, 0);
 		g_object_unref (location);
-
-		/* Avoid leaving the window's active slot on the last tab we opened */
-		if (window != NULL && i == 0) {
-			nemo_window_set_active_slot (window, slot);
-		}
 	}
 }
 

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -2106,7 +2106,7 @@ collect_pane_saved_tab_uris (NemoWindowPane *pane, gint *active_index_out)
 	return (char **) g_ptr_array_free (arr, FALSE);
 }
 
-static void
+void
 nemo_window_save_session_state (NemoWindow *window)
 {
 	NemoWindowPane *left_pane;
@@ -2146,12 +2146,6 @@ nemo_window_save_session_state (NemoWindow *window)
 
 	g_strfreev (left_uris);
 	g_strfreev (right_uris);
-}
-
-void
-nemo_window_save_session_state_for_quit (NemoWindow *window)
-{
-	nemo_window_save_session_state (window);
 }
 
 static void


### PR DESCRIPTION
Adds an optional feature to restore the tabs and split-view state of the last closed Nemo window when launching without explicit file arguments. This is similar to the 'session restore' feature in most modern web browsers.

## Changes

- **New preference**: "Restore last window tabs on startup" toggle in Preferences → Behaviour (default: off)
- **Session state storage**: Saves tab URIs, active tab indices, and split-view state when a window is closed
- **Restore logic**: On startup (when no file arguments provided), restores saved tabs if the preference is enabled
- **Fallback behavior**: Falls back to opening Home directory if restore fails or preference is disabled

## Implementation Details

- Session state is saved to GSettings keys under `org.nemo.window-state` schema
- Only native file system locations are saved (excludes search tabs and remote locations)
- When multiple windows are open on quit, the state of the last non-desktop window is saved
- Default startup behavior is unchanged (feature is opt-in)
