### PR TITLE
feat: add 'Copy Path' to context menu

### DIFF
--- a/gresources/nemo-directory-view-ui.xml
+++ b/gresources/nemo-directory-view-ui.xml
@@ -174,6 +174,7 @@
 	<placeholder name="File Clipboard Actions">
 		<menuitem name="Cut" action="Cut"/>
 		<menuitem name="Copy" action="Copy"/>
+		<menuitem name="Copy Path" action="Copy Path"/>
 		<menuitem name="Paste Files Into" action="Paste Files Into"/>
         <menuitem name="Duplicate" action="Duplicate"/>
 	</placeholder>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -3720,6 +3720,25 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                                 <property name="can-focus">True</property>
                                                 <property name="selectable">False</property>
                                                 <child>
+                                                  <object class="GtkCheckButton" id="selection_menu__copy_path_check">
+                                                    <property name="label" translatable="yes">Copy Pat_h</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="margin-left">2</property>
+                                                    <property name="margin-right">2</property>
+                                                    <property name="use-underline">True</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkListBoxRow">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="selectable">False</property>
+                                                <child>
                                                   <object class="GtkCheckButton" id="selection_menu__paste_check">
                                                     <property name="label" translatable="yes">_Paste</property>
                                                     <property name="visible">True</property>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -748,6 +748,10 @@
       <default>true</default>
       <summary>Show the selection context menu's Copy item.</summary>
     </key>
+    <key name="selection-menu-copy-path" type="b">
+      <default>true</default>
+      <summary>Show the selection context menu's Copy Path item.</summary>
+    </key>
     <key name="selection-menu-paste" type="b">
       <default>true</default>
       <summary>Show the selection context menu's Paste item.</summary>

--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -80,6 +80,7 @@
 #define NEMO_ACTION_CUT "Cut"
 #define NEMO_ACTION_LOCATION_CUT "LocationCut"
 #define NEMO_ACTION_COPY "Copy"
+#define NEMO_ACTION_COPY_PATH "Copy Path"
 #define NEMO_ACTION_LOCATION_COPY "LocationCopy"
 #define NEMO_ACTION_PASTE "Paste"
 #define NEMO_ACTION_PASTE_FILES_INTO "Paste Files Into"
@@ -193,6 +194,9 @@ static const ConfigurableMenuItemInfo CONFIGURABLE_MENU_ITEM_INFO [] = {
 
     { NEMO_ACTION_COPY, "selection_menu__copy_check",
      "/selection/File Clipboard Actions/Copy", "selection-menu-copy" },
+
+    { NEMO_ACTION_COPY_PATH, "selection_menu__copy_path_check",
+     "/selection/File Clipboard Actions/Copy Path", "selection-menu-copy-path" },
 
     { NEMO_ACTION_PASTE_FILES_INTO, "selection_menu__paste_check",
      "/selection/File Clipboard Actions/Paste Files Into", "selection-menu-paste" },

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -6781,6 +6781,54 @@ action_copy_files_callback (GtkAction *action,
 }
 
 static void
+action_copy_path_callback (GtkAction *action,
+			   gpointer callback_data)
+{
+	NemoView *view;
+	GList *selection, *l;
+	GString *paths;
+	GtkClipboard *clipboard;
+
+	view = NEMO_VIEW (callback_data);
+	selection = nemo_view_get_selection (view);
+
+	if (selection == NULL) {
+		return;
+	}
+
+	paths = g_string_new (NULL);
+
+	for (l = selection; l != NULL; l = l->next) {
+		NemoFile *file = NEMO_FILE (l->data);
+		GFile *location = nemo_file_get_location (file);
+		gchar *path = g_file_get_path (location);
+
+		if (path != NULL) {
+			if (paths->len > 0) {
+				g_string_append_c (paths, '\n');
+			}
+			g_string_append (paths, path);
+			g_free (path);
+		} else {
+			char *uri = nemo_file_get_uri (file);
+			if (paths->len > 0) {
+				g_string_append_c (paths, '\n');
+			}
+			g_string_append (paths, uri);
+			g_free (uri);
+		}
+
+		g_object_unref (location);
+	}
+
+	clipboard = nemo_clipboard_get (GTK_WIDGET (view));
+	gtk_clipboard_set_text (clipboard, paths->str, paths->len);
+
+	nemo_file_list_free (selection);
+	g_string_free (paths, TRUE);
+}
+
+static void
 move_copy_selection_to_next_pane (NemoView *view,
 				  int copy_action)
 {
@@ -8282,6 +8330,10 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("_Copy"), "<control>C",
   /* tooltip */                  N_("Prepare the selected files to be copied with a Paste command"),
 				 G_CALLBACK (action_copy_files_callback) },
+  /* name, stock id */         { "Copy Path", NULL,
+  /* label, accelerator */       N_("Copy Pat_h"), NULL,
+  /* tooltip */                  N_("Copy the path of the selected files to the clipboard"),
+				 G_CALLBACK (action_copy_path_callback) },
   /* name, stock id */         { "Paste", "xsi-edit-paste-symbolic",
   /* label, accelerator */       N_("_Paste"), "<control>V",
   /* tooltip */                  N_("Move or copy files previously selected by a Cut or Copy command"),
@@ -9930,6 +9982,10 @@ real_update_menus (NemoView *view)
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      NEMO_ACTION_COPY);
+	gtk_action_set_sensitive (action, can_copy_files);
+
+	action = gtk_action_group_get_action (view->details->dir_action_group,
+					      NEMO_ACTION_COPY_PATH);
 	gtk_action_set_sensitive (action, can_copy_files);
 
 	real_update_paste_menu (view, selection, selection_count);


### PR DESCRIPTION
## Summary

Adds a new **Copy Path** item to the right-click context menu that copies the full filesystem path of the selected file(s) to the clipboard. For non-local files (e.g. `sftp://`), the URI is copied instead.

### Changes

- **`nemo-actions.h`**: Added `NEMO_ACTION_COPY_PATH` define and configurable menu entry
- **`nemo-view.c`**: Added `action_copy_path_callback` that builds a newline-separated list of file paths and copies to clipboard via `gtk_clipboard_set_text`; action entry with label "Copy Pat_h"; sensitivity follows `can_copy_files`
- **`nemo-directory-view-ui.xml`**: Added `Copy Path` menuitem after `Copy` in the context menu
- **`org.nemo.gschema.xml`**: Added `selection-menu-copy-path` boolean key (default: true)
- **`nemo-file-management-properties.glade`**: Added "Copy Path" checkbox in the Context Menu preferences tab

### Behavior

- Single file selected → copies its absolute path
- Multiple files selected → copies paths separated by newlines
- Configurable: can be hidden via Preferences → Context Menu

Inspired by https://github.com/linuxmint/nemo/pull/3716