### PR TITLE
Add desktop icon label width scaling at runtime

### DIFF
--- a/gresources/nemo-desktop-overlay.glade
+++ b/gresources/nemo-desktop-overlay.glade
@@ -25,6 +25,13 @@
     <property name="step_increment">10</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_label_width">
+    <property name="lower">50</property>
+    <property name="upper">200</property>
+    <property name="value">100</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
+  </object>
   <object class="GtkImage" id="image6">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -239,6 +246,52 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_bottom">10</property>
+                                    <property name="homogeneous">True</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Icon Label Width Scale</property>
+                                        <property name="tooltip-text" translatable="yes">Scales the width of the desktop icon label</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkScale" id="label_width_slider">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="adjustment">adjustment_label_width</property>
+                                        <property name="restrict_to_fill_level">False</property>
+                                        <property name="draw_value">False</property>
+                                        <property name="has_origin">False</property>
+                                        <signal name="value-changed" handler="on_label_scale_adjust_changed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -251,7 +304,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">1</property>
+                                    <property name="position">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -656,7 +709,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">2</property>
+                                    <property name="position">3</property>
                                   </packing>
                                 </child>
                                 <child>

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -70,6 +70,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <math.h>
 
 #ifdef HAVE_SELINUX
 #include <selinux/selinux.h>
@@ -3947,6 +3948,50 @@ nemo_file_get_desktop_grid_adjusts (NemoFile   *file,
 
         g_strfreev (meta_strv);
     }
+}
+
+void
+nemo_file_set_desktop_label_scale_adjust (NemoFile   *file,
+                                          const char *key,
+                                          double      double_a)
+{
+    g_return_if_fail (NEMO_IS_FILE (file));
+    g_return_if_fail (key != NULL);
+    g_return_if_fail (key[0] != '\0');
+
+    /* double_a is a single decimal point value in the range [50.0, 200.0] */
+    /* to preserve this value multiple by 10 */
+    /* then use floorf to get the integer part */
+	int value = (int)floorf(double_a * 10);
+
+    /* 1000 is 100.0 - the default value of no scaling */
+    nemo_file_set_integer_metadata (file, key, 1000, value);
+}
+
+void
+nemo_file_get_desktop_label_scale_adjust (NemoFile   *file,
+                                          const char *key,
+                                          double     *double_a)
+{
+    char c;
+    double result;
+
+    g_return_if_fail (key != NULL);
+    g_return_if_fail (key[0] != '\0');
+
+    if (file == NULL ||
+        file->details->metadata == NULL) {
+        return;
+    }
+
+    g_return_if_fail (NEMO_IS_FILE (file));
+
+    /* 1000 is 100.0 - the default value of no scaling */
+	int value = nemo_file_get_integer_metadata (file, key, 1000);
+
+	if (double_a) {
+		*double_a = value / 10.0;
+	}
 }
 
 gboolean

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -386,6 +386,12 @@ void                    nemo_file_get_desktop_grid_adjusts (NemoFile   *file,
                                                             const char *key,
                                                             int        *int_a,
                                                             int        *int_b);
+void                    nemo_file_set_desktop_label_scale_adjust (NemoFile   *file,
+		                                                  const char *key,
+		                                                  double double_a);
+void                    nemo_file_get_desktop_label_scale_adjust (NemoFile   *file,
+		                                                  const char *key,
+		                                                  double *double_a);
 /* Covers for common data types. */
 gboolean                nemo_file_get_boolean_metadata              (NemoFile                   *file,
 									 const char                     *key,

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -821,10 +821,22 @@ static void
 prepare_pango_layout_width (NemoIconCanvasItem *item,
 			    PangoLayout *layout)
 {
+	NemoIconContainer *container;
+    int width;
+
 	if (nemo_icon_canvas_item_get_max_text_width (item) < 0) {
 		pango_layout_set_width (layout, -1);
 	} else {
-		pango_layout_set_width (layout, floor (nemo_icon_canvas_item_get_max_text_width (item)) * PANGO_SCALE);
+        width = floor (nemo_icon_canvas_item_get_max_text_width (item));
+
+		container = NEMO_ICON_CONTAINER (EEL_CANVAS_ITEM (item)->canvas);
+
+        /* check if the container is_desktop? */
+	    if (!IS_COMPACT_VIEW (container) && width % 2 != 0) {
+            width += 1;
+        }
+
+		pango_layout_set_width (layout, width * PANGO_SCALE);
 		pango_layout_set_ellipsize (layout, PANGO_ELLIPSIZE_END);
 	}
 }
@@ -970,6 +982,12 @@ measure_label_text (NemoIconCanvasItem *item)
 		details->text_dx = additional_dx;
 	}
 
+    /* check if the container is_desktop? */
+    if (!IS_COMPACT_VIEW (container) && details->text_width % 2 != 0) {
+		details->text_width += 1;
+		details->text_dx += 1;
+    }
+
 	if (have_additional) {
 		details->text_height = editable_height + LABEL_LINE_SPACING + additional_height;
 		details->text_height_for_layout = editable_height_for_layout + LABEL_LINE_SPACING + additional_height;
@@ -1052,6 +1070,11 @@ draw_label_text (NemoIconCanvasItem *item,
 	g_assert (have_editable || have_additional);
 
 	max_text_width = floor (nemo_icon_canvas_item_get_max_text_width (item));
+
+    /* check if the container is_desktop? */
+    if (!IS_COMPACT_VIEW (container) && max_text_width % 2 != 0) {
+        max_text_width += 1;
+    }
 
 	base_state = gtk_widget_get_state_flags (GTK_WIDGET (container));
 	base_state &= ~(GTK_STATE_FLAG_SELECTED |
@@ -1524,7 +1547,6 @@ nemo_icon_canvas_item_event (EelCanvasItem *item, GdkEvent *event)
 
 	icon_item = NEMO_ICON_CANVAS_ITEM (item);
 	cursor_window = ((GdkEventAny *)event)->window;
-
 
     if (event->type == GDK_ENTER_NOTIFY) {
         nemo_icon_container_update_tooltip_text (NEMO_ICON_CONTAINER (item->canvas), icon_item);
@@ -2008,7 +2030,11 @@ nemo_icon_canvas_item_get_max_text_width (NemoIconCanvasItem *item)
     } else {
         /* normal icon view */
         if (container->details->is_desktop) {
-            return nemo_get_desktop_text_width_for_zoom_level (nemo_icon_container_get_zoom_level (container));
+            return nemo_get_desktop_text_width_for_zoom_level (nemo_icon_container_get_zoom_level (container))
+					/* apply desktop icon label width scaling */
+					* (container->details->label_scale_adjust / 100.0)
+                    /* see measure_label_text(): extra to make it look nicer */
+					- (TEXT_BACK_PADDING_X * 2);
         } else {
             return nemo_get_icon_text_width_for_zoom_level (nemo_icon_container_get_zoom_level (container));
         }

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5007,6 +5007,7 @@ nemo_icon_container_init (NemoIconContainer *container)
 
     details->h_adjust = 100;
     details->v_adjust = 100;
+    details->label_scale_adjust = 100;
 }
 
 typedef struct {
@@ -6669,6 +6670,16 @@ nemo_icon_container_set_grid_adjusts (NemoIconContainer *container,
 
     container->details->h_adjust = h_adjust;
     container->details->v_adjust = v_adjust;
+}
+
+void
+nemo_icon_container_set_label_scale_adjust (NemoIconContainer *container,
+                                            double             label_scale_adjust)
+{
+    g_return_if_fail (NEMO_IS_ICON_CONTAINER (container));
+
+    container->details->label_scale_adjust = label_scale_adjust;
+
 }
 
 gboolean

--- a/libnemo-private/nemo-icon-container.h
+++ b/libnemo-private/nemo-icon-container.h
@@ -287,6 +287,8 @@ gboolean          nemo_icon_container_get_horizontal_layout (NemoIconContainer *
 void              nemo_icon_container_set_grid_adjusts (NemoIconContainer *container,
                                                         gint               h_adjust,
                                                         gint               v_adjust);
+void              nemo_icon_container_set_label_scale_adjust (NemoIconContainer *container,
+                                                              double             label_scale_adjust);
 
 void              nemo_icon_container_set_label_position            (NemoIconContainer  *container,
 									 NemoIconLabelPosition pos);

--- a/libnemo-private/nemo-icon-private.h
+++ b/libnemo-private/nemo-icon-private.h
@@ -257,6 +257,7 @@ struct NemoIconContainerDetails {
     gboolean horizontal;
     gint h_adjust;
     gint v_adjust;
+    double label_scale_adjust;
 
     gboolean show_desktop_tooltips;
     gboolean show_icon_view_tooltips;

--- a/libnemo-private/nemo-metadata.c
+++ b/libnemo-private/nemo-metadata.c
@@ -63,6 +63,7 @@ static char *used_metadata_names[] = {
   (char *)NEMO_METADATA_KEY_PINNED,
   (char *)NEMO_METADATA_KEY_FAVORITE,
   (char *)NEMO_METADATA_KEY_FAVORITE_AVAILABLE,
+  (char *)NEMO_METADATA_KEY_DESKTOP_LABEL_SACLE_ADJUST,
   NULL
 };
 

--- a/libnemo-private/nemo-metadata.h
+++ b/libnemo-private/nemo-metadata.h
@@ -78,6 +78,7 @@
 #define NEMO_METADATA_KEY_DESKTOP_GRID_HORIZONTAL  "desktop-horizontal"
 #define NEMO_METADATA_KEY_SHOW_THUMBNAILS "show-thumbnails"
 #define NEMO_METADATA_KEY_DESKTOP_GRID_ADJUST      "desktop-grid-adjust"
+#define NEMO_METADATA_KEY_DESKTOP_LABEL_SACLE_ADJUST      "desktop-label-scale-adjust"
 
 #define NEMO_METADATA_KEY_PINNED                   "pinned-to-top"
 #define NEMO_METADATA_KEY_FAVORITE                 "xapp-favorite"

--- a/src/nemo-desktop-icon-grid-view.c
+++ b/src/nemo-desktop-icon-grid-view.c
@@ -1259,3 +1259,36 @@ nemo_desktop_icon_grid_view_set_grid_adjusts (NemoDesktopIconGridView *view,
     nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
 
 }
+
+void
+nemo_desktop_icon_grid_view_set_label_scale_adjust (NemoDesktopIconGridView *view,
+                                                    double                   label_scale_adjust)
+{
+    NemoIconContainer *container;
+    NemoFile *file;
+
+    if (view->details->updating_menus) {
+        return;
+    }
+
+    container = get_icon_container (view);
+    clear_orphan_states (view);
+
+    file = nemo_view_get_directory_as_file (NEMO_VIEW (view));
+
+    nemo_icon_container_set_label_scale_adjust (container, label_scale_adjust);
+
+    container->details->needs_resort = TRUE;
+    container->details->auto_layout = TRUE;
+
+    nemo_icon_view_set_directory_label_scale_adjust (NEMO_ICON_VIEW (view),
+                                               file,
+                                               label_scale_adjust);
+
+    nemo_icon_container_redo_layout (container);
+
+    nemo_view_update_menus (NEMO_VIEW (view));
+
+    nemo_icon_container_store_layout_timestamps_now (get_icon_container (view));
+
+}

--- a/src/nemo-desktop-icon-grid-view.h
+++ b/src/nemo-desktop-icon-grid-view.h
@@ -56,5 +56,7 @@ GtkActionGroup *nemo_desktop_icon_grid_view_get_action_group (NemoDesktopIconGri
 void nemo_desktop_icon_grid_view_set_grid_adjusts (NemoDesktopIconGridView *view,
                                                    gint                     h_adjust,
                                                    gint                     v_adjust);
+void nemo_desktop_icon_grid_view_set_label_scale_adjust (NemoDesktopIconGridView *view,
+                                                         double                   label_scale_adjust);
 
 #endif /* NEMO_DESKTOP_ICON_GRID_VIEW_H */

--- a/src/nemo-desktop-manager.c
+++ b/src/nemo-desktop-manager.c
@@ -537,6 +537,18 @@ on_overlay_adjustments_changed (NemoDesktopOverlay      *overlay,
 }
 
 static void
+on_overlay_label_scale_changed (NemoDesktopOverlay      *overlay,
+                                NemoWindow              *window,
+                                double                   label_scale,
+                                NemoDesktopManager      *manager)
+{
+    g_return_if_fail (NEMO_IS_DESKTOP_WINDOW (window));
+
+    nemo_desktop_window_set_label_scale_adjust (NEMO_DESKTOP_WINDOW (window),
+                                                label_scale);
+}
+
+static void
 on_proxy_signal (GDBusProxy *proxy,
                  gchar      *sender,
                  gchar      *signal_name,
@@ -950,7 +962,8 @@ nemo_desktop_manager_get_overlay_info (NemoDesktopManager *manager,
                                        gint                monitor,
                                        GtkActionGroup    **action_group,
                                        gint               *h_adjust,
-                                       gint               *v_adjust)
+                                       gint               *v_adjust,
+                                       double             *label_scale_adjust)
 {
     GtkWindow *window;
 
@@ -959,7 +972,9 @@ nemo_desktop_manager_get_overlay_info (NemoDesktopManager *manager,
     if (NEMO_IS_DESKTOP_WINDOW (window) &&
         nemo_desktop_window_get_grid_adjusts (NEMO_DESKTOP_WINDOW (window),
                                               h_adjust,
-                                              v_adjust)) {
+                                              v_adjust) &&
+        nemo_desktop_window_get_label_scale_adjust (NEMO_DESKTOP_WINDOW (window),
+                                                    label_scale_adjust)) {
 
         *action_group = nemo_desktop_window_get_action_group (NEMO_DESKTOP_WINDOW (window));
     } else {
@@ -981,6 +996,11 @@ nemo_desktop_manager_show_desktop_overlay (NemoDesktopManager *manager,
         g_signal_connect (priv->overlay,
                           "adjusts-changed",
                           G_CALLBACK (on_overlay_adjustments_changed),
+                          manager);
+
+        g_signal_connect (priv->overlay,
+                          "label-scale-changed",
+                          G_CALLBACK (on_overlay_label_scale_changed),
                           manager);
     }
 

--- a/src/nemo-desktop-manager.h
+++ b/src/nemo-desktop-manager.h
@@ -47,7 +47,8 @@ void nemo_desktop_manager_get_overlay_info              (NemoDesktopManager *man
                                                          gint                monitor,
                                                          GtkActionGroup    **action_group,
                                                          gint               *h_adjust,
-                                                         gint               *v_adjust);
+                                                         gint               *v_adjust,
+                                                         double             *label_scale_adjust);
 void     nemo_desktop_manager_show_desktop_overlay    (NemoDesktopManager *manager,
                                                        gint                initial_monitor);
 gboolean nemo_desktop_manager_get_is_cinnamon         (NemoDesktopManager *manager);

--- a/src/nemo-desktop-overlay.c
+++ b/src/nemo-desktop-overlay.c
@@ -31,9 +31,12 @@ typedef struct
 
     guint adjust_changed_id;
     guint configure_event_id;
+    guint label_scale_adjust_changed_id;
 
     gint h_percent;
     gint v_percent;
+
+    double label_scale;
 
     gboolean syncing;
 } NemoDesktopOverlayPrivate;
@@ -48,6 +51,7 @@ struct _NemoDesktopOverlay
 enum
 {
     ADJUSTS_CHANGED,
+    LABEL_SCALE_CHANGED,
     LAST_SIGNAL
 };
 
@@ -113,6 +117,7 @@ sync_controls (NemoDesktopOverlay *overlay,
     gint h_adjust, v_adjust, active_id;
     gboolean fake_group;
     const gchar *combo_id;
+    double label_scale;
 
     priv->syncing = TRUE;
 
@@ -133,13 +138,17 @@ sync_controls (NemoDesktopOverlay *overlay,
                                                priv->monitor,
                                                &action_group,
                                                &h_adjust,
-                                               &v_adjust);
+                                               &v_adjust,
+                                               &label_scale);
 
         range = GTK_RANGE (gtk_builder_get_object (priv->builder, "horizontal_adjust_slider"));
         gtk_range_set_value (range, (double) h_adjust);
 
         range = GTK_RANGE (gtk_builder_get_object (priv->builder, "vertical_adjust_slider"));
         gtk_range_set_value (range, (double) v_adjust);
+
+        range = GTK_RANGE (gtk_builder_get_object (priv->builder, "label_width_slider"));
+        gtk_range_set_value (range, label_scale);
 
         /* Catch enabling of a particular monitor.  If we were a blank window and now
          * we're a real desktop window, it makes sense to present the view settings to the user */
@@ -268,6 +277,28 @@ signal_adjust_changed (NemoDesktopOverlay *overlay)
     }
 }
 
+static void
+signal_label_scale_adjust_changed (NemoDesktopOverlay *overlay)
+{
+    NemoDesktopOverlayPrivate *priv = overlay->priv;
+    double label_scale, val;
+
+    val = gtk_range_get_value (GTK_RANGE (gtk_builder_get_object (priv->builder,
+                                                                    "label_width_slider")));
+
+    /* limit icon label width scaling to 50% to 200% */
+    label_scale =  fmax (fmin (val, 200.0), 50.0);
+
+    if (label_scale != priv->label_scale) {
+        priv->label_scale = label_scale;
+
+        g_signal_emit (overlay,
+                       signals[LABEL_SCALE_CHANGED], 0,
+                       priv->nemo_window,
+                       label_scale);
+    }
+}
+
 static gboolean
 signal_adjust_delay_timeout (gpointer user_data)
 {
@@ -277,6 +308,19 @@ signal_adjust_delay_timeout (gpointer user_data)
     priv->adjust_changed_id = 0;
 
     signal_adjust_changed (overlay);
+
+    return FALSE;
+}
+
+static gboolean
+signal_label_scale_adjust_delay_timeout (gpointer user_data)
+{
+    NemoDesktopOverlay *overlay = NEMO_DESKTOP_OVERLAY (user_data);
+    NemoDesktopOverlayPrivate *priv = nemo_desktop_overlay_get_instance_private (overlay);
+
+    priv->label_scale_adjust_changed_id = 0;
+
+    signal_label_scale_adjust_changed (overlay);
 
     return FALSE;
 }
@@ -298,6 +342,22 @@ queue_changed_signal (NemoDesktopOverlay *overlay)
 }
 
 static void
+queue_label_scale_changed_signal (NemoDesktopOverlay *overlay)
+{
+    NemoDesktopOverlayPrivate *priv = nemo_desktop_overlay_get_instance_private (overlay);
+
+    if (priv->syncing) {
+        return;
+    }
+
+    if (priv->label_scale_adjust_changed_id > 0) {
+        return;
+    }
+
+    priv->label_scale_adjust_changed_id = g_timeout_add (50, (GSourceFunc) signal_label_scale_adjust_delay_timeout, overlay);
+}
+
+static void
 on_horizontal_adjust_changed (GtkRange *range,
                               gpointer  user_data)
 {
@@ -313,6 +373,16 @@ on_vertical_adjust_changed (GtkRange *range,
     NemoDesktopOverlay *overlay = NEMO_DESKTOP_OVERLAY (user_data);
 
     queue_changed_signal (overlay);
+}
+
+
+static void
+on_label_scale_adjust_changed (GtkRange *range,
+                               gpointer  user_data)
+{
+    NemoDesktopOverlay *overlay = NEMO_DESKTOP_OVERLAY (user_data);
+
+    queue_label_scale_changed_signal (overlay);
 }
 
 static void
@@ -388,6 +458,9 @@ on_grid_reset_button_clicked (GtkWidget *button,
     gtk_range_set_value (range, 100.0);
 
     range = GTK_RANGE (gtk_builder_get_object (priv->builder, "vertical_adjust_slider"));
+    gtk_range_set_value (range, 100.0);
+
+    range = GTK_RANGE (gtk_builder_get_object (priv->builder, "label_width_slider"));
     gtk_range_set_value (range, 100.0);
 }
 
@@ -515,6 +588,7 @@ nemo_desktop_overlay_init (NemoDesktopOverlay *overlay)
     gtk_builder_add_callback_symbols (priv->builder,
       "on_vertical_adjust_changed", G_CALLBACK (on_vertical_adjust_changed),
       "on_horizontal_adjust_changed", G_CALLBACK (on_horizontal_adjust_changed),
+      "on_label_scale_adjust_changed", G_CALLBACK (on_label_scale_adjust_changed),
       "on_disabled_view_link_button_clicked", G_CALLBACK (on_view_prefs_button_clicked),
       "on_disabled_view_link_button_activate_link", G_CALLBACK (on_link_button_activate_link),
       "on_view_prefs_link_button_clicked", G_CALLBACK (on_view_prefs_button_clicked),
@@ -600,6 +674,15 @@ nemo_desktop_overlay_class_init (NemoDesktopOverlayClass *klass)
                       NULL, NULL, NULL,
                       G_TYPE_NONE, 3,
                       NEMO_TYPE_WINDOW, G_TYPE_INT, G_TYPE_INT);
+
+    signals[LABEL_SCALE_CHANGED] =
+        g_signal_new ("label-scale-changed",
+                      G_TYPE_FROM_CLASS (klass),
+                      G_SIGNAL_RUN_LAST,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE, 2,
+                      NEMO_TYPE_WINDOW, G_TYPE_DOUBLE);
 
     G_OBJECT_CLASS (klass)->dispose = nemo_desktop_overlay_dispose;
 }

--- a/src/nemo-desktop-window.c
+++ b/src/nemo-desktop-window.c
@@ -415,6 +415,47 @@ nemo_desktop_window_set_grid_adjusts (NemoDesktopWindow *window,
     return TRUE;
 }
 
+
+gboolean
+nemo_desktop_window_get_label_scale_adjust (NemoDesktopWindow *window,
+                                            double            *label_scale_adjust)
+{
+    NemoView *view;
+    NemoWindowSlot *slot;
+    NemoFile *file;
+
+    slot = nemo_window_get_active_slot (NEMO_WINDOW (window));
+    view = nemo_window_slot_get_current_view (slot);
+
+    g_return_val_if_fail (NEMO_IS_VIEW (view), FALSE);
+
+    file = nemo_view_get_directory_as_file (view);
+
+    nemo_icon_view_get_directory_label_scale_adjust (NEMO_ICON_VIEW (view),
+                                                     file,
+                                                     label_scale_adjust);
+
+    return TRUE;
+}
+
+gboolean
+nemo_desktop_window_set_label_scale_adjust (NemoDesktopWindow *window,
+                                            double             label_scale_adjust)
+{
+    NemoView *view;
+    NemoWindowSlot *slot;
+
+    slot = nemo_window_get_active_slot (NEMO_WINDOW (window));
+    view = nemo_window_slot_get_current_view (slot);
+
+    g_return_val_if_fail (NEMO_IS_DESKTOP_ICON_GRID_VIEW (view), FALSE);
+
+    nemo_desktop_icon_grid_view_set_label_scale_adjust (NEMO_DESKTOP_ICON_GRID_VIEW (view),
+                                                        label_scale_adjust);
+
+    return TRUE;
+}
+
 GtkActionGroup *
 nemo_desktop_window_get_action_group (NemoDesktopWindow *window)
 {

--- a/src/nemo-desktop-window.h
+++ b/src/nemo-desktop-window.h
@@ -53,16 +53,20 @@ typedef struct {
 	NemoWindowClass parent_spot;
 } NemoDesktopWindowClass;
 
-GType                  nemo_desktop_window_get_type            (void);
-NemoDesktopWindow     *nemo_desktop_window_new                 (gint monitor);
-gboolean               nemo_desktop_window_loaded              (NemoDesktopWindow *window);
-gint                   nemo_desktop_window_get_monitor         (NemoDesktopWindow *window);
-void                   nemo_desktop_window_update_geometry     (NemoDesktopWindow *window);
-gboolean               nemo_desktop_window_get_grid_adjusts    (NemoDesktopWindow *window,
-                                                                gint              *h_adjust,
-                                                                gint              *v_adjust);
-gboolean               nemo_desktop_window_set_grid_adjusts    (NemoDesktopWindow *window,
-                                                                gint               h_adjust,
-                                                                gint               v_adjust);
-GtkActionGroup *       nemo_desktop_window_get_action_group (NemoDesktopWindow *window);
+GType                  nemo_desktop_window_get_type                  (void);
+NemoDesktopWindow     *nemo_desktop_window_new                       (gint monitor);
+gboolean               nemo_desktop_window_loaded                    (NemoDesktopWindow *window);
+gint                   nemo_desktop_window_get_monitor               (NemoDesktopWindow *window);
+void                   nemo_desktop_window_update_geometry           (NemoDesktopWindow *window);
+gboolean               nemo_desktop_window_get_grid_adjusts          (NemoDesktopWindow *window,
+                                                                      gint              *h_adjust,
+                                                                      gint              *v_adjust);
+gboolean               nemo_desktop_window_set_grid_adjusts          (NemoDesktopWindow *window,
+		                                                      gint               h_adjust,
+		                                                      gint               v_adjust);
+gboolean               nemo_desktop_window_get_label_scale_adjust    (NemoDesktopWindow *window,
+                                                                      double            *label_scale_adjust);
+gboolean               nemo_desktop_window_set_label_scale_adjust    (NemoDesktopWindow *window,
+                                                                      double             label_scale_adjust);
+GtkActionGroup *       nemo_desktop_window_get_action_group          (NemoDesktopWindow *window);
 #endif /* NEMO_DESKTOP_WINDOW_H */

--- a/src/nemo-icon-view-grid-container.c
+++ b/src/nemo-icon-view-grid-container.c
@@ -1418,7 +1418,7 @@ update_layout_constants (NemoIconContainer *container)
 {
     gint icon_size, ellipsis_pref;
     NemoViewLayoutConstants *constants;
-    gdouble scale, h_adjust, v_adjust;
+    gdouble scale, h_adjust, v_adjust, label_scale_adjust;
 
     update_auto_strv_as_quarks (nemo_icon_view_preferences,
                                 NEMO_PREFERENCES_ICON_VIEW_CAPTIONS,
@@ -1433,12 +1433,13 @@ update_layout_constants (NemoIconContainer *container)
 
     h_adjust = container->details->h_adjust / 100.0;
     v_adjust = container->details->v_adjust / 100.0;
+    label_scale_adjust = container->details->label_scale_adjust / 100.0;
 
     constants = container->details->view_constants;
 
     constants->snap_size_x = BASE_SNAP_SIZE_X * scale * h_adjust;
     constants->snap_size_y = BASE_SNAP_SIZE_Y * scale * v_adjust;
-    constants->max_text_width_standard = BASE_MAX_TEXT_WIDTH * scale * h_adjust;
+    constants->max_text_width_standard = BASE_MAX_TEXT_WIDTH * scale * label_scale_adjust;
 
     constants->icon_vertical_adjust = MIN (get_vertical_adjustment (container, icon_size), constants->snap_size_y / 2);
     /* This isn't what this is intended for, but it's a simple way vs. overriding what

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -865,6 +865,37 @@ nemo_icon_view_get_directory_grid_adjusts (NemoIconView *icon_view,
         *vertical = v;
 }
 
+void
+nemo_icon_view_set_directory_label_scale_adjust (NemoIconView *icon_view,
+                                                 NemoFile     *file,
+                                                 double       scale)
+{
+    sync_directory_monitor_number (icon_view, file);
+
+    nemo_file_set_desktop_label_scale_adjust (file,
+                                              NEMO_METADATA_KEY_DESKTOP_LABEL_SACLE_ADJUST,
+                                              scale);
+}
+
+void
+nemo_icon_view_get_directory_label_scale_adjust (NemoIconView *icon_view,
+                                                 NemoFile     *file,
+                                                 double       *scale)
+{
+    double the_scale;
+
+    sync_directory_monitor_number (icon_view, file);
+
+    nemo_file_get_desktop_label_scale_adjust (file,
+                                              NEMO_METADATA_KEY_DESKTOP_LABEL_SACLE_ADJUST,
+                                              &the_scale);
+
+    if (scale) {
+        *scale = the_scale;
+    }
+
+}
+
 gboolean
 nemo_icon_view_set_sort_reversed (NemoIconView *icon_view,
                                   gboolean      new_value,
@@ -984,6 +1015,7 @@ nemo_icon_view_begin_loading (NemoView *view)
 	int level;
     int h_adjust, v_adjust;
 	char *sort_name, *uri;
+	double label_scale_adjust;
 
 	g_return_if_fail (NEMO_IS_ICON_VIEW (view));
 
@@ -1048,7 +1080,12 @@ nemo_icon_view_begin_loading (NemoView *view)
                                                &h_adjust,
                                                &v_adjust);
 
+    nemo_icon_view_get_directory_label_scale_adjust (NEMO_ICON_VIEW (view),
+                                               file,
+                                               &label_scale_adjust);
+
     nemo_icon_container_set_grid_adjusts (get_icon_container (icon_view), h_adjust, v_adjust);
+    nemo_icon_container_set_label_scale_adjust (get_icon_container (icon_view), label_scale_adjust);
 
 	set_labels_beside_icons (icon_view);
 	set_columns_same_width (icon_view);

--- a/src/nemo-icon-view.h
+++ b/src/nemo-icon-view.h
@@ -96,4 +96,11 @@ void nemo_icon_view_get_directory_grid_adjusts (NemoIconView *icon_view,
                                                 NemoFile     *file,
                                                 gint         *horizontal,
                                                 gint         *vertical);
+
+void nemo_icon_view_set_directory_label_scale_adjust (NemoIconView *icon_view,
+		                                      NemoFile     *file,
+		                                      double        scale);
+void nemo_icon_view_get_directory_label_scale_adjust (NemoIconView *icon_view,
+		                                      NemoFile     *file,
+		                                      double       *scale);
 #endif /* NEMO_ICON_VIEW_H */


### PR DESCRIPTION
### Purpose

This pull request addresses the issue where desktop icon labels can overlap when horiztonal grid spacing is reduced (typically when trying to get the icons closer together and/or closer to the left hand edge of the desktop).

### Change Target

This change is only for nemo-desktop, nemo's (file manager) behaviour should be unchanged.

### Background

The issue of overlapping desktop icon labels has been raised in the following bug [#2700](https://github.com/linuxmint/nemo/issues/2700) (linuxmint locked as too heated and limited conversation to collaborators on May 30, 2021).

### Discovery

The width of the desktop icon label is currently hard coded in libnemo-private/nemo-icon-info.h; for each particular zoom level (e.g. #define NEMO_DESKTOP_TEXT_WIDTH_STANDARD 110). 

The layout system (pango) uses these values to set the maximum width for which the label name is to be formatted. 

If the text is short, then the layout rectangle is generally less than the maximum width. 

If the text is long, then the text displayed is capped at the hard coded width maximum and is broken down over multiple lines.

The desktop icons will display a maximum of two lines, with an ellipsis added at the end of the second line in lieu of any omitted text, if required. The omitted text becomes visible when the mouse enters the icon / label area.

As icons are brought closer together, these hard coded maximum width values cause the labels to start to overlap. Aesthetically, a displeasing outcome.

### Solution (tentative)

The solution presented is to add the ability to scale the width of the desktop label at runtime, via the "desktop overlay" window that appears when right-clicking on the desktop and selecting "Customise".

Much like the horizontal and vertical grid spacing sliders, a new "Icon Label Width Scale" (feel free to rename) slider has been added. This new slider allows the user to control the maximum width of the desktop icon label. Currently, from 50% to 200% of the hard coded values.

Also, like the horizontal and vertical grid adjusts, the desktop label width scale adjust value is stored in and loaded from the ~/.config/nemo/desktop.metadata file.

All the plumbing has been implemented to replicate the same behaviour produced when interacting with the existing grid spacing sliders.

### Screenshots

The following imagines show a portion of a 1080x1920 desktop with a background image of a 96x104 pixel grid (effectively giving 10 icons down and 20 icons across).

A variety of long and short label texts are on display. 

The grid spacing has been set to horizontally: center the desktop icons within its "grid cell", and vertically: place the icons near the top of their respective "grid cell".

1. Nemo Desktop Overlay Window Modified

<img width="677" height="491" alt="1  Nemo Desktop Overlay Window Modified" src="https://github.com/user-attachments/assets/9dcaa74c-e1dd-4edf-90d9-7073e6b59c84" />

Image shows the modified "customise" window.

2. Current layout with no scaling applied

<img width="327" height="1079" alt="2  Current layout with no scaling applied" src="https://github.com/user-attachments/assets/f8c1e0e3-d8c4-4d98-8433-57dc627c0180" />

Image shows the current layout with hard coded maximum desktop icon label widths, where the longer labels overlap.

3. New layout with scaling applied

<img width="321" height="1079" alt="3  New layout with scaling applied" src="https://github.com/user-attachments/assets/93fdfa3f-3bed-4e9c-9e19-57fe6e8693fc" />

Image show the new layout with the desktop icon label scaling set to reduce the maximum desktop icon label width, where the longer labels do not overlap.

4. Nemo (unmodified)

<img width="1267" height="750" alt="4  Nemo (unmodified)" src="https://github.com/user-attachments/assets/2b18ece2-6840-44e9-940f-fae3de50fe3d" />

Image shows Nemo (unmodified) file explorer running showing the Desktop icons

5. Nemo (modified)

<img width="1271" height="729" alt="5  Nemo (modified)" src="https://github.com/user-attachments/assets/9b67e85b-b6b4-401b-8125-c52c4b7d4d77" />

Image shows Nemo (modified) file explorer running showing the Desktop icons

Images 4. and 5. are effectively the same, just shown for visual reference.

First time attempting to contribute to an open source project. Valid, constructive criticisms welcomed.