### PR TITLE
add 'copy path' to context menus

### DIFF
--- a/gresources/nemo-directory-view-ui.xml
+++ b/gresources/nemo-directory-view-ui.xml
@@ -174,6 +174,7 @@
 	<placeholder name="File Clipboard Actions">
 		<menuitem name="Cut" action="Cut"/>
 		<menuitem name="Copy" action="Copy"/>
+		<menuitem name="Copy Path" action="Copy Path"/>
 		<menuitem name="Paste Files Into" action="Paste Files Into"/>
         <menuitem name="Duplicate" action="Duplicate"/>
 	</placeholder>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -3720,6 +3720,25 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                                 <property name="can-focus">True</property>
                                                 <property name="selectable">False</property>
                                                 <child>
+                                                  <object class="GtkCheckButton" id="selection_menu__copy_path_check">
+                                                    <property name="label" translatable="yes">Copy Pat_h</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="margin-left">2</property>
+                                                    <property name="margin-right">2</property>
+                                                    <property name="use-underline">True</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkListBoxRow">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="selectable">False</property>
+                                                <child>
                                                   <object class="GtkCheckButton" id="selection_menu__paste_check">
                                                     <property name="label" translatable="yes">_Paste</property>
                                                     <property name="visible">True</property>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -748,6 +748,10 @@
       <default>true</default>
       <summary>Show the selection context menu's Copy item.</summary>
     </key>
+    <key name="selection-menu-copy-path" type="b">
+      <default>true</default>
+      <summary>Show the selection context menu's Copy Path item.</summary>
+    </key>
     <key name="selection-menu-paste" type="b">
       <default>true</default>
       <summary>Show the selection context menu's Paste item.</summary>

--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -80,6 +80,7 @@
 #define NEMO_ACTION_CUT "Cut"
 #define NEMO_ACTION_LOCATION_CUT "LocationCut"
 #define NEMO_ACTION_COPY "Copy"
+#define NEMO_ACTION_COPY_PATH "Copy Path"
 #define NEMO_ACTION_LOCATION_COPY "LocationCopy"
 #define NEMO_ACTION_PASTE "Paste"
 #define NEMO_ACTION_PASTE_FILES_INTO "Paste Files Into"
@@ -193,6 +194,9 @@ static const ConfigurableMenuItemInfo CONFIGURABLE_MENU_ITEM_INFO [] = {
 
     { NEMO_ACTION_COPY, "selection_menu__copy_check",
      "/selection/File Clipboard Actions/Copy", "selection-menu-copy" },
+
+    { NEMO_ACTION_COPY_PATH, "selection_menu__copy_path_check",
+     "/selection/File Clipboard Actions/Copy Path", "selection-menu-copy-path" },
 
     { NEMO_ACTION_PASTE_FILES_INTO, "selection_menu__paste_check",
      "/selection/File Clipboard Actions/Paste Files Into", "selection-menu-paste" },

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -6781,6 +6781,49 @@ action_copy_files_callback (GtkAction *action,
 }
 
 static void
+action_copy_path_callback (GtkAction *action,
+			   gpointer callback_data)
+{
+	NemoView *view;
+	GList *selection, *l;
+	GString *path_string;
+	gboolean first;
+
+	view = NEMO_VIEW (callback_data);
+	selection = nemo_view_get_selection (view);
+
+	if (selection == NULL)
+		return;
+
+	path_string = g_string_new (NULL);
+	first = TRUE;
+
+	for (l = selection; l != NULL; l = l->next) {
+		char *path = nemo_file_get_path (NEMO_FILE (l->data));
+
+		if (!first)
+			g_string_append_c (path_string, '\n');
+
+		if (path != NULL) {
+			g_string_append (path_string, path);
+			g_free (path);
+		} else {
+			/* Non-local file: fall back to URI */
+			char *uri = nemo_file_get_uri (NEMO_FILE (l->data));
+			g_string_append (path_string, uri);
+			g_free (uri);
+		}
+		first = FALSE;
+	}
+
+	gtk_clipboard_set_text (nemo_clipboard_get (GTK_WIDGET (view)),
+				path_string->str, -1);
+
+	g_string_free (path_string, TRUE);
+	nemo_file_list_free (selection);
+}
+
+static void
 move_copy_selection_to_next_pane (NemoView *view,
 				  int copy_action)
 {
@@ -8282,6 +8325,10 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("_Copy"), "<control>C",
   /* tooltip */                  N_("Prepare the selected files to be copied with a Paste command"),
 				 G_CALLBACK (action_copy_files_callback) },
+  /* name, stock id */         { NEMO_ACTION_COPY_PATH, "xsi-edit-copy-symbolic",
+  /* label, accelerator */       N_("Copy Pat_h"), "",
+  /* tooltip */                  N_("Copy the path of the selected items to the clipboard"),
+				 G_CALLBACK (action_copy_path_callback) },
   /* name, stock id */         { "Paste", "xsi-edit-paste-symbolic",
   /* label, accelerator */       N_("_Paste"), "<control>V",
   /* tooltip */                  N_("Move or copy files previously selected by a Cut or Copy command"),
@@ -9931,6 +9978,10 @@ real_update_menus (NemoView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      NEMO_ACTION_COPY);
 	gtk_action_set_sensitive (action, can_copy_files);
+
+	action = gtk_action_group_get_action (view->details->dir_action_group,
+					      NEMO_ACTION_COPY_PATH);
+	gtk_action_set_sensitive (action, selection_count > 0);
 
 	real_update_paste_menu (view, selection, selection_count);
 


### PR DESCRIPTION
Adds a "Copy Path" item to the right-click context menu that copies the full path to the clipboard. For multiple selections, paths are on a line each. Falls back to URI for nonlocal files (smb://, ftp://, etc). Toggleable in Preferences / Context Menus. 

I followed the pattern for 'copy' more or less. One area I'm not sure, is the sensitivity check for NEMO_ACTION_COPY_PATH in real_update_menus(), because it's technically redundant since the selection menu only appears with a selection, but I followed the existing pattern (including 'copy') which use clipboard. Hope I did this right but pls let me know otherwise.