### PR TITLE
feat: match anywhere in filename during interactive search

### DIFF
--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -3875,8 +3875,7 @@ nemo_icon_container_search_iter (NemoIconContainer *container,
 			continue;
 		}
 
-		if (strncmp (case_normalized_key, case_normalized_name,
-			     strlen (case_normalized_key)) == 0) {
+		if (strstr (case_normalized_name, case_normalized_key) != NULL) {
 			count++;
 		}
 

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -191,6 +191,53 @@ G_DEFINE_TYPE (NemoListView, nemo_list_view, NEMO_TYPE_VIEW);
 
 static gint click_policy = NEMO_CLICK_POLICY_SINGLE;
 
+static gboolean
+list_view_search_equal_func (GtkTreeModel *model,
+                             gint search_column,
+                             const gchar *key,
+                             GtkTreeIter *iter,
+                             gpointer user_data)
+{
+	gchar *name = NULL;
+	gchar *normalized_key = NULL;
+	gchar *case_normalized_key = NULL;
+	gchar *normalized_name = NULL;
+	gchar *case_normalized_name = NULL;
+	gboolean is_match = FALSE;
+
+	(void) user_data;
+
+	if (key == NULL || key[0] == '\0') {
+		return TRUE;
+	}
+
+	gtk_tree_model_get (model, iter, search_column, &name, -1);
+	if (name == NULL) {
+		return TRUE;
+	}
+
+	normalized_key = g_utf8_normalize (key, -1, G_NORMALIZE_ALL);
+	normalized_name = g_utf8_normalize (name, -1, G_NORMALIZE_ALL);
+
+	if (normalized_key != NULL && normalized_name != NULL) {
+		case_normalized_key = g_utf8_casefold (normalized_key, -1);
+		case_normalized_name = g_utf8_casefold (normalized_name, -1);
+
+		if (case_normalized_key != NULL && case_normalized_name != NULL) {
+			is_match = strstr (case_normalized_name, case_normalized_key) != NULL;
+		}
+	}
+
+	g_free (case_normalized_name);
+	g_free (normalized_name);
+	g_free (case_normalized_key);
+	g_free (normalized_key);
+	g_free (name);
+
+	/* GtkTreeView expects FALSE for a row that matches. */
+	return !is_match;
+}
+
 static const char * default_trash_visible_columns[] = {
 	"name", "size", "type", "trashed_on", "trash_orig_path", NULL
 };
@@ -2538,6 +2585,10 @@ create_and_set_up_tree_view (NemoListView *view)
 							NULL);
 
 	gtk_tree_view_set_enable_search (view->details->tree_view, TRUE);
+	gtk_tree_view_set_search_equal_func (view->details->tree_view,
+					     list_view_search_equal_func,
+					     view,
+					     NULL);
 
 	/* Don't handle backspace key. It's used to open the parent folder. */
 	binding_set = gtk_binding_set_by_class (GTK_WIDGET_GET_CLASS (view->details->tree_view));


### PR DESCRIPTION
## Summary

Changes the interactive type-ahead search (the search that activates when you start typing in a file view) to match **anywhere** in the filename instead of only matching from the beginning.

### Changes

- **Icon view** (`nemo-icon-container.c`): Changed `strncmp(key, name, strlen(key))` → `strstr(name, key)` so typing e.g. "log" matches "changelog.txt"
- **List view** (`nemo-list-view.c`): Added a custom `search_equal_func` that normalizes both the search key and filename to UTF-8 NFD + casefold, then uses `strstr` for substring matching

### Motivation

The prefix-only matching behavior is unintuitive — users often know part of a filename but not the exact beginning. Substring matching is the standard in most modern file managers.

Inspired by https://github.com/linuxmint/nemo/pull/3714