### PR TITLE
feat: use Tab key to switch between split panes

### DIFF
--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1233,6 +1233,18 @@ nemo_window_key_press_event (GtkWidget *widget,
 		}
 	}
 
+	/* Tab switches between split panes when both are visible */
+	if (event->keyval == GDK_KEY_Tab &&
+	    (event->state & gtk_accelerator_get_default_mod_mask ()) == 0) {
+		NemoWindowPane *next_pane;
+
+		next_pane = nemo_window_get_next_pane (window);
+		if (next_pane != NULL) {
+			nemo_window_pane_grab_focus (next_pane);
+			return TRUE;
+		}
+	}
+
 	for (i = 0; i < G_N_ELEMENTS (extra_window_keybindings); i++) {
 		if (extra_window_keybindings[i].keyval == event->keyval) {
 			const GList *action_groups;


### PR DESCRIPTION
## Summary

When split view is active (F3), pressing **Tab** switches focus between the two panes. When split view is not active, Tab behaves normally (default GTK focus traversal).

### Changes

- **`nemo-window.c`**: Added a Tab key handler in `nemo_window_key_press_event` that checks for an available next pane via `nemo_window_get_next_pane()` and calls `nemo_window_pane_grab_focus()` on it

### Design decisions

- The handler runs **before** the `extra_window_keybindings` loop and before GTK's default key-press processing, so Tab is intercepted before it gets consumed by the focus chain
- Only bare Tab (no modifiers) triggers the switch — Shift+Tab, Ctrl+Tab etc. are unaffected
- When there is no split view, Tab falls through to GTK's default behavior

Inspired by https://github.com/linuxmint/nemo/pull/3648