### PR TITLE
Fix several memory leaks

### DIFF
--- a/libnemo-private/nemo-file-conflict-dialog.c
+++ b/libnemo-private/nemo-file-conflict-dialog.c
@@ -106,7 +106,7 @@ file_list_ready_cb (GList *files,
 	NemoFileConflictDialogDetails *details;
 	char *primary_text, *message, *secondary_text;
 	const gchar *message_extra;
-	char *dest_name, *dest_dir_name, *edit_name;
+	char *edit_name;
 	char *label_text;
 	char *size, *date, *type = NULL;
 	GdkPixbuf *pixbuf;
@@ -127,8 +127,8 @@ file_list_ready_cb (GList *files,
 	src_mtime = nemo_file_get_mtime (src);
 	dest_mtime = nemo_file_get_mtime (dest);
 
-	dest_name = nemo_file_get_display_name (dest);
-	dest_dir_name = nemo_file_get_display_name (dest_dir);
+	g_autofree gchar *dest_name = nemo_file_get_display_name (dest);
+	g_autofree gchar *dest_dir_name = nemo_file_get_display_name (dest_dir);
 
 	source_is_dir = nemo_file_is_directory (src);
 	dest_is_dir = nemo_file_is_directory (dest);

--- a/src/nemo-mime-actions.c
+++ b/src/nemo-mime-actions.c
@@ -1149,6 +1149,7 @@ open_with_dialog_response_cb (GtkDialog *dialog,
 
     gtk_widget_destroy (GTK_WIDGET (dialog));
     g_object_unref (info);
+    nemo_file_unref (file);
 }
 
 static void
@@ -1178,6 +1179,9 @@ run_open_with_dialog (ActivateParametersSpecial *params)
     gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 
     GtkWidget *chooser = nemo_mime_application_chooser_new (uri, uris, mime_type, ok_button);
+
+    g_free (uri);
+    g_free (mime_type);
 
     GtkWidget *content = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
 
@@ -1713,6 +1717,7 @@ activate_files (ActivateParameters *parameters)
 
                 file_path = g_file_get_path (initial_location);
                 uri = g_strconcat ("admin://", file_path, NULL);
+                g_free (file_path);
             }
 
             final_location = g_file_new_for_uri (uri);

--- a/src/nemo-open-with-main.c
+++ b/src/nemo-open-with-main.c
@@ -80,6 +80,7 @@ app_chooser_dialog_response_cb (GtkDialog *dialog,
 
     gtk_widget_destroy (GTK_WIDGET (dialog));
     g_object_unref (info);
+    nemo_file_unref (file);
 }
 
 int

--- a/src/nemo-properties-window.c
+++ b/src/nemo-properties-window.c
@@ -3052,6 +3052,7 @@ create_volume_usage_widget (NemoPropertiesWindow *window)
 	uri = nemo_file_get_activation_uri (file);
 
 	location = g_file_new_for_uri (uri);
+	g_free (uri);
 	info = g_file_query_filesystem_info (location, "filesystem::*", NULL, NULL);
 
 	if (info) {

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1623,6 +1623,7 @@ nemo_window_show (GtkWidget *widget)
 
 	window = NEMO_WINDOW (widget);
 
+    g_free (window->details->sidebar_id);
     window->details->sidebar_id = g_settings_get_string (nemo_window_state,
                                                          NEMO_WINDOW_STATE_SIDE_PANE_VIEW);
 


### PR DESCRIPTION
Fix missing free/unref calls found via static analysis:

- nemo-mime-actions.c: free g_file_get_path() result after admin URI construction, unref NemoFile in open_with_dialog_response_cb, free uri and mime_type in run_open_with_dialog
- nemo-open-with-main.c: unref NemoFile in app_chooser_dialog_response_cb
- nemo-window.c: free sidebar_id before overwriting with g_settings_get_string()
- nemo-file-conflict-dialog.c: use g_autofree for dest_name and dest_dir_name
- nemo-properties-window.c: free uri after g_file_new_for_uri()

Validated with Valgrind — 0 bytes definitely or possibly lost.