### PR TITLE
libnemo-private: fix use-after-free crash in nemo_file_mark_gone

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -7947,11 +7947,18 @@ nemo_file_mark_gone (NemoFile *file)
 
 	/* Let the directory know it's gone. */
 	directory = file->details->directory;
+	/* Hold a temporary ref so the object stays alive through both
+	 * nemo_directory_remove_file() (which may drop the last directory ref
+	 * and free the object) AND the nemo_file_clear_info() call below.
+	 * Without this, remove_file can free the NemoFile and clear_info then
+	 * dereferences the freed pointer, causing a SIGSEGV (bug #3712). */
+	nemo_file_ref (file);
 	if (!nemo_file_is_self_owned (file)) {
 		nemo_directory_remove_file (directory, file);
 	}
 
 	nemo_file_clear_info (file);
+	nemo_file_unref (file);
 
 	/* FIXME bugzilla.gnome.org 42429:
 	 * Maybe we can get rid of the name too eventually, but


### PR DESCRIPTION
Fixes #3712.

nemo_directory_remove_file() calls nemo_file_unref() when the directory is monitoring its file list. If the caller holds no extra ref on the file, this can drop the refcount to zero and free the NemoFile object. The nemo_file_clear_info() call immediately after then dereferences the freed pointer, causing a SIGSEGV.

This crash surfaces during file rename: rename_get_info_callback finds an existing file with the same new name and passes it to nemo_file_mark_gone() without holding an extra ref.

The fix is to take a temporary ref around the nemo_directory_remove_file() call so the object stays alive until nemo_file_clear_info() returns.