### PR TITLE
Add Keyboard Shortcut for Open in Terminal

### DIFF
--- a/gresources/nemo-shortcuts.ui
+++ b/gresources/nemo-shortcuts.ui
@@ -122,6 +122,13 @@
                 <property name="accelerator">&lt;Primary&gt;&lt;alt&gt;O</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Open in Terminal</property>
+                <property name="accelerator">&lt;shift&gt;F4</property>
+              </object>
+            </child>
 
           </object>
         </child>

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -8246,7 +8246,7 @@ static const GtkActionEntry directory_view_entries[] = {
   /* tooltip */                  N_("Open each selected item in a new tab"),
 				 G_CALLBACK (action_open_new_tab_callback) },
   /* name, stock id */         { NEMO_ACTION_OPEN_IN_TERMINAL, "xsi-utilities-terminal-symbolic",
-  /* label, accelerator */       N_("Open in Terminal"), "",
+  /* label, accelerator */       N_("Open in Terminal"), "<shift>F4",
   /* tooltip */                  N_("Open terminal in the selected folder"),
 				 G_CALLBACK (action_open_in_terminal_callback) },
   /* name, stock id */         { NEMO_ACTION_OPEN_AS_ROOT, "xsi-dialog-password-symbolic",


### PR DESCRIPTION
Hi Linux Mint Team!

Hope you don't mind adding this shortcut. The shortcut to open the terminal at the current directory is commonly bound to "F4" or "Shift+F4" in other file managers like SpaceFM and Dolphin. I chose "Shift+F4" as it's the same shortcut as Dolphin's one, and shouldn't interfere with F4 being used for the embedded terminal plugin, or the WIP PR that might replace it #3567

Thanks.