### PR TITLE
Add configurable keyboard shortcuts

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -4383,6 +4383,22 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                     <property name="position">8</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="keybindings_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">keybindings</property>
+                    <property name="title" translatable="yes">Keyboard Shortcuts</property>
+                    <property name="icon-name">xsi-keyboard-shortcuts-symbolic</property>
+                    <property name="position">9</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/gresources/nemo-shell-ui.xml
+++ b/gresources/nemo-shell-ui.xml
@@ -1,6 +1,8 @@
 <ui>
 <accelerator action="Search"/>
 <accelerator action="SplitViewNextPane"/>
+<accelerator action="Bookmark Picker"/>
+<accelerator action="Bookmark Picker Other Pane"/>
 <accelerator action="TabsPrevious"/>
 <accelerator action="TabsNext"/>
 <accelerator action="TabsMoveLeft"/>

--- a/gresources/nemo-style-fallback-mandatory.css
+++ b/gresources/nemo-style-fallback-mandatory.css
@@ -7,6 +7,18 @@
     background-color: @theme_unfocused_bg_color;
 }
 
+/* Hide selection highlight and focus cursor in the inactive pane */
+.nemo-window .nemo-inactive-pane .view:selected {
+    background-color: alpha(@theme_unfocused_selected_bg_color, 0.4);
+    color: @theme_fg_color;
+}
+
+.nemo-window .nemo-inactive-pane .view:focus {
+    outline-width: 0;
+    outline-offset: 0;
+    -gtk-outline-radius: 0;
+}
+
 /* Rename box styling in the icon view. */
 
 .nemo-window .nemo-window-pane widget.entry {

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -895,4 +895,262 @@
       <summary>List of search helper filenames to skip when using content search.</summary>
     </key>
   </schema>
+
+  <schema id="org.nemo.keybindings" path="/org/nemo/keybindings/">
+    <!-- Navigation -->
+    <key name="go-back" type="s">
+      <default>'&lt;Alt&gt;Left'</default>
+      <summary>Go back</summary>
+    </key>
+    <key name="go-forward" type="s">
+      <default>'&lt;Alt&gt;Right'</default>
+      <summary>Go forward</summary>
+    </key>
+    <key name="go-up" type="s">
+      <default>'&lt;Alt&gt;Up'</default>
+      <summary>Go to parent folder</summary>
+    </key>
+    <key name="go-home" type="s">
+      <default>'&lt;Alt&gt;Home'</default>
+      <summary>Go to home folder</summary>
+    </key>
+    <key name="edit-location" type="s">
+      <default>'&lt;Control&gt;l'</default>
+      <summary>Toggle location entry</summary>
+    </key>
+    <key name="reload" type="s">
+      <default>'&lt;Control&gt;r'</default>
+      <summary>Reload current location</summary>
+    </key>
+    <key name="reload-alt" type="s">
+      <default>'F5'</default>
+      <summary>Reload current location (alternate)</summary>
+    </key>
+    <key name="go-up-alt" type="s">
+      <default>'BackSpace'</default>
+      <summary>Go to parent folder (alternate)</summary>
+    </key>
+    <key name="search" type="s">
+      <default>'&lt;Control&gt;f'</default>
+      <summary>Search for files</summary>
+    </key>
+
+    <!-- Window -->
+    <key name="new-window" type="s">
+      <default>'&lt;Control&gt;n'</default>
+      <summary>Open a new window</summary>
+    </key>
+    <key name="close-window" type="s">
+      <default>'&lt;Control&gt;w'</default>
+      <summary>Close window or tab</summary>
+    </key>
+    <key name="close-all-windows" type="s">
+      <default>'&lt;Control&gt;q'</default>
+      <summary>Close all windows</summary>
+    </key>
+    <key name="show-hidden-files" type="s">
+      <default>'&lt;Control&gt;h'</default>
+      <summary>Toggle hidden files</summary>
+    </key>
+    <key name="show-sidebar" type="s">
+      <default>'F9'</default>
+      <summary>Toggle sidebar</summary>
+    </key>
+    <key name="split-view" type="s">
+      <default>'F3'</default>
+      <summary>Toggle split view</summary>
+    </key>
+    <key name="switch-pane" type="s">
+      <default>'F6'</default>
+      <summary>Switch to other pane</summary>
+    </key>
+    <key name="same-location-pane" type="s">
+      <default>'&lt;Alt&gt;s'</default>
+      <summary>Same location as other pane</summary>
+    </key>
+
+    <!-- Tabs -->
+    <key name="new-tab" type="s">
+      <default>'&lt;Control&gt;t'</default>
+      <summary>Open a new tab</summary>
+    </key>
+    <key name="previous-tab" type="s">
+      <default>'&lt;Control&gt;Page_Up'</default>
+      <summary>Previous tab</summary>
+    </key>
+    <key name="next-tab" type="s">
+      <default>'&lt;Control&gt;Page_Down'</default>
+      <summary>Next tab</summary>
+    </key>
+    <key name="move-tab-left" type="s">
+      <default>'&lt;Shift&gt;&lt;Control&gt;Page_Up'</default>
+      <summary>Move tab left</summary>
+    </key>
+    <key name="move-tab-right" type="s">
+      <default>'&lt;Shift&gt;&lt;Control&gt;Page_Down'</default>
+      <summary>Move tab right</summary>
+    </key>
+
+    <!-- View -->
+    <key name="zoom-in" type="s">
+      <default>'&lt;Control&gt;plus'</default>
+      <summary>Zoom in</summary>
+    </key>
+    <key name="zoom-out" type="s">
+      <default>'&lt;Control&gt;minus'</default>
+      <summary>Zoom out</summary>
+    </key>
+    <key name="zoom-normal" type="s">
+      <default>'&lt;Control&gt;0'</default>
+      <summary>Reset zoom to normal</summary>
+    </key>
+    <key name="icon-view" type="s">
+      <default>'&lt;Control&gt;1'</default>
+      <summary>Switch to icon view</summary>
+    </key>
+    <key name="list-view" type="s">
+      <default>'&lt;Control&gt;2'</default>
+      <summary>Switch to list view</summary>
+    </key>
+    <key name="compact-view" type="s">
+      <default>'&lt;Control&gt;3'</default>
+      <summary>Switch to compact view</summary>
+    </key>
+
+    <!-- Bookmarks -->
+    <key name="add-bookmark" type="s">
+      <default>'&lt;Control&gt;d'</default>
+      <summary>Add bookmark</summary>
+    </key>
+    <key name="edit-bookmarks" type="s">
+      <default>'&lt;Control&gt;b'</default>
+      <summary>Edit bookmarks</summary>
+    </key>
+    <key name="bookmark-picker" type="s">
+      <default>'&lt;Alt&gt;F1'</default>
+      <summary>Open bookmark and disk picker for current pane</summary>
+    </key>
+    <key name="bookmark-picker-other" type="s">
+      <default>'&lt;Alt&gt;F2'</default>
+      <summary>Open bookmark and disk picker for other pane</summary>
+    </key>
+
+    <!-- File Operations -->
+    <key name="open" type="s">
+      <default>'&lt;Control&gt;o'</default>
+      <summary>Open selected item</summary>
+    </key>
+    <key name="open-default" type="s">
+      <default>''</default>
+      <summary>Open with default application</summary>
+    </key>
+    <key name="open-alternate" type="s">
+      <default>'&lt;Control&gt;&lt;Shift&gt;o'</default>
+      <summary>Open in new window</summary>
+    </key>
+    <key name="open-in-new-tab" type="s">
+      <default>'&lt;Control&gt;&lt;Shift&gt;t'</default>
+      <summary>Open in new tab</summary>
+    </key>
+    <key name="open-in-terminal" type="s">
+      <default>'&lt;Shift&gt;F4'</default>
+      <summary>Open in terminal</summary>
+    </key>
+    <key name="open-containing-folder" type="s">
+      <default>'&lt;Control&gt;&lt;Alt&gt;o'</default>
+      <summary>Open containing folder</summary>
+    </key>
+    <key name="properties" type="s">
+      <default>'&lt;Alt&gt;Return'</default>
+      <summary>Show properties</summary>
+    </key>
+    <key name="new-folder" type="s">
+      <default>'&lt;Control&gt;&lt;Shift&gt;n'</default>
+      <summary>Create new folder</summary>
+    </key>
+    <key name="new-folder-alt" type="s">
+      <default>''</default>
+      <summary>Create new folder (alternate)</summary>
+    </key>
+    <key name="rename" type="s">
+      <default>'F2'</default>
+      <summary>Rename selected item</summary>
+    </key>
+    <key name="create-link" type="s">
+      <default>'&lt;Control&gt;m'</default>
+      <summary>Create symbolic link</summary>
+    </key>
+    <key name="pin-file" type="s">
+      <default>'&lt;Control&gt;&lt;Shift&gt;d'</default>
+      <summary>Pin or unpin file</summary>
+    </key>
+    <key name="trash" type="s">
+      <default>'Delete'</default>
+      <summary>Move to trash</summary>
+    </key>
+    <key name="trash-alt" type="s">
+      <default>''</default>
+      <summary>Move to trash (alternate key)</summary>
+    </key>
+    <key name="delete-permanently" type="s">
+      <default>'&lt;Shift&gt;Delete'</default>
+      <summary>Delete permanently</summary>
+    </key>
+    <key name="copy-to-other-pane" type="s">
+      <default>''</default>
+      <summary>Copy selection to other pane</summary>
+    </key>
+    <key name="move-to-other-pane" type="s">
+      <default>''</default>
+      <summary>Move selection to other pane</summary>
+    </key>
+
+    <!-- Clipboard -->
+    <key name="cut" type="s">
+      <default>'&lt;Control&gt;x'</default>
+      <summary>Cut files</summary>
+    </key>
+    <key name="copy" type="s">
+      <default>'&lt;Control&gt;c'</default>
+      <summary>Copy files</summary>
+    </key>
+    <key name="paste" type="s">
+      <default>'&lt;Control&gt;v'</default>
+      <summary>Paste files</summary>
+    </key>
+
+    <!-- Selection -->
+    <key name="select-all" type="s">
+      <default>'&lt;Control&gt;a'</default>
+      <summary>Select all items</summary>
+    </key>
+    <key name="select-pattern" type="s">
+      <default>'&lt;Control&gt;s'</default>
+      <summary>Select items matching a pattern</summary>
+    </key>
+    <key name="invert-selection" type="s">
+      <default>'&lt;Control&gt;&lt;Shift&gt;i'</default>
+      <summary>Invert selection</summary>
+    </key>
+
+    <!-- Edit -->
+    <key name="undo" type="s">
+      <default>'&lt;Control&gt;z'</default>
+      <summary>Undo</summary>
+    </key>
+    <key name="redo" type="s">
+      <default>'&lt;Control&gt;y'</default>
+      <summary>Redo</summary>
+    </key>
+
+    <!-- Help -->
+    <key name="show-help" type="s">
+      <default>'F1'</default>
+      <summary>Show help</summary>
+    </key>
+    <key name="show-shortcuts" type="s">
+      <default>'&lt;Control&gt;F1'</default>
+      <summary>Show keyboard shortcuts</summary>
+    </key>
+  </schema>
 </schemalist>

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ nemoCommon_sources = [
   'nemo-icon-view.c',
   'nemo-image-properties-page.c',
   'nemo-interesting-folder-bar.c',
+  'nemo-keybindings.c',
   'nemo-list-model.c',
   'nemo-list-view.c',
   'nemo-location-bar.c',

--- a/src/nemo-actions.h
+++ b/src/nemo-actions.h
@@ -54,6 +54,8 @@
 #define NEMO_ACTION_GO_HOME "Home"
 #define NEMO_ACTION_ADD_BOOKMARK "Add Bookmark"
 #define NEMO_ACTION_EDIT_BOOKMARKS "Edit Bookmarks"
+#define NEMO_ACTION_BOOKMARK_PICKER "Bookmark Picker"
+#define NEMO_ACTION_BOOKMARK_PICKER_OTHER "Bookmark Picker Other Pane"
 #define NEMO_ACTION_HOME "Home"
 #define NEMO_ACTION_ZOOM_IN "Zoom In"
 #define NEMO_ACTION_ZOOM_OUT "Zoom Out"

--- a/src/nemo-application.c
+++ b/src/nemo-application.c
@@ -61,6 +61,8 @@
 #include <libnemo-private/nemo-thumbnails.h>
 #include <libnemo-extension/nemo-menu-provider.h>
 
+#include "nemo-keybindings.h"
+
 #define DEBUG_FLAG NEMO_DEBUG_APPLICATION
 #include <libnemo-private/nemo-debug.h>
 
@@ -564,6 +566,9 @@ nemo_application_startup (GApplication *app)
 	/* initialize theming */
 	init_icons_and_styles ();
 	init_gtk_accels ();
+
+	/* initialize configurable keybindings */
+	nemo_keybindings_init ();
 
 	/* initialize nemo modules */
 	nemo_module_setup ();

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -43,6 +43,7 @@
 #include "nemo-plugin-manager.h"
 #include "nemo-template-config-widget.h"
 #include "nemo-actions.h"
+#include "nemo-keybindings.h"
 
 /* string enum preferences */
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET "default_view_combobox"
@@ -485,6 +486,18 @@ nemo_file_management_properties_dialog_setup_templates_page (GtkBuilder *builder
     gtk_box_pack_start (GTK_BOX (box),
                         GTK_WIDGET (nemo_template_config_widget_new ()),
                         TRUE, TRUE, 0);
+}
+
+static void
+nemo_file_management_properties_dialog_setup_keybindings_page (GtkBuilder *builder)
+{
+    GtkWidget *box;
+    GtkWidget *editor;
+
+    box = GTK_WIDGET (gtk_builder_get_object (builder, "keybindings_box"));
+    editor = nemo_keybindings_create_editor ();
+
+    gtk_box_pack_start (GTK_BOX (box), editor, TRUE, TRUE, 0);
 }
 
 static void
@@ -1144,6 +1157,7 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 	nemo_file_management_properties_dialog_setup_list_column_page (builder);
     nemo_file_management_properties_dialog_setup_plugin_page (builder);
     nemo_file_management_properties_dialog_setup_templates_page (builder);
+    nemo_file_management_properties_dialog_setup_keybindings_page (builder);
 
 
     setup_configurable_menu_items (builder);

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -2336,7 +2336,7 @@ button_press_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_da
     GdkEventButton *event_button = (GdkEventButton *)event;
     gint selection_count = nemo_view_get_selection_count (NEMO_VIEW (view));
 
-    if (!nemo_view_get_active (view) && selection_count > 0) {
+    if (!nemo_view_get_active (view)) {
         NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (view);
         nemo_window_slot_make_hosting_pane_active (slot);
         return GDK_EVENT_STOP;

--- a/src/nemo-keybindings.c
+++ b/src/nemo-keybindings.c
@@ -1,0 +1,684 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/*
+ * nemo-keybindings.c - Configurable keyboard shortcuts for Nemo.
+ *
+ * Copyright (C) 2026 Nemo contributors
+ *
+ * Nemo is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Nemo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, MA 02110-1335, USA.
+ */
+
+#include <config.h>
+#include "nemo-keybindings.h"
+
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+
+GSettings *nemo_keybinding_settings = NULL;
+
+/*
+ * Master table of all configurable keybindings.
+ *
+ * settings_key: GSettings key in org.nemo.keybindings
+ * accel_path: GtkAccelMap path (<Actions>/<group>/<action>)
+ * description: shown in the preferences UI
+ * category: grouping for the preferences UI
+ * default_accel: default GTK accelerator string
+ */
+const NemoKeybindingEntry nemo_keybinding_entries[] = {
+	/* Navigation — accel-map entries */
+	{ "go-back",               "<Actions>/ShellActions/Back",               N_("Go Back"),                    N_("Navigation"), "<Alt>Left",              NULL, NULL },
+	{ "go-forward",            "<Actions>/ShellActions/Forward",            N_("Go Forward"),                 N_("Navigation"), "<Alt>Right",             NULL, NULL },
+	{ "go-up",                 "<Actions>/ShellActions/Up",                 N_("Go to Parent Folder"),        N_("Navigation"), "<Alt>Up",                NULL, NULL },
+	{ "go-home",               "<Actions>/ShellActions/Home",               N_("Go Home"),                    N_("Navigation"), "<Alt>Home",              NULL, NULL },
+	{ "edit-location",         "<Actions>/ShellActions/Edit Location",      N_("Toggle Location Entry"),      N_("Navigation"), "<Control>l",             NULL, NULL },
+	{ "reload",                "<Actions>/ShellActions/Reload",             N_("Reload"),                     N_("Navigation"), "<Control>r",             NULL, NULL },
+	{ "search",                "<Actions>/ShellActions/Search",             N_("Search"),                     N_("Navigation"), "<Control>f",             NULL, NULL },
+
+	/* Navigation — binding-set entries (unified from nemo-window.c) */
+	{ "reload-alt",            NULL,                                        N_("Reload (alternate)"),         N_("Navigation"), "F5",                     "NemoWindow", "reload" },
+	{ "go-up-alt",             NULL,                                        N_("Go Up (alternate)"),          N_("Navigation"), "BackSpace",              "NemoWindow", "go-up" },
+
+	/* Window */
+	{ "new-window",            "<Actions>/ShellActions/New Window",         N_("New Window"),                 N_("Window"), "<Control>n",                 NULL, NULL },
+	{ "close-window",          "<Actions>/ShellActions/Close",              N_("Close Window/Tab"),           N_("Window"), "<Control>w",                 NULL, NULL },
+	{ "close-all-windows",     "<Actions>/ShellActions/Close All Windows",  N_("Close All Windows"),          N_("Window"), "<Control>q",                NULL, NULL },
+	{ "show-hidden-files",     "<Actions>/ShellActions/Show Hidden Files",  N_("Show Hidden Files"),          N_("Window"), "<Control>h",                NULL, NULL },
+	{ "show-sidebar",          "<Actions>/ShellActions/Show Hide Sidebar",  N_("Toggle Sidebar"),             N_("Window"), "F9",                        NULL, NULL },
+	{ "split-view",            "<Actions>/ShellActions/Show Hide Extra Pane", N_("Toggle Split View"),        N_("Window"), "F3",                        NULL, NULL },
+	{ "switch-pane",           "<Actions>/ShellActions/SplitViewNextPane",  N_("Switch to Other Pane"),       N_("Window"), "F6",                        NULL, NULL },
+	{ "same-location-pane",    "<Actions>/ShellActions/SplitViewSameLocation", N_("Same Location as Other Pane"), N_("Window"), "<Alt>s",                NULL, NULL },
+
+	/* Tabs */
+	{ "new-tab",               "<Actions>/ShellActions/New Tab",            N_("New Tab"),                    N_("Tabs"), "<Control>t",                   NULL, NULL },
+	{ "previous-tab",          "<Actions>/ShellActions/TabsPrevious",       N_("Previous Tab"),               N_("Tabs"), "<Control>Page_Up",             NULL, NULL },
+	{ "next-tab",              "<Actions>/ShellActions/TabsNext",           N_("Next Tab"),                   N_("Tabs"), "<Control>Page_Down",            NULL, NULL },
+	{ "move-tab-left",         "<Actions>/ShellActions/TabsMoveLeft",       N_("Move Tab Left"),              N_("Tabs"), "<Shift><Control>Page_Up",      NULL, NULL },
+	{ "move-tab-right",        "<Actions>/ShellActions/TabsMoveRight",      N_("Move Tab Right"),             N_("Tabs"), "<Shift><Control>Page_Down",    NULL, NULL },
+
+	/* View */
+	{ "zoom-in",               "<Actions>/ShellActions/Zoom In",            N_("Zoom In"),                    N_("View"), "<Control>plus",                NULL, NULL },
+	{ "zoom-out",              "<Actions>/ShellActions/Zoom Out",           N_("Zoom Out"),                   N_("View"), "<Control>minus",               NULL, NULL },
+	{ "zoom-normal",           "<Actions>/ShellActions/Zoom Normal",        N_("Normal Size"),                N_("View"), "<Control>0",                   NULL, NULL },
+	{ "icon-view",             "<Actions>/ShellActions/IconView",           N_("Icon View"),                  N_("View"), "<Control>1",                   NULL, NULL },
+	{ "list-view",             "<Actions>/ShellActions/ListView",           N_("List View"),                  N_("View"), "<Control>2",                   NULL, NULL },
+	{ "compact-view",          "<Actions>/ShellActions/CompactView",        N_("Compact View"),               N_("View"), "<Control>3",                   NULL, NULL },
+
+	/* Bookmarks */
+	{ "add-bookmark",          "<Actions>/ShellActions/Add Bookmark",       N_("Add Bookmark"),               N_("Bookmarks"), "<Control>d",              NULL, NULL },
+	{ "edit-bookmarks",        "<Actions>/ShellActions/Edit Bookmarks",     N_("Edit Bookmarks"),             N_("Bookmarks"), "<Control>b",              NULL, NULL },
+	{ "bookmark-picker",       "<Actions>/ShellActions/Bookmark Picker",    N_("Bookmark/Disk Picker"),       N_("Bookmarks"), "<Alt>F1",                 NULL, NULL },
+	{ "bookmark-picker-other", "<Actions>/ShellActions/Bookmark Picker Other Pane", N_("Bookmark/Disk Picker (Other Pane)"), N_("Bookmarks"), "<Alt>F2",     NULL, NULL },
+
+	/* File Operations — accel-map entries */
+	{ "open",                  "<Actions>/DirViewActions/Open",             N_("Open"),                       N_("File Operations"), "<Control>o",        NULL, NULL },
+	{ "open-default",          NULL,                                        N_("Open with Default App"),       N_("File Operations"), "",                  NULL, NULL },
+	{ "open-alternate",        "<Actions>/DirViewActions/OpenAlternate",    N_("Open in New Window"),         N_("File Operations"), "<Control><Shift>o", NULL, NULL },
+	{ "open-in-new-tab",       "<Actions>/DirViewActions/OpenInNewTab",     N_("Open in New Tab"),            N_("File Operations"), "<Control><Shift>t", NULL, NULL },
+	{ "open-in-terminal",      "<Actions>/DirViewActions/OpenInTerminal",   N_("Open in Terminal"),           N_("File Operations"), "<Shift>F4",         NULL, NULL },
+	{ "open-containing-folder","<Actions>/DirViewActions/OpenContainingFolder", N_("Open Containing Folder"), N_("File Operations"), "<Control><Alt>o",   NULL, NULL },
+	{ "properties",            "<Actions>/DirViewActions/Properties",       N_("Properties"),                 N_("File Operations"), "<Alt>Return",       NULL, NULL },
+	{ "new-folder",            "<Actions>/DirViewActions/New Folder",       N_("New Folder"),                 N_("File Operations"), "<Control><Shift>n", NULL, NULL },
+	{ "new-folder-alt",        NULL,                                        N_("New Folder (alternate)"),      N_("File Operations"), "",                  NULL, NULL },
+	{ "rename",                "<Actions>/DirViewActions/Rename",           N_("Rename"),                     N_("File Operations"), "F2",                NULL, NULL },
+	{ "create-link",           "<Actions>/DirViewActions/Create Link",      N_("Make Symbolic Link"),         N_("File Operations"), "<Control>m",        NULL, NULL },
+	{ "pin-file",              "<Actions>/DirViewActions/Pin File",         N_("Pin/Unpin File"),             N_("File Operations"), "<Control><Shift>d", NULL, NULL },
+	{ "copy-to-other-pane",    "<Actions>/DirViewActions/Copy to next pane", N_("Copy to Other Pane"),         N_("File Operations"), "",                  NULL, NULL },
+	{ "move-to-other-pane",    "<Actions>/DirViewActions/Move to next pane", N_("Move to Other Pane"),         N_("File Operations"), "",                  NULL, NULL },
+
+	/* File Operations — binding-set entries (unified from nemo-view.c) */
+	{ "trash",                 NULL,                                        N_("Move to Trash"),              N_("File Operations"), "Delete",             "NemoView", "trash" },
+	{ "trash-alt",             NULL,                                        N_("Move to Trash (alternate)"),  N_("File Operations"), "",                   "NemoView", "trash" },
+	{ "delete-permanently",    NULL,                                        N_("Delete Permanently"),         N_("File Operations"), "<Shift>Delete",      "NemoView", "delete" },
+
+	/* Clipboard */
+	{ "cut",                   "<Actions>/DirViewActions/Cut",              N_("Cut"),                        N_("Clipboard"), "<Control>x",               NULL, NULL },
+	{ "copy",                  "<Actions>/DirViewActions/Copy",             N_("Copy"),                       N_("Clipboard"), "<Control>c",               NULL, NULL },
+	{ "paste",                 "<Actions>/DirViewActions/Paste",            N_("Paste"),                      N_("Clipboard"), "<Control>v",               NULL, NULL },
+
+	/* Selection */
+	{ "select-all",            "<Actions>/DirViewActions/Select All",       N_("Select All"),                 N_("Selection"), "<Control>a",               NULL, NULL },
+	{ "select-pattern",        "<Actions>/DirViewActions/Select Pattern",   N_("Select Items Matching..."),   N_("Selection"), "<Control>s",               NULL, NULL },
+	{ "invert-selection",      "<Actions>/DirViewActions/Invert Selection", N_("Invert Selection"),           N_("Selection"), "<Control><Shift>i",        NULL, NULL },
+
+	/* Undo/Redo */
+	{ "undo",                  "<Actions>/DirViewActions/Undo",             N_("Undo"),                       N_("Edit"), "<Control>z",                    NULL, NULL },
+	{ "redo",                  "<Actions>/DirViewActions/Redo",             N_("Redo"),                       N_("Edit"), "<Control>y",                    NULL, NULL },
+
+	/* Help */
+	{ "show-help",             "<Actions>/ShellActions/NemoHelp",           N_("Help"),                       N_("Help"), "F1",                            NULL, NULL },
+	{ "show-shortcuts",        "<Actions>/ShellActions/NemoShortcuts",      N_("Keyboard Shortcuts"),         N_("Help"), "<Control>F1",                   NULL, NULL },
+};
+
+const gint nemo_keybinding_entries_count = G_N_ELEMENTS (nemo_keybinding_entries);
+
+/*
+ * Apply a single keybinding from GSettings.
+ *
+ * Handles both mechanisms:
+ *   - accel-map entries (accel_path != NULL): modify GtkAccelMap
+ *   - binding-set entries (binding_set_name != NULL): modify GtkBindingSet
+ */
+static void
+apply_keybinding (const NemoKeybindingEntry *entry)
+{
+	g_autofree gchar *accel_string = NULL;
+	guint key = 0;
+	GdkModifierType mods = 0;
+	guint default_key = 0;
+	GdkModifierType default_mods = 0;
+
+	accel_string = g_settings_get_string (nemo_keybinding_settings,
+	                                      entry->settings_key);
+
+	/* Parse the default so we can remove the old binding-set entry */
+	gtk_accelerator_parse (entry->default_accel, &default_key, &default_mods);
+
+	if (entry->binding_set_name != NULL) {
+		/* --- Binding-set entry --- */
+		GtkBindingSet *binding_set;
+
+		binding_set = gtk_binding_set_find (entry->binding_set_name);
+		if (binding_set == NULL) {
+			return;
+		}
+
+		/* Always remove the default binding first */
+		gtk_binding_entry_remove (binding_set, default_key, default_mods);
+
+		if (accel_string == NULL || accel_string[0] == '\0') {
+			/* Disabled — just leave it removed */
+			return;
+		}
+
+		gtk_accelerator_parse (accel_string, &key, &mods);
+
+		if (key == 0 && mods == 0) {
+			g_warning ("Failed to parse accelerator '%s' for %s",
+			           accel_string, entry->settings_key);
+			return;
+		}
+
+		/* Remove the new key too in case it was already bound */
+		gtk_binding_entry_remove (binding_set, key, mods);
+
+		gtk_binding_entry_add_signal (binding_set, key, mods,
+		                              entry->signal_name, 0);
+		return;
+	}
+
+	/* --- Accel-map entry --- */
+
+	if (entry->accel_path == NULL) {
+		/* Window-level keybinding handled elsewhere (e.g. key_press_event).
+		 * Nothing to apply here. */
+		return;
+	}
+
+	if (accel_string == NULL || accel_string[0] == '\0') {
+		/* Disabled binding: remove any existing accelerator */
+		gtk_accel_map_change_entry (entry->accel_path, 0, 0, TRUE);
+		return;
+	}
+
+	/* If the value matches the default, don't touch the accel map —
+	 * let the hardcoded GtkActionEntry handle it normally. This avoids
+	 * corrupting the accel map by pre-registering paths before action
+	 * groups exist. */
+	if (g_strcmp0 (accel_string, entry->default_accel) == 0) {
+		return;
+	}
+
+	gtk_accelerator_parse (accel_string, &key, &mods);
+
+	if (key == 0 && mods == 0) {
+		g_warning ("Failed to parse accelerator '%s' for %s",
+		           accel_string, entry->settings_key);
+		return;
+	}
+
+	gtk_accel_map_change_entry (entry->accel_path, key, mods, TRUE);
+}
+
+/*
+ * Apply all keybindings from GSettings.
+ */
+void
+nemo_keybindings_apply_all (void)
+{
+	gint i;
+
+	if (nemo_keybinding_settings == NULL) {
+		return;
+	}
+
+	for (i = 0; i < nemo_keybinding_entries_count; i++) {
+		apply_keybinding (&nemo_keybinding_entries[i]);
+	}
+}
+
+/*
+ * Set a specific keybinding in GSettings and apply it immediately.
+ */
+void
+nemo_keybindings_set_for_action (const gchar *settings_key,
+                                 const gchar *accel_string)
+{
+	g_settings_set_string (nemo_keybinding_settings,
+	                       settings_key,
+	                       accel_string ? accel_string : "");
+}
+
+/*
+ * Handle GSettings "changed" signal for keybindings.
+ */
+static void
+on_keybinding_changed (GSettings   *settings,
+                       const gchar *key,
+                       gpointer     user_data)
+{
+	gint i;
+
+	for (i = 0; i < nemo_keybinding_entries_count; i++) {
+		if (g_strcmp0 (nemo_keybinding_entries[i].settings_key, key) == 0) {
+			apply_keybinding (&nemo_keybinding_entries[i]);
+			break;
+		}
+	}
+}
+
+/*
+ * Initialize the keybinding settings and apply all overrides.
+ */
+void
+nemo_keybindings_init (void)
+{
+	if (nemo_keybinding_settings != NULL) {
+		return;
+	}
+
+	nemo_keybinding_settings = g_settings_new ("org.nemo.keybindings");
+
+	g_signal_connect (nemo_keybinding_settings, "changed",
+	                  G_CALLBACK (on_keybinding_changed), NULL);
+
+	nemo_keybindings_apply_all ();
+}
+
+/* --- Preferences UI --- */
+
+enum {
+	COL_CATEGORY,
+	COL_DESCRIPTION,
+	COL_ACCEL_KEY,
+	COL_ACCEL_MODS,
+	COL_SETTINGS_KEY,
+	COL_ENTRY_INDEX,
+	NUM_COLS
+};
+
+static void
+on_accel_edited (GtkCellRendererAccel *renderer,
+                 gchar               *path_string,
+                 guint                accel_key,
+                 GdkModifierType      accel_mods,
+                 guint                hardware_keycode,
+                 gpointer             user_data)
+{
+	GtkTreeModelFilter *filter = GTK_TREE_MODEL_FILTER (user_data);
+	GtkTreeModel *child_model = gtk_tree_model_filter_get_model (filter);
+	GtkTreeIter filter_iter, child_iter;
+	gchar *settings_key;
+	gchar *accel_string;
+
+	if (!gtk_tree_model_get_iter_from_string (GTK_TREE_MODEL (filter),
+	                                          &filter_iter, path_string)) {
+		return;
+	}
+
+	gtk_tree_model_filter_convert_iter_to_child_iter (filter, &child_iter,
+	                                                  &filter_iter);
+
+	gtk_tree_model_get (child_model, &child_iter,
+	                    COL_SETTINGS_KEY, &settings_key, -1);
+
+	accel_string = gtk_accelerator_name (accel_key, accel_mods);
+
+	g_settings_set_string (nemo_keybinding_settings, settings_key, accel_string);
+
+	gtk_tree_store_set (GTK_TREE_STORE (child_model), &child_iter,
+	                    COL_ACCEL_KEY, accel_key,
+	                    COL_ACCEL_MODS, accel_mods,
+	                    -1);
+
+	g_free (accel_string);
+	g_free (settings_key);
+}
+
+static void
+on_accel_cleared (GtkCellRendererAccel *renderer,
+                  gchar               *path_string,
+                  gpointer             user_data)
+{
+	GtkTreeModelFilter *filter = GTK_TREE_MODEL_FILTER (user_data);
+	GtkTreeModel *child_model = gtk_tree_model_filter_get_model (filter);
+	GtkTreeIter filter_iter, child_iter;
+	gchar *settings_key;
+
+	if (!gtk_tree_model_get_iter_from_string (GTK_TREE_MODEL (filter),
+	                                          &filter_iter, path_string)) {
+		return;
+	}
+
+	gtk_tree_model_filter_convert_iter_to_child_iter (filter, &child_iter,
+	                                                  &filter_iter);
+
+	gtk_tree_model_get (child_model, &child_iter,
+	                    COL_SETTINGS_KEY, &settings_key, -1);
+
+	g_settings_set_string (nemo_keybinding_settings, settings_key, "");
+
+	gtk_tree_store_set (GTK_TREE_STORE (child_model), &child_iter,
+	                    COL_ACCEL_KEY, 0,
+	                    COL_ACCEL_MODS, (GdkModifierType) 0,
+	                    -1);
+
+	g_free (settings_key);
+}
+
+static void
+on_reset_all_clicked (GtkButton *button,
+                      gpointer   user_data)
+{
+	GtkTreeStore *store = GTK_TREE_STORE (user_data);
+	GtkTreeIter iter, child;
+	gint i;
+
+	/* Reset all settings to defaults */
+	for (i = 0; i < nemo_keybinding_entries_count; i++) {
+		g_settings_reset (nemo_keybinding_settings,
+		                  nemo_keybinding_entries[i].settings_key);
+	}
+
+	/* Refresh the tree store */
+	if (!gtk_tree_model_get_iter_first (GTK_TREE_MODEL (store), &iter)) {
+		return;
+	}
+
+	do {
+		if (gtk_tree_model_iter_children (GTK_TREE_MODEL (store), &child, &iter)) {
+			do {
+				gint idx;
+				guint key;
+				GdkModifierType mods;
+
+				gtk_tree_model_get (GTK_TREE_MODEL (store), &child,
+				                    COL_ENTRY_INDEX, &idx, -1);
+
+				if (idx >= 0 && idx < nemo_keybinding_entries_count) {
+					gtk_accelerator_parse (nemo_keybinding_entries[idx].default_accel,
+					                       &key, &mods);
+					gtk_tree_store_set (store, &child,
+					                    COL_ACCEL_KEY, key,
+					                    COL_ACCEL_MODS, mods,
+					                    -1);
+				}
+			} while (gtk_tree_model_iter_next (GTK_TREE_MODEL (store), &child));
+		}
+	} while (gtk_tree_model_iter_next (GTK_TREE_MODEL (store), &iter));
+}
+
+/*
+ * Case-insensitive substring match (simple fuzzy).
+ */
+static gboolean
+string_contains_ci (const gchar *haystack, const gchar *needle)
+{
+	g_autofree gchar *h = g_utf8_strdown (haystack, -1);
+	g_autofree gchar *n = g_utf8_strdown (needle, -1);
+
+	return strstr (h, n) != NULL;
+}
+
+/*
+ * Filter visible function: show a row if the search text matches
+ * either the action description or the accelerator label.
+ * Category (parent) rows are visible if any child matches.
+ */
+static gboolean
+filter_visible_func (GtkTreeModel *model,
+                     GtkTreeIter  *iter,
+                     gpointer      user_data)
+{
+	GtkSearchEntry *search_entry = GTK_SEARCH_ENTRY (user_data);
+	const gchar *search_text;
+	gchar *description = NULL;
+	guint key = 0;
+	GdkModifierType mods = 0;
+	gint idx;
+	gboolean visible = TRUE;
+
+	search_text = gtk_entry_get_text (GTK_ENTRY (search_entry));
+
+	/* If search is empty, show everything */
+	if (search_text == NULL || search_text[0] == '\0') {
+		return TRUE;
+	}
+
+	gtk_tree_model_get (model, iter,
+	                    COL_DESCRIPTION, &description,
+	                    COL_ACCEL_KEY, &key,
+	                    COL_ACCEL_MODS, &mods,
+	                    COL_ENTRY_INDEX, &idx,
+	                    -1);
+
+	if (idx == -1) {
+		/* Category row: visible if any child matches */
+		GtkTreeIter child;
+		visible = FALSE;
+
+		if (gtk_tree_model_iter_children (model, &child, iter)) {
+			do {
+				if (filter_visible_func (model, &child, user_data)) {
+					visible = TRUE;
+					break;
+				}
+			} while (gtk_tree_model_iter_next (model, &child));
+		}
+	} else {
+		visible = FALSE;
+
+		/* Match against description */
+		if (description && string_contains_ci (description, search_text)) {
+			visible = TRUE;
+		}
+
+		/* Match against accelerator label */
+		if (!visible && key != 0) {
+			gchar *accel_label = gtk_accelerator_get_label (key, mods);
+			if (accel_label && string_contains_ci (accel_label, search_text)) {
+				visible = TRUE;
+			}
+			g_free (accel_label);
+		}
+
+		/* Also match against the raw accelerator name (e.g. "<Control>w") */
+		if (!visible && key != 0) {
+			gchar *accel_name = gtk_accelerator_name (key, mods);
+			if (accel_name && string_contains_ci (accel_name, search_text)) {
+				visible = TRUE;
+			}
+			g_free (accel_name);
+		}
+	}
+
+	g_free (description);
+
+	return visible;
+}
+
+static void
+on_search_changed (GtkSearchEntry *entry,
+                   gpointer        user_data)
+{
+	GtkTreeModelFilter *filter = GTK_TREE_MODEL_FILTER (user_data);
+	GtkTreeView *tree_view;
+
+	gtk_tree_model_filter_refilter (filter);
+
+	/* Re-expand all after filtering */
+	tree_view = g_object_get_data (G_OBJECT (filter), "tree-view");
+	if (tree_view) {
+		gtk_tree_view_expand_all (tree_view);
+	}
+}
+
+static void
+accel_cell_data_func (GtkTreeViewColumn *column,
+                     GtkCellRenderer   *renderer,
+                     GtkTreeModel      *model,
+                     GtkTreeIter       *iter,
+                     gpointer           user_data)
+{
+	gint idx;
+
+	gtk_tree_model_get (model, iter, COL_ENTRY_INDEX, &idx, -1);
+
+	g_object_set (renderer, "visible", idx >= 0, NULL);
+}
+
+/*
+ * Create the keybinding editor widget for the preferences dialog.
+ */
+GtkWidget *
+nemo_keybindings_create_editor (void)
+{
+	GtkWidget *vbox;
+	GtkWidget *search_entry;
+	GtkWidget *scrolled;
+	GtkWidget *tree_view;
+	GtkWidget *button_box;
+	GtkWidget *reset_button;
+	GtkTreeStore *store;
+	GtkTreeModel *filter_model;
+	GtkTreeViewColumn *column;
+	GtkCellRenderer *renderer;
+	GtkTreeIter entry_iter;
+	GHashTable *category_iters;
+	gint i;
+
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+	gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
+
+	/* Search entry */
+	search_entry = gtk_search_entry_new ();
+	gtk_entry_set_placeholder_text (GTK_ENTRY (search_entry),
+	                                _("Filter shortcuts…"));
+	gtk_box_pack_start (GTK_BOX (vbox), search_entry, FALSE, FALSE, 0);
+
+	/* Tree store: category, description, accel_key, accel_mods, settings_key, entry_index */
+	store = gtk_tree_store_new (NUM_COLS,
+	                            G_TYPE_STRING,    /* category */
+	                            G_TYPE_STRING,    /* description */
+	                            G_TYPE_UINT,      /* accel key */
+	                            G_TYPE_UINT,      /* accel mods */
+	                            G_TYPE_STRING,    /* settings key */
+	                            G_TYPE_INT);      /* entry index */
+
+	/* Build the tree grouped by category */
+	category_iters = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
+
+	for (i = 0; i < nemo_keybinding_entries_count; i++) {
+		const NemoKeybindingEntry *entry = &nemo_keybinding_entries[i];
+		GtkTreeIter *cat_iter;
+		guint key = 0;
+		GdkModifierType mods = 0;
+		g_autofree gchar *accel_string = NULL;
+
+		/* Get or create category row */
+		cat_iter = g_hash_table_lookup (category_iters, entry->category);
+		if (cat_iter == NULL) {
+			cat_iter = g_new0 (GtkTreeIter, 1);
+			gtk_tree_store_append (store, cat_iter, NULL);
+			gtk_tree_store_set (store, cat_iter,
+			                    COL_CATEGORY, _(entry->category),
+			                    COL_DESCRIPTION, _(entry->category),
+			                    COL_ACCEL_KEY, 0,
+			                    COL_ACCEL_MODS, 0,
+			                    COL_SETTINGS_KEY, "",
+			                    COL_ENTRY_INDEX, -1,
+			                    -1);
+			g_hash_table_insert (category_iters,
+			                     (gpointer) entry->category,
+			                     cat_iter);
+		}
+
+		/* Read current accel from GSettings */
+		accel_string = g_settings_get_string (nemo_keybinding_settings,
+		                                      entry->settings_key);
+		if (accel_string && accel_string[0] != '\0') {
+			gtk_accelerator_parse (accel_string, &key, &mods);
+		}
+
+		gtk_tree_store_append (store, &entry_iter, cat_iter);
+		gtk_tree_store_set (store, &entry_iter,
+		                    COL_CATEGORY, _(entry->category),
+		                    COL_DESCRIPTION, _(entry->description),
+		                    COL_ACCEL_KEY, key,
+		                    COL_ACCEL_MODS, mods,
+		                    COL_SETTINGS_KEY, entry->settings_key,
+		                    COL_ENTRY_INDEX, i,
+		                    -1);
+	}
+
+	g_hash_table_destroy (category_iters);
+
+	/* Wrap store in a filter model */
+	filter_model = gtk_tree_model_filter_new (GTK_TREE_MODEL (store), NULL);
+	gtk_tree_model_filter_set_visible_func (
+		GTK_TREE_MODEL_FILTER (filter_model),
+		filter_visible_func, search_entry, NULL);
+
+	/* Tree view uses the filter model */
+	tree_view = gtk_tree_view_new_with_model (filter_model);
+	gtk_tree_view_set_headers_visible (GTK_TREE_VIEW (tree_view), TRUE);
+	gtk_tree_view_set_enable_search (GTK_TREE_VIEW (tree_view), FALSE);
+
+	/* Connect search to filter */
+	g_object_set_data (G_OBJECT (filter_model), "tree-view", tree_view);
+	g_signal_connect (search_entry, "search-changed",
+	                  G_CALLBACK (on_search_changed), filter_model);
+
+	/* Action column */
+	renderer = gtk_cell_renderer_text_new ();
+	column = gtk_tree_view_column_new_with_attributes (
+		_("Action"), renderer,
+		"text", COL_DESCRIPTION,
+		NULL);
+	gtk_tree_view_column_set_expand (column, TRUE);
+	gtk_tree_view_column_set_resizable (column, TRUE);
+	gtk_tree_view_append_column (GTK_TREE_VIEW (tree_view), column);
+
+	/* Shortcut column with editable accelerator cells */
+	renderer = gtk_cell_renderer_accel_new ();
+	g_object_set (renderer,
+	              "editable", TRUE,
+	              "accel-mode", GTK_CELL_RENDERER_ACCEL_MODE_GTK,
+	              NULL);
+
+	g_signal_connect (renderer, "accel-edited",
+	                  G_CALLBACK (on_accel_edited), filter_model);
+	g_signal_connect (renderer, "accel-cleared",
+	                  G_CALLBACK (on_accel_cleared), filter_model);
+
+	column = gtk_tree_view_column_new_with_attributes (
+		_("Shortcut"), renderer,
+		"accel-key", COL_ACCEL_KEY,
+		"accel-mods", COL_ACCEL_MODS,
+		NULL);
+	gtk_tree_view_column_set_cell_data_func (column, renderer,
+	                                         accel_cell_data_func,
+	                                         NULL, NULL);
+	gtk_tree_view_column_set_min_width (column, 200);
+	gtk_tree_view_append_column (GTK_TREE_VIEW (tree_view), column);
+
+	/* Expand all categories */
+	gtk_tree_view_expand_all (GTK_TREE_VIEW (tree_view));
+
+	/* Scrolled window */
+	scrolled = gtk_scrolled_window_new (NULL, NULL);
+	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled),
+	                                GTK_POLICY_NEVER,
+	                                GTK_POLICY_AUTOMATIC);
+	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolled),
+	                                     GTK_SHADOW_IN);
+	gtk_container_add (GTK_CONTAINER (scrolled), tree_view);
+	gtk_box_pack_start (GTK_BOX (vbox), scrolled, TRUE, TRUE, 0);
+
+	/* Reset button */
+	button_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+	reset_button = gtk_button_new_with_label (_("Reset All to Defaults"));
+	g_signal_connect (reset_button, "clicked",
+	                  G_CALLBACK (on_reset_all_clicked), store);
+	gtk_box_pack_end (GTK_BOX (button_box), reset_button, FALSE, FALSE, 0);
+	gtk_box_pack_start (GTK_BOX (vbox), button_box, FALSE, FALSE, 0);
+
+	gtk_widget_show_all (vbox);
+
+	g_object_unref (filter_model);
+	g_object_unref (store);
+
+	return vbox;
+}

--- a/src/nemo-keybindings.h
+++ b/src/nemo-keybindings.h
@@ -1,0 +1,50 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/*
+ * nemo-keybindings.h - Configurable keyboard shortcuts for Nemo.
+ *
+ * Copyright (C) 2026 Nemo contributors
+ *
+ * Nemo is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Nemo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, MA 02110-1335, USA.
+ */
+
+#ifndef NEMO_KEYBINDINGS_H
+#define NEMO_KEYBINDINGS_H
+
+#include <gtk/gtk.h>
+#include <gio/gio.h>
+
+typedef struct {
+	const gchar *settings_key;     /* GSettings key name */
+	const gchar *accel_path;       /* GtkAccelMap path (NULL for binding-set entries) */
+	const gchar *description;      /* Human-readable description */
+	const gchar *category;         /* Category for grouping in UI */
+	const gchar *default_accel;    /* Default accelerator string */
+	const gchar *binding_set_name; /* GtkBindingSet class name (NULL for accel-map entries) */
+	const gchar *signal_name;      /* Signal to emit (NULL for accel-map entries) */
+} NemoKeybindingEntry;
+
+extern const NemoKeybindingEntry nemo_keybinding_entries[];
+extern const gint nemo_keybinding_entries_count;
+
+extern GSettings *nemo_keybinding_settings;
+
+void     nemo_keybindings_init                (void);
+void     nemo_keybindings_apply_all           (void);
+void     nemo_keybindings_set_for_action      (const gchar *settings_key,
+                                               const gchar *accel_string);
+GtkWidget *nemo_keybindings_create_editor     (void);
+
+#endif /* NEMO_KEYBINDINGS_H */

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -1128,11 +1128,24 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
 		return GDK_EVENT_PROPAGATE;
 	}
 
-    if (!nemo_view_get_active (NEMO_VIEW (view)) && gtk_tree_selection_count_selected_rows (selection) > 0) {
-        NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
-        nemo_window_slot_make_hosting_pane_active (slot);
-        return GDK_EVENT_STOP;
-    }
+	if (!nemo_view_get_active (NEMO_VIEW (view))) {
+		NemoWindowSlot *slot = nemo_view_get_nemo_window_slot (NEMO_VIEW (view));
+		nemo_window_slot_make_hosting_pane_active (slot);
+
+		/* Select and cursor the clicked file so the pane activates
+		 * with the right item highlighted. */
+		{
+			GtkTreePath *click_path = NULL;
+			if (gtk_tree_view_get_path_at_pos (tree_view, event->x, event->y,
+			                                   &click_path, NULL, NULL, NULL)) {
+				gtk_tree_selection_unselect_all (selection);
+				gtk_tree_selection_select_path (selection, click_path);
+				gtk_tree_view_set_cursor (tree_view, click_path, NULL, FALSE);
+				gtk_tree_path_free (click_path);
+			}
+		}
+		return GDK_EVENT_STOP;
+	}
 
 	nemo_list_model_set_drag_view
 		(NEMO_LIST_MODEL (gtk_tree_view_get_model (tree_view)),
@@ -4303,13 +4316,34 @@ nemo_list_view_end_loading (NemoView *view,
 {
 	NemoClipboardMonitor *monitor;
 	NemoClipboardInfo *info;
+	NemoListView *list_view;
 
-    set_ok_to_load_deferred_attrs (NEMO_LIST_VIEW (view), TRUE);
+	list_view = NEMO_LIST_VIEW (view);
+
+	set_ok_to_load_deferred_attrs (list_view, TRUE);
 
 	monitor = nemo_clipboard_monitor_get ();
 	info = nemo_clipboard_monitor_get_clipboard_info (monitor);
 
-	list_view_notify_clipboard_info (monitor, info, NEMO_LIST_VIEW (view));
+	list_view_notify_clipboard_info (monitor, info, list_view);
+
+	/* In split-pane mode, if nothing is selected after loading,
+	 * select and cursor the first row so there's always a visible
+	 * cursor in each pane. */
+	{
+		GtkTreeSelection *sel;
+		GtkTreeIter first;
+
+		sel = gtk_tree_view_get_selection (list_view->details->tree_view);
+		if (gtk_tree_selection_count_selected_rows (sel) == 0) {
+			GtkTreeModel *model = gtk_tree_view_get_model (list_view->details->tree_view);
+			if (model != NULL && gtk_tree_model_get_iter_first (model, &first)) {
+				GtkTreePath *path = gtk_tree_model_get_path (model, &first);
+				gtk_tree_view_set_cursor (list_view->details->tree_view, path, NULL, FALSE);
+				gtk_tree_path_free (path);
+			}
+		}
+	}
 }
 
 static const char *

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -34,6 +34,7 @@
 #include "nemo-actions.h"
 #include "nemo-desktop-icon-view.h"
 #include "nemo-error-reporting.h"
+#include "nemo-keybindings.h"
 #include "nemo-list-view.h"
 #include "nemo-mime-actions.h"
 #include "nemo-previewer.h"
@@ -2333,34 +2334,9 @@ sort_favorites_first_changed_callback (gpointer callback_data)
 static void
 swap_delete_keybinding_changed_callback (gpointer callback_data)
 {
-    GtkBindingSet *binding_set = gtk_binding_set_find ("NemoView");
-
-    gboolean swap_keys = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SWAP_TRASH_DELETE);
-
-    gtk_binding_entry_remove (binding_set, GDK_KEY_Delete, 0);
-    gtk_binding_entry_remove (binding_set, GDK_KEY_KP_Delete, 0);
-    gtk_binding_entry_remove (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK);
-    gtk_binding_entry_remove (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK);
-
-    if (swap_keys) {
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
-                          "trash", 0);
-    } else {
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
-                          "delete", 0);
-    }
+    /* Handled by the unified keybinding system in nemo-keybindings.c.
+     * Re-apply the trash and delete-permanently bindings from GSettings. */
+    nemo_keybindings_apply_all ();
 }
 
 static gboolean
@@ -6781,11 +6757,20 @@ action_copy_files_callback (GtkAction *action,
 }
 
 static void
-move_copy_selection_to_next_pane (NemoView *view,
-				  int copy_action)
+action_copy_to_next_pane_callback (GtkAction *action, gpointer callback_data)
 {
+	NemoView *view;
 	NemoWindowSlot *slot;
 	char *dest_location;
+	GList *selection;
+	guint count;
+	GtkWidget *dialog;
+	gint response;
+	gchar *primary;
+	gchar *dest_basename;
+	GFile *dest_file;
+
+	view = NEMO_VIEW (callback_data);
 
 	slot = nemo_window_get_extra_slot (nemo_view_get_nemo_window (view));
 	g_return_if_fail (slot != NULL);
@@ -6793,17 +6778,45 @@ move_copy_selection_to_next_pane (NemoView *view,
 	dest_location = nemo_window_slot_get_current_uri (slot);
 	g_return_if_fail (dest_location != NULL);
 
-	move_copy_selection_to_location (view, copy_action, dest_location);
-}
+	selection = nemo_view_get_selection_for_file_transfer (view);
+	if (selection == NULL) {
+		g_free (dest_location);
+		return;
+	}
 
-static void
-action_copy_to_next_pane_callback (GtkAction *action, gpointer callback_data)
-{
-	NemoView *view;
+	count = g_list_length (selection);
+	dest_file = g_file_new_for_uri (dest_location);
+	dest_basename = g_file_get_basename (dest_file);
 
-	view = NEMO_VIEW (callback_data);
-	move_copy_selection_to_next_pane (view,
-					  GDK_ACTION_COPY);
+	if (count == 1) {
+		NemoFile *file = NEMO_FILE (selection->data);
+		primary = g_strdup_printf (_("Copy \"%s\" to \"%s\"?"),
+		                           nemo_file_get_display_name (file),
+		                           dest_basename);
+	} else {
+		primary = g_strdup_printf (_("Copy %u items to \"%s\"?"),
+		                           count, dest_basename);
+	}
+
+	dialog = gtk_message_dialog_new (nemo_view_get_containing_window (view),
+	                                 GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+	                                 GTK_MESSAGE_QUESTION,
+	                                 GTK_BUTTONS_OK_CANCEL,
+	                                 "%s", primary);
+	gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
+
+	response = gtk_dialog_run (GTK_DIALOG (dialog));
+	gtk_widget_destroy (dialog);
+
+	if (response == GTK_RESPONSE_OK) {
+		move_copy_selection_to_location (view, GDK_ACTION_COPY, dest_location);
+	}
+
+	g_free (primary);
+	g_free (dest_basename);
+	g_object_unref (dest_file);
+	g_free (dest_location);
+	nemo_file_list_free (selection);
 }
 
 static void
@@ -6812,6 +6825,13 @@ action_move_to_next_pane_callback (GtkAction *action, gpointer callback_data)
 	NemoWindowSlot *slot;
 	char *dest_location;
 	NemoView *view;
+	GList *selection;
+	guint count;
+	GtkWidget *dialog;
+	gint response;
+	gchar *primary;
+	gchar *dest_basename;
+	GFile *dest_file;
 
 	view = NEMO_VIEW (callback_data);
 
@@ -6821,7 +6841,45 @@ action_move_to_next_pane_callback (GtkAction *action, gpointer callback_data)
 	dest_location = nemo_window_slot_get_current_uri (slot);
 	g_return_if_fail (dest_location != NULL);
 
-	move_copy_selection_to_location (view, GDK_ACTION_MOVE, dest_location);
+	selection = nemo_view_get_selection_for_file_transfer (view);
+	if (selection == NULL) {
+		g_free (dest_location);
+		return;
+	}
+
+	count = g_list_length (selection);
+	dest_file = g_file_new_for_uri (dest_location);
+	dest_basename = g_file_get_basename (dest_file);
+
+	if (count == 1) {
+		NemoFile *file = NEMO_FILE (selection->data);
+		primary = g_strdup_printf (_("Move \"%s\" to \"%s\"?"),
+		                           nemo_file_get_display_name (file),
+		                           dest_basename);
+	} else {
+		primary = g_strdup_printf (_("Move %u items to \"%s\"?"),
+		                           count, dest_basename);
+	}
+
+	dialog = gtk_message_dialog_new (nemo_view_get_containing_window (view),
+	                                 GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+	                                 GTK_MESSAGE_QUESTION,
+	                                 GTK_BUTTONS_OK_CANCEL,
+	                                 "%s", primary);
+	gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
+
+	response = gtk_dialog_run (GTK_DIALOG (dialog));
+	gtk_widget_destroy (dialog);
+
+	if (response == GTK_RESPONSE_OK) {
+		move_copy_selection_to_location (view, GDK_ACTION_MOVE, dest_location);
+	}
+
+	g_free (primary);
+	g_free (dest_basename);
+	g_object_unref (dest_file);
+	g_free (dest_location);
+	nemo_file_list_free (selection);
 }
 
 static void
@@ -11239,25 +11297,55 @@ nemo_view_class_init (NemoViewClass *klass)
 
 	binding_set = gtk_binding_set_by_class (klass);
 
-    gboolean swap_keys = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SWAP_TRASH_DELETE);
+	/* Initial Delete/Trash binding-set setup.
+	 * If the keybinding settings are already initialized, use them;
+	 * otherwise fall back to the swap-trash-delete preference.
+	 * After startup, nemo_keybindings_apply_all() will re-apply these. */
+	if (nemo_keybinding_settings != NULL) {
+		g_autofree gchar *trash_accel = g_settings_get_string (nemo_keybinding_settings, "trash");
+		g_autofree gchar *trash_alt_accel = g_settings_get_string (nemo_keybinding_settings, "trash-alt");
+		g_autofree gchar *delete_accel = g_settings_get_string (nemo_keybinding_settings, "delete-permanently");
+		guint trash_key = 0, trash_alt_key = 0, delete_key = 0;
+		GdkModifierType trash_mods = 0, trash_alt_mods = 0, delete_mods = 0;
 
-    if (swap_keys) {
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
-                          "trash", 0);
-    } else {
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
-                          "trash", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
-                          "delete", 0);
-        gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
-                          "delete", 0);
-    }
+		gtk_accelerator_parse (trash_accel, &trash_key, &trash_mods);
+		gtk_accelerator_parse (trash_alt_accel, &trash_alt_key, &trash_alt_mods);
+		gtk_accelerator_parse (delete_accel, &delete_key, &delete_mods);
+
+		if (trash_key != 0) {
+			gtk_binding_entry_add_signal (binding_set, trash_key, trash_mods,
+			                              "trash", 0);
+		}
+		if (trash_alt_key != 0) {
+			gtk_binding_entry_add_signal (binding_set, trash_alt_key, trash_alt_mods,
+			                              "trash", 0);
+		}
+		if (delete_key != 0) {
+			gtk_binding_entry_add_signal (binding_set, delete_key, delete_mods,
+			                              "delete", 0);
+		}
+	} else {
+		gboolean swap_keys = g_settings_get_boolean (nemo_preferences,
+		                                             NEMO_PREFERENCES_SWAP_TRASH_DELETE);
+
+		if (swap_keys) {
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
+			                              "delete", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
+			                              "delete", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
+			                              "trash", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
+			                              "trash", 0);
+		} else {
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, 0,
+			                              "trash", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, 0,
+			                              "trash", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_KP_Delete, GDK_SHIFT_MASK,
+			                              "delete", 0);
+			gtk_binding_entry_add_signal (binding_set, GDK_KEY_Delete, GDK_SHIFT_MASK,
+			                              "delete", 0);
+		}
+	}
 }

--- a/src/nemo-window-menus.c
+++ b/src/nemo-window-menus.c
@@ -58,6 +58,7 @@
 #include <libnemo-private/nemo-global-preferences.h>
 #include <libnemo-private/nemo-icon-names.h>
 #include <libnemo-private/nemo-ui-utilities.h>
+#include <libnemo-private/nemo-bookmark.h>
 #include <libnemo-private/nemo-module.h>
 #include <libnemo-private/nemo-undo-manager.h>
 #include <libnemo-private/nemo-program-choosing.h>
@@ -578,6 +579,29 @@ action_show_hide_sidebar_callback (GtkAction *action,
 
 		if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
 			nemo_window_show_sidebar (window);
+
+			/* Focus the first row in the sidebar tree view
+			 * so keyboard navigation works immediately */
+			if (window->details->sidebar != NULL) {
+				GList *children = gtk_container_get_children (
+					GTK_CONTAINER (window->details->sidebar));
+				GList *l;
+				for (l = children; l != NULL; l = l->next) {
+					GtkWidget *child = GTK_WIDGET (l->data);
+					if (GTK_IS_SCROLLED_WINDOW (child)) {
+						GtkWidget *inner = gtk_bin_get_child (GTK_BIN (child));
+						if (GTK_IS_TREE_VIEW (inner)) {
+							GtkTreeView *tv = GTK_TREE_VIEW (inner);
+							GtkTreePath *first = gtk_tree_path_new_first ();
+							gtk_tree_view_set_cursor (tv, first, NULL, FALSE);
+							gtk_widget_grab_focus (GTK_WIDGET (tv));
+							gtk_tree_path_free (first);
+							break;
+						}
+					}
+				}
+				g_list_free (children);
+			}
 		} else {
 			nemo_window_hide_sidebar (window);
 		}
@@ -827,6 +851,515 @@ action_edit_bookmarks_callback (GtkAction *action,
     if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
         nemo_window_edit_bookmarks (NEMO_WINDOW (user_data));
     }
+}
+
+/*
+ * Bookmark / Disk Picker popup menu (Alt+F1 / Alt+F2)
+ *
+ * Shows a popup menu listing all bookmarks and mounted volumes.
+ * Alt+F1: always navigate in the LEFT (first) pane.
+ * Alt+F2: always navigate in the RIGHT (second) pane (opens split view if needed).
+ */
+
+typedef struct {
+	NemoWindow *window;
+	gboolean    right_pane;      /* TRUE = navigate the right (second) pane */
+	GFile      *location;        /* owned */
+	GVolume    *volume;          /* owned, may be NULL */
+} BookmarkPickerData;
+
+static void
+bookmark_picker_data_free (BookmarkPickerData *data)
+{
+	g_clear_object (&data->location);
+	g_clear_object (&data->volume);
+	g_slice_free (BookmarkPickerData, data);
+}
+
+/* Idle callback to switch focus to a specific pane after navigation completes */
+static gboolean
+deferred_focus_pane (gpointer user_data)
+{
+	NemoWindowPane *pane = NEMO_WINDOW_PANE (user_data);
+
+	if (NEMO_IS_WINDOW_PANE (pane) && pane->window != NULL) {
+		nemo_window_set_active_pane (pane->window, pane);
+		nemo_window_pane_grab_focus (pane);
+	}
+
+	g_object_unref (pane);
+	return G_SOURCE_REMOVE;
+}
+
+/* Get the slot for the left (first) or right (second) pane.
+ * Creates split view if necessary for the right pane. */
+static NemoWindowSlot *
+get_pane_slot (NemoWindow *window, gboolean right_pane, NemoWindowPane **out_pane)
+{
+	GList *panes = window->details->panes;
+	NemoWindowPane *target_pane;
+
+	if (right_pane) {
+		/* Ensure split view is open for the right pane */
+		if (!nemo_window_split_view_showing (window)) {
+			nemo_window_split_view_on (window);
+			panes = window->details->panes;
+		}
+		/* The second pane in the list is the right pane */
+		if (panes != NULL && panes->next != NULL) {
+			target_pane = NEMO_WINDOW_PANE (panes->next->data);
+		} else {
+			target_pane = NULL;
+		}
+	} else {
+		/* The first pane in the list is the left pane */
+		if (panes != NULL) {
+			target_pane = NEMO_WINDOW_PANE (panes->data);
+		} else {
+			target_pane = NULL;
+		}
+	}
+
+	if (out_pane != NULL) {
+		*out_pane = target_pane;
+	}
+
+	return (target_pane != NULL) ? target_pane->active_slot : NULL;
+}
+
+/* Called when a bookmark / volume entry in the picker menu is activated. */
+static void
+bookmark_picker_item_activated (GtkMenuItem *item,
+                                gpointer     user_data)
+{
+	BookmarkPickerData *data = user_data;
+	NemoWindowSlot *slot;
+	NemoWindowPane *target_pane = NULL;
+	GFile *location;
+
+	location = data->location;
+
+	if (location == NULL && data->volume != NULL) {
+		GMount *mount = g_volume_get_mount (data->volume);
+		if (mount != NULL) {
+			location = g_mount_get_default_location (mount);
+			g_object_unref (mount);
+		}
+		if (location == NULL) {
+			/* Volume not mounted — could mount it, but skip for now */
+			return;
+		}
+		/* Take ownership so free works correctly */
+		data->location = location;
+	}
+
+	if (location == NULL) {
+		return;
+	}
+
+	slot = get_pane_slot (data->window, data->right_pane, &target_pane);
+
+	if (slot != NULL) {
+		nemo_window_slot_open_location (slot, location, 0);
+
+		/* Defer focus switch so the content view has time to be
+		 * created by the async loader */
+		if (target_pane != NULL) {
+			g_object_ref (target_pane);
+			g_idle_add (deferred_focus_pane, target_pane);
+		}
+	}
+}
+
+static gchar
+pick_mnemonic (const gchar *name, gboolean *used, gchar *out_char)
+{
+	/* Try to find an unused letter in the name for the mnemonic */
+	const gchar *p;
+	for (p = name; *p != '\0'; p = g_utf8_next_char (p)) {
+		gunichar c = g_utf8_get_char (p);
+		gunichar lower = g_unichar_tolower (c);
+		if (g_unichar_isalpha (c) && lower >= 'a' && lower <= 'z') {
+			int idx = (int)(lower - 'a');
+			if (!used[idx]) {
+				used[idx] = TRUE;
+				*out_char = (gchar)lower;
+				return (gchar)lower;
+			}
+		}
+	}
+	*out_char = '\0';
+	return '\0';
+}
+
+static GtkWidget *
+create_picker_menu_item (const gchar *name,
+                         const gchar *icon_name,
+                         gboolean    *mnemonic_used)
+{
+	GtkWidget *item;
+	GtkWidget *box;
+	GtkWidget *icon;
+	GtkWidget *label;
+	gchar mnem_char;
+	gchar *label_text;
+
+	pick_mnemonic (name, mnemonic_used, &mnem_char);
+
+	if (mnem_char != '\0') {
+		/* Build label with underscore before the mnemonic char */
+		GString *s = g_string_new (NULL);
+		const gchar *p;
+		gboolean inserted = FALSE;
+		for (p = name; *p != '\0'; p = g_utf8_next_char (p)) {
+			gunichar c = g_utf8_get_char (p);
+			if (!inserted && g_unichar_tolower (c) == (gunichar)mnem_char) {
+				g_string_append_c (s, '_');
+				inserted = TRUE;
+			}
+			g_string_append_unichar (s, c);
+		}
+		label_text = g_string_free (s, FALSE);
+	} else {
+		label_text = g_strdup (name);
+	}
+
+	item = gtk_menu_item_new ();
+	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+	if (icon_name != NULL) {
+		icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+		gtk_box_pack_start (GTK_BOX (box), icon, FALSE, FALSE, 0);
+	}
+
+	label = gtk_label_new_with_mnemonic (label_text);
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_box_pack_start (GTK_BOX (box), label, TRUE, TRUE, 0);
+
+	gtk_container_add (GTK_CONTAINER (item), box);
+
+	g_free (label_text);
+
+	return item;
+}
+
+static void
+show_bookmark_picker (NemoWindow *window,
+                      gboolean    right_pane)
+{
+	GtkWidget *menu;
+	GtkWidget *item;
+	NemoBookmarkList *bookmarks;
+	GVolumeMonitor *volume_monitor;
+	guint bookmark_count;
+	guint i;
+	GList *drives, *volumes, *mounts, *l, *ll;
+	gboolean mnemonic_used[26] = { FALSE };
+
+	menu = gtk_menu_new ();
+
+	/* --- Section: Bookmarks --- */
+	item = gtk_menu_item_new_with_label (_("Bookmarks"));
+	gtk_widget_set_sensitive (item, FALSE);
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+	item = gtk_separator_menu_item_new ();
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+	/* Home */
+	{
+		BookmarkPickerData *data = g_slice_new0 (BookmarkPickerData);
+		data->window = window;
+		data->right_pane = right_pane;
+		data->location = g_file_new_for_path (g_get_home_dir ());
+
+		item = create_picker_menu_item (_("Home"), "user-home", mnemonic_used);
+		g_signal_connect_data (item, "activate",
+		                       G_CALLBACK (bookmark_picker_item_activated),
+		                       data,
+		                       (GClosureNotify) bookmark_picker_data_free, 0);
+		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+	}
+
+	/* User bookmarks */
+	if (window->details->bookmark_list == NULL) {
+		window->details->bookmark_list = nemo_bookmark_list_get_default ();
+	}
+	bookmarks = window->details->bookmark_list;
+	bookmark_count = nemo_bookmark_list_length (bookmarks);
+
+	for (i = 0; i < bookmark_count; i++) {
+		NemoBookmark *bookmark;
+		const gchar *name;
+		gchar *icon_name;
+		GFile *location;
+		BookmarkPickerData *data;
+
+		bookmark = nemo_bookmark_list_item_at (bookmarks, i);
+		name = nemo_bookmark_get_name (bookmark);
+		icon_name = nemo_bookmark_get_icon_name (bookmark);
+		location = nemo_bookmark_get_location (bookmark);
+
+		data = g_slice_new0 (BookmarkPickerData);
+		data->window = window;
+		data->right_pane = right_pane;
+		data->location = g_object_ref (location);
+
+		item = create_picker_menu_item (name, icon_name, mnemonic_used);
+		g_signal_connect_data (item, "activate",
+		                       G_CALLBACK (bookmark_picker_item_activated),
+		                       data,
+		                       (GClosureNotify) bookmark_picker_data_free, 0);
+		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+		g_free (icon_name);
+	}
+
+	/* --- Section: Disks / Volumes --- */
+	item = gtk_separator_menu_item_new ();
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+	item = gtk_menu_item_new_with_label (_("Disks"));
+	gtk_widget_set_sensitive (item, FALSE);
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+	item = gtk_separator_menu_item_new ();
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+	/* Root filesystem */
+	{
+		BookmarkPickerData *data = g_slice_new0 (BookmarkPickerData);
+		data->window = window;
+		data->right_pane = right_pane;
+		data->location = g_file_new_for_path ("/");
+
+		item = create_picker_menu_item (_("File System"), "drive-harddisk", mnemonic_used);
+		g_signal_connect_data (item, "activate",
+		                       G_CALLBACK (bookmark_picker_item_activated),
+		                       data,
+		                       (GClosureNotify) bookmark_picker_data_free, 0);
+		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+	}
+
+	volume_monitor = g_volume_monitor_get ();
+
+	/* 1) Connected drives and their volumes */
+	drives = g_volume_monitor_get_connected_drives (volume_monitor);
+	for (l = drives; l != NULL; l = l->next) {
+		GDrive *drive = G_DRIVE (l->data);
+		GList *drive_volumes;
+
+		drive_volumes = g_drive_get_volumes (drive);
+
+		if (drive_volumes == NULL) {
+			/* Drive with no volumes (e.g. empty card reader) — skip */
+			continue;
+		}
+
+		for (ll = drive_volumes; ll != NULL; ll = ll->next) {
+			GVolume *volume = G_VOLUME (ll->data);
+			GMount *mount = g_volume_get_mount (volume);
+			gchar *name;
+			GIcon *gicon;
+			gchar *icon_name_str = NULL;
+			BookmarkPickerData *data;
+
+			if (mount == NULL) {
+				/* Not mounted — skip */
+				continue;
+			}
+
+			name = g_volume_get_name (volume);
+			gicon = g_volume_get_icon (volume);
+
+			if (gicon != NULL && G_IS_THEMED_ICON (gicon)) {
+				const gchar * const *names = g_themed_icon_get_names (G_THEMED_ICON (gicon));
+				if (names && names[0])
+					icon_name_str = g_strdup (names[0]);
+			}
+
+			data = g_slice_new0 (BookmarkPickerData);
+			data->window = window;
+			data->right_pane = right_pane;
+			data->location = g_mount_get_default_location (mount);
+
+			item = create_picker_menu_item (name,
+			                                icon_name_str ? icon_name_str : "drive-removable-media",
+			                                mnemonic_used);
+			g_signal_connect_data (item, "activate",
+			                       G_CALLBACK (bookmark_picker_item_activated),
+			                       data,
+			                       (GClosureNotify) bookmark_picker_data_free, 0);
+			gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+			g_free (name);
+			g_free (icon_name_str);
+			g_clear_object (&gicon);
+			g_object_unref (mount);
+		}
+		g_list_free_full (drive_volumes, g_object_unref);
+	}
+	g_list_free_full (drives, g_object_unref);
+
+	/* 2) Volumes without a drive (e.g. loop devices, disk images) */
+	volumes = g_volume_monitor_get_volumes (volume_monitor);
+	for (l = volumes; l != NULL; l = l->next) {
+		GVolume *volume = G_VOLUME (l->data);
+		GDrive *drive;
+
+		drive = g_volume_get_drive (volume);
+		if (drive != NULL) {
+			/* Already listed above under its drive */
+			g_object_unref (drive);
+			continue;
+		}
+
+		{
+			GMount *mount = g_volume_get_mount (volume);
+			gchar *name;
+			GIcon *gicon;
+			gchar *icon_name_str = NULL;
+			BookmarkPickerData *data;
+
+			if (mount == NULL) {
+				/* Not mounted — skip */
+				continue;
+			}
+
+			name = g_volume_get_name (volume);
+			gicon = g_volume_get_icon (volume);
+
+			if (gicon != NULL && G_IS_THEMED_ICON (gicon)) {
+				const gchar * const *names = g_themed_icon_get_names (G_THEMED_ICON (gicon));
+				if (names && names[0])
+					icon_name_str = g_strdup (names[0]);
+			}
+
+			data = g_slice_new0 (BookmarkPickerData);
+			data->window = window;
+			data->right_pane = right_pane;
+			data->location = g_mount_get_default_location (mount);
+
+			item = create_picker_menu_item (name,
+			                                icon_name_str ? icon_name_str : "drive-harddisk",
+			                                mnemonic_used);
+			g_signal_connect_data (item, "activate",
+			                       G_CALLBACK (bookmark_picker_item_activated),
+			                       data,
+			                       (GClosureNotify) bookmark_picker_data_free, 0);
+			gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+			g_free (name);
+			g_free (icon_name_str);
+			g_clear_object (&gicon);
+			g_object_unref (mount);
+		}
+	}
+	g_list_free_full (volumes, g_object_unref);
+
+	/* 3) Mounts without a volume (network shares, MTP phones, fuse mounts) */
+	mounts = g_volume_monitor_get_mounts (volume_monitor);
+	for (l = mounts; l != NULL; l = l->next) {
+		GMount *mount = G_MOUNT (l->data);
+		GVolume *volume;
+
+		volume = g_mount_get_volume (mount);
+		if (volume != NULL) {
+			/* Already listed above under its volume */
+			g_object_unref (volume);
+			continue;
+		}
+
+		/* Shadow mounts (internal implementation detail) — skip */
+		if (g_mount_is_shadowed (mount)) {
+			continue;
+		}
+
+		{
+			gchar *name = g_mount_get_name (mount);
+			GIcon *gicon = g_mount_get_icon (mount);
+			gchar *icon_name_str = NULL;
+			BookmarkPickerData *data;
+
+			if (gicon != NULL && G_IS_THEMED_ICON (gicon)) {
+				const gchar * const *names = g_themed_icon_get_names (G_THEMED_ICON (gicon));
+				if (names && names[0])
+					icon_name_str = g_strdup (names[0]);
+			}
+
+			data = g_slice_new0 (BookmarkPickerData);
+			data->window = window;
+			data->right_pane = right_pane;
+			data->location = g_mount_get_default_location (mount);
+
+			item = create_picker_menu_item (name,
+			                                icon_name_str ? icon_name_str : "folder-remote",
+			                                mnemonic_used);
+			g_signal_connect_data (item, "activate",
+			                       G_CALLBACK (bookmark_picker_item_activated),
+			                       data,
+			                       (GClosureNotify) bookmark_picker_data_free, 0);
+			gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+			g_free (name);
+			g_free (icon_name_str);
+			g_clear_object (&gicon);
+		}
+	}
+	g_list_free_full (mounts, g_object_unref);
+
+	g_object_unref (volume_monitor);
+
+	/* Show and popup anchored to the target pane's toolbar */
+	gtk_widget_show_all (menu);
+
+	{
+		GList *panes = window->details->panes;
+		NemoWindowPane *target = NULL;
+
+		if (right_pane && panes != NULL && panes->next != NULL) {
+			target = NEMO_WINDOW_PANE (panes->next->data);
+		} else if (panes != NULL) {
+			target = NEMO_WINDOW_PANE (panes->data);
+		}
+
+		GtkWidget *anchor = (target && target->tool_bar && gtk_widget_get_visible (target->tool_bar))
+		                     ? target->tool_bar
+		                     : (window->details->active_pane && window->details->active_pane->tool_bar)
+		                       ? window->details->active_pane->tool_bar
+		                       : GTK_WIDGET (window);
+		GdkRectangle rect = { 0, 0, 1, 1 };
+		GtkAllocation alloc;
+
+		gtk_widget_get_allocation (anchor, &alloc);
+		rect.width = alloc.width;
+		rect.y = alloc.height;  /* position just below the toolbar */
+
+		gtk_menu_popup_at_rect (GTK_MENU (menu),
+		                        gtk_widget_get_window (anchor),
+		                        &rect,
+		                        GDK_GRAVITY_NORTH_WEST,
+		                        GDK_GRAVITY_NORTH_WEST,
+		                        NULL);
+	}
+}
+
+static void
+action_bookmark_picker_callback (GtkAction *action,
+                                 gpointer   user_data)
+{
+	if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+		show_bookmark_picker (NEMO_WINDOW (user_data), FALSE);
+	}
+}
+
+static void
+action_bookmark_picker_other_callback (GtkAction *action,
+                                       gpointer   user_data)
+{
+	if (!NEMO_IS_DESKTOP_WINDOW (user_data)) {
+		show_bookmark_picker (NEMO_WINDOW (user_data), TRUE);
+	}
 }
 
 static void
@@ -1522,6 +2055,12 @@ static const GtkActionEntry main_entries[] = {
   /* name, stock id, label */  { "Edit Bookmarks", NULL, N_("_Edit Bookmarks..."),
                                  "<control>b", N_("Display a window that allows editing the bookmarks in this menu"),
                                  G_CALLBACK (action_edit_bookmarks_callback) },
+  /* name, stock id, label */  { NEMO_ACTION_BOOKMARK_PICKER, NULL, N_("Bookmark/_Disk Picker"),
+                                 "<alt>F1", N_("Show a list of bookmarks and disks to navigate to"),
+                                 G_CALLBACK (action_bookmark_picker_callback) },
+  /* name, stock id, label */  { NEMO_ACTION_BOOKMARK_PICKER_OTHER, NULL, N_("Bookmark/Disk Picker (Other _Pane)"),
+                                 "<alt>F2", N_("Show a list of bookmarks and disks to navigate to in the other pane"),
+                                 G_CALLBACK (action_bookmark_picker_other_callback) },
   { "TabsPrevious", NULL, N_("_Previous Tab"), "<control>Page_Up",
     N_("Activate previous tab"),
     G_CALLBACK (action_tabs_previous_callback) },

--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -34,6 +34,7 @@
 #include "nemo-actions.h"
 #include "nemo-application.h"
 #include "nemo-bookmarks-window.h"
+#include "nemo-keybindings.h"
 #include "nemo-desktop-window.h"
 #include "nemo-location-bar.h"
 #include "nemo-mime-actions.h"
@@ -1233,6 +1234,58 @@ nemo_window_key_press_event (GtkWidget *widget,
 		}
 	}
 
+	/* New Folder alternate key (configurable via new-folder-alt) */
+	if (nemo_keybinding_settings != NULL) {
+		g_autofree gchar *nf_accel = g_settings_get_string (nemo_keybinding_settings, "new-folder-alt");
+		guint nf_key = 0;
+		GdkModifierType nf_mods = 0;
+
+		gtk_accelerator_parse (nf_accel, &nf_key, &nf_mods);
+
+		if (nf_key != 0 && event->keyval == nf_key &&
+		    (event->state & gtk_accelerator_get_default_mod_mask ()) == nf_mods) {
+			const GList *action_groups;
+			GtkAction *action = NULL;
+
+			action_groups = gtk_ui_manager_get_action_groups (window->details->ui_manager);
+			while (action_groups != NULL && action == NULL) {
+				action = gtk_action_group_get_action (action_groups->data, NEMO_ACTION_NEW_FOLDER);
+				action_groups = action_groups->next;
+			}
+
+			if (action != NULL && gtk_action_is_sensitive (action)) {
+				gtk_action_activate (action);
+				return TRUE;
+			}
+		}
+	}
+
+	/* Open with default application (configurable via open-default) */
+	if (nemo_keybinding_settings != NULL) {
+		g_autofree gchar *od_accel = g_settings_get_string (nemo_keybinding_settings, "open-default");
+		guint od_key = 0;
+		GdkModifierType od_mods = 0;
+
+		gtk_accelerator_parse (od_accel, &od_key, &od_mods);
+
+		if (od_key != 0 && event->keyval == od_key &&
+		    (event->state & gtk_accelerator_get_default_mod_mask ()) == od_mods) {
+			const GList *action_groups;
+			GtkAction *action = NULL;
+
+			action_groups = gtk_ui_manager_get_action_groups (window->details->ui_manager);
+			while (action_groups != NULL && action == NULL) {
+				action = gtk_action_group_get_action (action_groups->data, NEMO_ACTION_OPEN);
+				action_groups = action_groups->next;
+			}
+
+			if (action != NULL && gtk_action_is_sensitive (action)) {
+				gtk_action_activate (action);
+				return TRUE;
+			}
+		}
+	}
+
 	for (i = 0; i < G_N_ELEMENTS (extra_window_keybindings); i++) {
 		if (extra_window_keybindings[i].keyval == event->keyval) {
 			const GList *action_groups;
@@ -2140,10 +2193,36 @@ nemo_window_class_init (NemoWindowClass *class)
 			      G_TYPE_NONE, 1, NEMO_TYPE_WINDOW_SLOT);
 
 	binding_set = gtk_binding_set_by_class (class);
-	gtk_binding_entry_add_signal (binding_set, GDK_KEY_BackSpace, 0,
-				      "go-up", 0);
-	gtk_binding_entry_add_signal (binding_set, GDK_KEY_F5, 0,
-				      "reload", 0);
+
+	/* BackSpace and F5 are managed by nemo-keybindings.c via GSettings,
+	 * but we need defaults in class_init because the binding set doesn't
+	 * exist yet when nemo_keybindings_apply_all() runs at startup.
+	 * If GSettings are already initialized, read from them;
+	 * otherwise use the hardcoded defaults. */
+	if (nemo_keybinding_settings != NULL) {
+		g_autofree gchar *go_up_accel = g_settings_get_string (nemo_keybinding_settings, "go-up-alt");
+		g_autofree gchar *reload_accel = g_settings_get_string (nemo_keybinding_settings, "reload-alt");
+		guint go_up_key = 0, reload_key = 0;
+		GdkModifierType go_up_mods = 0, reload_mods = 0;
+
+		gtk_accelerator_parse (go_up_accel, &go_up_key, &go_up_mods);
+		gtk_accelerator_parse (reload_accel, &reload_key, &reload_mods);
+
+		if (go_up_key != 0) {
+			gtk_binding_entry_add_signal (binding_set, go_up_key, go_up_mods,
+						      "go-up", 0);
+		}
+		if (reload_key != 0) {
+			gtk_binding_entry_add_signal (binding_set, reload_key, reload_mods,
+						      "reload", 0);
+		}
+	} else {
+		gtk_binding_entry_add_signal (binding_set, GDK_KEY_BackSpace, 0,
+					      "go-up", 0);
+		gtk_binding_entry_add_signal (binding_set, GDK_KEY_F5, 0,
+					      "reload", 0);
+	}
+
 	gtk_binding_entry_add_signal (binding_set, GDK_KEY_slash, 0,
 				      "prompt-for-location", 1,
 				      G_TYPE_STRING, "/");
@@ -2215,6 +2294,8 @@ nemo_window_split_view_on (NemoWindow *window)
 	g_object_unref (location);
 
 	window_set_search_action_text (window, FALSE);
+
+	nemo_window_update_show_hide_ui_elements (window);
 }
 
 void

--- a/support/smplos-keybindings-reset.sh
+++ b/support/smplos-keybindings-reset.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Reset all keybindings back to Nemo defaults
+#
+# Usage:
+#   GSETTINGS_SCHEMA_DIR=libnemo-private/ ./support/smplos-keybindings-reset.sh
+
+SCHEMA="org.nemo.keybindings"
+
+echo "Resetting all keybindings to defaults..."
+
+gsettings reset $SCHEMA copy-to-other-pane
+gsettings reset $SCHEMA move-to-other-pane
+gsettings reset $SCHEMA switch-pane
+gsettings reset $SCHEMA new-folder
+gsettings reset $SCHEMA trash
+gsettings reset $SCHEMA search
+gsettings reset $SCHEMA show-sidebar
+gsettings reset $SCHEMA edit-bookmarks
+gsettings reset $SCHEMA add-bookmark
+gsettings reset $SCHEMA split-view
+gsettings reset $SCHEMA reload-alt
+gsettings reset $SCHEMA open-alternate
+gsettings reset $SCHEMA bookmark-picker
+gsettings reset $SCHEMA bookmark-picker-other
+
+echo "Done. Restart Nemo for changes to take effect."

--- a/support/smplos-keybindings.sh
+++ b/support/smplos-keybindings.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# smplOS Keybinding Profile for Nemo
+# Double Commander-inspired keybindings
+#
+# Usage:
+#   GSETTINGS_SCHEMA_DIR=libnemo-private/ ./support/smplos-keybindings.sh
+#
+# To reset all back to defaults:
+#   GSETTINGS_SCHEMA_DIR=libnemo-private/ ./support/smplos-keybindings-reset.sh
+
+SCHEMA="org.nemo.keybindings"
+
+echo "Applying smplOS keybinding profile..."
+
+# --- Double Commander style ---
+# F5 = Copy selection to other pane (clear reload-alt which also uses F5)
+gsettings set $SCHEMA reload-alt ""
+gsettings set $SCHEMA copy-to-other-pane "F5"
+
+# F6 = Move selection to other pane (clear switch-pane which also uses F6)
+gsettings set $SCHEMA switch-pane ""
+gsettings set $SCHEMA move-to-other-pane "F6"
+
+# F7 = New Folder (was: Ctrl+Shift+N)
+gsettings set $SCHEMA new-folder "F7"
+
+# F8 = Move to Trash (was: Delete)
+gsettings set $SCHEMA trash "F8"
+
+# Alt+F7 = Search (was: Ctrl+F)
+gsettings set $SCHEMA search "<Alt>F7"
+
+# --- Sidebar / Bookmarks ---
+# Ctrl+B = Toggle Sidebar (was: F9) — like VS Code
+gsettings set $SCHEMA show-sidebar "<Control>b"
+
+# Ctrl+Shift+O = Edit Bookmarks (clear open-alternate which also uses Ctrl+Shift+O)
+gsettings set $SCHEMA open-alternate ""
+gsettings set $SCHEMA edit-bookmarks "<Control><Shift>o"
+
+# Ctrl+D = Add Bookmark (already default, but set explicitly)
+gsettings set $SCHEMA add-bookmark "<Control>d"
+
+# --- Bookmark/Disk Picker (Double Commander Alt+F1/F2) ---
+gsettings set $SCHEMA bookmark-picker "<Alt>F1"
+gsettings set $SCHEMA bookmark-picker-other "<Alt>F2"
+
+# --- Enable trash confirmation dialog ---
+gsettings set org.nemo.preferences confirm-move-to-trash true
+
+echo ""
+echo "smplOS keybindings applied:"
+echo "  F5           → Copy to other pane"
+echo "  F6           → Move to other pane"
+echo "  F7           → New folder"
+echo "  F8           → Move to Trash"
+echo "  Alt+F7       → Search"
+echo "  Ctrl+B       → Toggle sidebar (with focus)"
+echo "  Ctrl+Shift+O → Edit bookmarks"
+echo "  Ctrl+D       → Add bookmark"
+echo "  Alt+F1       → Bookmark/disk picker (current pane)"
+echo "  Alt+F2       → Bookmark/disk picker (other pane)"
+echo ""
+echo "Cleared conflicts:"
+echo "  reload-alt      (was F5, use Ctrl+R instead)"
+echo "  switch-pane     (was F6, disabled)"
+echo "  open-alternate  (was Ctrl+Shift+O, disabled)"
+echo ""
+echo "Restart Nemo for all changes to take effect."


### PR DESCRIPTION
All keyboard shortcuts are now stored in GSettings under `org.nemo.keybindings` and can be changed at runtime. A new **Keyboard Shortcuts** tab in Edit → Preferences lets users view, search, and rebind any shortcut using an inline key-capture widget. Changes take effect immediately without restart.

Additional configurable bindings included:
- **open-default** — open with default application (unbound by default)
- **new-folder-alt** — alternate new-folder key (unbound by default)
- **trash-alt** — alternate move-to-trash key (unbound by default)

These allow distro or user profiles to add secondary bindings (e.g. F4, Insert, Delete) without changing Nemo's stock defaults.

<img width="826" height="655" alt="key bindings" src="https://github.com/user-attachments/assets/ccd6e193-1c4b-442a-b684-30fc529dc0d2" />