### PR TITLE
[Bugfix] Sort network mounts alphabetically

### DIFF
--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -373,6 +373,16 @@ sort_places_func (gconstpointer a,
     return g_utf8_collate (((PlaceInfo *) a)->name, ((PlaceInfo *) b)->name);
 }
 
+static gint
+sort_mounts_func (gconstpointer a,
+                  gconstpointer b)
+{
+    g_autofree gchar *name_a = g_mount_get_name (G_MOUNT (a));
+    g_autofree gchar *name_b = g_mount_get_name (G_MOUNT (b));
+
+    return g_utf8_collate (name_a, name_b);
+}
+
 static PlaceInfo *
 new_place_info (PlaceType place_type,
                 SectionType section_type,
@@ -1254,7 +1264,7 @@ update_places (NemoPlacesSidebar *sidebar)
 
 	g_list_free_full (network_volumes, g_object_unref);
 
-	network_mounts = g_list_reverse (network_mounts);
+	network_mounts = g_list_sort(network_mounts, sort_mounts_func);
 	for (l = network_mounts; l != NULL; l = l->next) {
 		mount = l->data;
 		root = g_mount_get_default_location (mount);


### PR DESCRIPTION
This is a fix for #3687, sorting network mounts alphabetically in the sidebar.

I didn't find any contributing guidelines in the repository, so please advice if something isn't quite right.

| Before | After |
|-----------|---------|
| <img width="240" height="139" alt="image" src="https://github.com/user-attachments/assets/dc8a88c6-69c0-4fa4-b237-149ba3d23b90" /> | <img width="242" height="140" alt="image" src="https://github.com/user-attachments/assets/2d4fe624-4757-4880-9448-778feac2649f" /> |

