### PR TITLE
nemo-places-sidebar.c: Restore visibility of mounts with no associated volume

### DIFF
--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -987,6 +987,21 @@ update_places (NemoPlacesSidebar *sidebar)
             }
         }
 
+        icon = nemo_get_mount_icon_name (mount);
+        mount_uri = g_file_get_uri (root);
+        name = g_mount_get_name (mount);
+        tooltip = g_file_get_parse_name (root);
+        place_info = new_place_info (PLACES_MOUNTED_VOLUME,
+                                     SECTION_DEVICES,
+                                     name, icon, mount_uri,
+                                     NULL, NULL, mount, 0, tooltip, 0, FALSE);
+        place_infos = g_list_prepend (place_infos, place_info);
+
+        g_free (icon);
+        g_free (name);
+        g_free (mount_uri);
+        g_free (tooltip);
+
         g_object_unref (root);
         g_object_unref (mount);
     }


### PR DESCRIPTION
We started skipping these in 93815617c16, but there are some legitimate instances where these should be shown, and are still shown in other areas of Nemo (the desktop, the move/copy-to submenus).

One case is Virtualbox shared folders. If sharing a host folder with a guest and no mount point is provided, guest-additions mounts this in /media and it shows up in the GVolumeMonitor (and desktop, etc...). If a mount-point *is* provided, and that folder exists on the guest, the mount is *not* visible in a GVolumeMonitor, and will not be visible in Nemo, except as a normal folder. This seems logical.

Another seems to be cifs/samba mounts, depending on how they're mounted. Using smb:// uris causes these to appear in the Network section, but using mount they no longer appear in the sidebar in any section.

The other part of that commit, skipping shadowed mounts, remains correct - and these other places mentioned above were already filtering these out as well.

Ref:
linuxmint/mint22.3-beta#67.