### PR TITLE
Add custom date format and alternating row colors in list view

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -938,14 +938,14 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="list_view_alternating_rows_checkbutton">
-                                            <property name="label" translatable="yes">Abwechselnde Zeilenfarben (weiß / hellgrau)</property>
+                                            <property name="label" translatable="yes">Alternating row colors (white / light gray)</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="use-underline">True</property>
                                             <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
-                                            <property name="tooltip-text" translatable="yes">Zeilen abwechselnd weiß und hellgrau darstellen, um die Lesbarkeit zu verbessern.</property>
+                                            <property name="tooltip-text" translatable="yes">Display rows alternating white and light gray to improve readability.</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -936,6 +936,23 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="list_view_alternating_rows_checkbutton">
+                                            <property name="label" translatable="yes">Abwechselnde Zeilenfarben (weiß / hellgrau)</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <property name="tooltip-text" translatable="yes">Zeilen abwechselnd weiß und hellgrau darstellen, um die Lesbarkeit zu verbessern.</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -1968,6 +1985,44 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkBox" id="date_format_custom_box">
+                                    <property name="visible">False</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="date_format_custom_label">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Format string:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="date_format_custom_entry">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="width-chars">24</property>
+                                        <property name="tooltip-text" translatable="yes">Tokens: YYYY=year, YY=2-digit year, MM=month, DD=day, HH=hour(24h), hh=hour(12h), mm=minute, SS=second&#10;Example: YYYY.MM.DD HH:mm:SS</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkAlignment" id="alignment10">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
@@ -2024,6 +2079,54 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment_date_autosize">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">40</property>
+                                <child>
+                                  <object class="GtkBox" id="date_column_buttons_box">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="orientation">horizontal</property>
+                                    <property name="spacing">8</property>
+                                    <child>
+                                      <object class="GtkButton" id="date_column_autofit_button">
+                                        <property name="label" translatable="yes">Auto-fit</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="tooltip-text" translatable="yes">Sets all date column widths to text width plus saved padding. Column widths remain manually adjustable.</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="date_column_save_padding_button">
+                                        <property name="label" translatable="yes">Save padding</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="tooltip-text" translatable="yes">Saves the current padding between text and column border as the new default for &quot;Auto-fit&quot;.</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                             <child>

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -5158,6 +5158,106 @@ nemo_date_type_to_string (NemoDateType type)
 }
 
 /**
+ * nemo_custom_date_format_to_strftime:
+ *
+ * Convert a user-friendly date format string (e.g. "YYYY.MM.DD HH:mm:SS")
+ * into a strftime-compatible format string.
+ *
+ * Supported tokens:
+ *   YYYY  -> %Y  (4-digit year)
+ *   YY    -> %y  (2-digit year)
+ *   MM    -> %m  (month 01-12)
+ *   DD    -> %d  (day 01-31)
+ *   HH    -> %H  (hour 00-23, 24h)
+ *   hh    -> %I  (hour 01-12, 12h)
+ *   mm    -> %M  (minute 00-59)
+ *   SS    -> %S  (second 00-59)
+ *
+ * Returns: Newly allocated strftime format string (caller must g_free).
+ **/
+static gchar *
+nemo_custom_date_format_to_strftime (const gchar *user_fmt)
+{
+    /* Token table: order matters – longer tokens before shorter ones
+     * that share a prefix (YYYY before YY, HH before hh). */
+    static const struct { const gchar *token; const gchar *replacement; } tokens[] = {
+        { "YYYY", "%Y" },
+        { "YY",   "%y" },
+        { "MM",   "%m" },
+        { "DD",   "%d" },
+        { "HH",   "%H" },
+        { "hh",   "%I" },
+        { "mm",   "%M" },
+        { "SS",   "%S" },
+        { NULL, NULL }
+    };
+
+    GString *out = g_string_new ("");
+    const gchar *p = user_fmt;
+
+    while (*p != '\0') {
+        gboolean matched = FALSE;
+        gint i;
+
+        for (i = 0; tokens[i].token != NULL; i++) {
+            gsize tlen = strlen (tokens[i].token);
+            if (g_ascii_strncasecmp (p, tokens[i].token, tlen) == 0 &&
+                /* Case-sensitive check: token must match exactly */
+                strncmp (p, tokens[i].token, tlen) == 0) {
+                g_string_append (out, tokens[i].replacement);
+                p += tlen;
+                matched = TRUE;
+                break;
+            }
+        }
+
+        if (!matched) {
+            g_string_append_c (out, *p);
+            p++;
+        }
+    }
+
+    return g_string_free (out, FALSE);
+}
+
+/**
+ * nemo_file_get_sample_date_string:
+ *
+ * Returns a sample date string formatted with the current date format
+ * preference. Useful for measuring the required column width.
+ * The caller is responsible for g_free-ing the result.
+ **/
+gchar *
+nemo_file_get_sample_date_string (void)
+{
+    GDateTime *now = g_date_time_new_now_local ();
+    gchar *result = NULL;
+
+    switch (prefs_current_date_format) {
+        case NEMO_DATE_FORMAT_ISO:
+            result = g_date_time_format (now, "%Y-%m-%d %H:%M:%S");
+            break;
+        case NEMO_DATE_FORMAT_CUSTOM: {
+            const gchar *user_fmt = (prefs_current_date_custom_format != NULL &&
+                                     *prefs_current_date_custom_format != '\0')
+                                    ? prefs_current_date_custom_format
+                                    : "YYYY.MM.DD HH:mm:SS";
+            gchar *strfmt = nemo_custom_date_format_to_strftime (user_fmt);
+            result = g_date_time_format (now, strfmt);
+            g_free (strfmt);
+            break;
+        }
+        case NEMO_DATE_FORMAT_LOCALE:
+        default:
+            result = g_date_time_format (now, "%c");
+            break;
+    }
+
+    g_date_time_unref (now);
+    return result;
+}
+
+/**
  * nemo_file_get_date_as_string:
  *
  * Get a user-displayable string representing a file modification date.
@@ -5207,7 +5307,16 @@ nemo_file_get_date_as_string (NemoFile       *file,
 	} else if (date_format_pref == NEMO_DATE_FORMAT_ISO) {
 		result = g_date_time_format (file_date_time, "%Y-%m-%d %H:%M:%S");
 		goto out;
-	}
+	} else if (date_format_pref == NEMO_DATE_FORMAT_CUSTOM) {
+        const gchar *user_fmt = (prefs_current_date_custom_format != NULL &&
+                                 *prefs_current_date_custom_format != '\0')
+                                ? prefs_current_date_custom_format
+                                : "YYYY.MM.DD HH:mm:SS";
+        gchar *strfmt = nemo_custom_date_format_to_strftime (user_fmt);
+        result = g_date_time_format (file_date_time, strfmt);
+        g_free (strfmt);
+        goto out;
+    }
 
     if (date_format != NEMO_DATE_FORMAT_FULL) {
         GDateTime *file_date;

--- a/libnemo-private/nemo-file.h
+++ b/libnemo-private/nemo-file.h
@@ -552,6 +552,9 @@ gint nemo_file_get_search_result_count            (NemoFile *file, gpointer sear
 gchar *nemo_file_get_search_result_count_as_string (NemoFile *file, gpointer search_dir);
 gchar *nemo_file_get_search_result_snippet        (NemoFile *file, gpointer search_dir);
 
+/* Date formatting helpers */
+gchar *nemo_file_get_sample_date_string (void);
+
 /* Debugging */
 void                    nemo_file_dump                              (NemoFile                   *file);
 

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -61,6 +61,7 @@ GSettings *gnome_interface_preferences;
 GTimeZone      *prefs_current_timezone;
 gboolean        prefs_current_24h_time_format;
 NemoDateFormat  prefs_current_date_format;
+gchar          *prefs_current_date_custom_format = NULL;
 
 GTimer    *nemo_startup_timer;
 
@@ -413,6 +414,8 @@ on_time_data_changed (gpointer user_data)
 {
     prefs_current_date_format = g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_DATE_FORMAT);
     prefs_current_24h_time_format = g_settings_get_boolean (cinnamon_interface_preferences, "clock-use-24h");
+    g_free (prefs_current_date_custom_format);
+    prefs_current_date_custom_format = g_settings_get_string (nemo_preferences, NEMO_PREFERENCES_DATE_FORMAT_CUSTOM);
 
     if (prefs_current_timezone != NULL) {
         g_time_zone_unref (prefs_current_timezone);
@@ -430,6 +433,10 @@ setup_cached_time_data (void)
 
     g_signal_connect_swapped (nemo_preferences,
                               "changed::" NEMO_PREFERENCES_DATE_FORMAT,
+                              G_CALLBACK (on_time_data_changed), NULL);
+
+    g_signal_connect_swapped (nemo_preferences,
+                              "changed::" NEMO_PREFERENCES_DATE_FORMAT_CUSTOM,
                               G_CALLBACK (on_time_data_changed), NULL);
 
     g_signal_connect_swapped (cinnamon_interface_preferences,

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -43,6 +43,12 @@ G_BEGIN_DECLS
 #define NEMO_PREFERENCES_SHOW_HIDDEN_FILES			"show-hidden-files"
 #define NEMO_PREFERENCES_SHOW_ADVANCED_PERMISSIONS		"show-advanced-permissions"
 #define NEMO_PREFERENCES_DATE_FORMAT            "date-format"
+#define NEMO_PREFERENCES_DATE_FORMAT_CUSTOM     "date-format-custom"
+#define NEMO_PREFERENCES_DATE_COLUMN_AUTOSIZE        "date-column-autosize"
+#define NEMO_PREFERENCES_DATE_COLUMN_FIT_TRIGGER         "date-column-fit-trigger"
+#define NEMO_PREFERENCES_DATE_COLUMN_PADDING             "date-column-padding"
+#define NEMO_PREFERENCES_DATE_COLUMN_SAVE_PADDING_TRIGGER "date-column-save-padding-trigger"
+#define NEMO_PREFERENCES_LIST_VIEW_ALTERNATING_ROWS  "list-view-alternating-rows"
 #define NEMO_PREFERENCES_DATE_FONT_CHOICE  "date-font-choice"
 #define NEMO_PREFERENCES_MONO_FONT_NAME "monospace-font-name"
 
@@ -55,7 +61,8 @@ typedef enum
 {
 	NEMO_DATE_FORMAT_LOCALE,
 	NEMO_DATE_FORMAT_ISO,
-	NEMO_DATE_FORMAT_INFORMAL
+	NEMO_DATE_FORMAT_INFORMAL,
+	NEMO_DATE_FORMAT_CUSTOM
 } NemoDateFormat;
 
 typedef enum
@@ -327,6 +334,7 @@ extern GSettings *gnome_interface_preferences;
 extern GTimeZone      *prefs_current_timezone;
 extern gboolean        prefs_current_24h_time_format;
 extern NemoDateFormat  prefs_current_date_format;
+extern gchar          *prefs_current_date_custom_format;
 
 extern GTimer    *nemo_startup_timer;
 

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -26,6 +26,7 @@
     <value nick="locale" value="0"/>
     <value nick="iso" value="1"/>
     <value nick="informal" value="2"/>
+    <value nick="custom" value="3"/>
   </enum>
 
   <enum id="org.nemo.DateFontChoice">
@@ -309,7 +310,37 @@
     <key name="date-format" enum="org.nemo.DateFormat">
       <default>'locale'</default>
       <summary>Date Format</summary>
-      <description>The format of file dates. Possible values are "locale", "iso", and "informal".</description>
+      <description>The format of file dates. Possible values are "locale", "iso", "informal", and "custom".</description>
+    </key>
+    <key name="date-format-custom" type="s">
+      <default>'YYYY.MM.DD HH:mm:SS'</default>
+      <summary>Custom Date Format</summary>
+      <description>Custom date format string. Tokens: YYYY=4-digit year, YY=2-digit year, MM=month, DD=day, HH=hour(24h), hh=hour(12h), mm=minute, SS=second.</description>
+    </key>
+    <key name="date-column-autosize" type="b">
+      <default>false</default>
+      <summary>Auto-size date columns</summary>
+      <description>Automatically resize date columns in list view to fit the date string.</description>
+    </key>
+    <key name="date-column-fit-trigger" type="i">
+      <default>0</default>
+      <summary>Date column fit trigger</summary>
+      <description>Incremented each time the user clicks the auto-fit button for date columns.</description>
+    </key>
+    <key name="date-column-padding" type="i">
+      <default>-16</default>
+      <summary>Date column padding</summary>
+      <description>Pixel offset added to the measured text width when auto-fitting date columns. Negative values make the column tighter.</description>
+    </key>
+    <key name="date-column-save-padding-trigger" type="i">
+      <default>0</default>
+      <summary>Save date column padding trigger</summary>
+      <description>Incremented each time the user clicks the save-padding button.</description>
+    </key>
+    <key name="list-view-alternating-rows" type="b">
+      <default>true</default>
+      <summary>Alternating row colors in list view</summary>
+      <description>Show alternating white and light-gray rows in the list view for easier reading.</description>
     </key>
     <key name="date-font-choice" enum="org.nemo.DateFontChoice">
       <default>'auto-mono'</default>

--- a/po/de_custom.po
+++ b/po/de_custom.po
@@ -1,0 +1,29 @@
+# German translations for custom Nemo date format additions.
+# These strings are not in the upstream nemo.mo and must be merged manually.
+#
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
+
+msgid "Custom…"
+msgstr "Benutzerdefiniert…"
+
+msgid "Format string:"
+msgstr "Formatzeichenfolge:"
+
+msgid "Tokens: YYYY=year, YY=2-digit year, MM=month, DD=day, HH=hour(24h), hh=hour(12h), mm=minute, SS=second\nExample: YYYY.MM.DD HH:mm:SS"
+msgstr "Token: YYYY=Jahr, YY=2-stelliges Jahr, MM=Monat, DD=Tag, HH=Stunde(24h), hh=Stunde(12h), mm=Minute, SS=Sekunde\nBeispiel: YYYY.MM.DD HH:mm:SS"
+
+msgid "Auto-fit"
+msgstr "Automatisch anpassen"
+
+msgid "Sets all date column widths to text width plus saved padding. Column widths remain manually adjustable."
+msgstr "Setzt die Breite aller Datumsspalten auf Textbreite + gespeicherter Abstand. Die Breite bleibt manuell verschiebbar."
+
+msgid "Save padding"
+msgstr "Abstand speichern"
+
+msgid "Saves the current padding between text and column border as the new default for \"Auto-fit\"."
+msgstr "Speichert den aktuellen Abstand zwischen Textinhalt und Spaltenrand als neuen Standard für \"Automatisch anpassen\"."

--- a/po/de_custom.po
+++ b/po/de_custom.po
@@ -16,6 +16,12 @@ msgstr "Formatzeichenfolge:"
 msgid "Tokens: YYYY=year, YY=2-digit year, MM=month, DD=day, HH=hour(24h), hh=hour(12h), mm=minute, SS=second\nExample: YYYY.MM.DD HH:mm:SS"
 msgstr "Token: YYYY=Jahr, YY=2-stelliges Jahr, MM=Monat, DD=Tag, HH=Stunde(24h), hh=Stunde(12h), mm=Minute, SS=Sekunde\nBeispiel: YYYY.MM.DD HH:mm:SS"
 
+msgid "Alternating row colors (white / light gray)"
+msgstr "Abwechselnde Zeilenfarben (weiß / hellgrau)"
+
+msgid "Display rows alternating white and light gray to improve readability."
+msgstr "Zeilen abwechselnd weiß und hellgrau darstellen, um die Lesbarkeit zu verbessern."
+
 msgid "Auto-fit"
 msgstr "Automatisch anpassen"
 

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -50,8 +50,14 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_COMPACT_VIEW_ZOOM_WIDGET "compact_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_LIST_VIEW_ZOOM_WIDGET "list_view_zoom_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SORT_ORDER_WIDGET "sort_order_combobox"
-#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_WIDGET "date_format_combobox"
-#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET "date_font_choice_combobox"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_WIDGET       "date_format_combobox"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_CUSTOM_BOX   "date_format_custom_box"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_CUSTOM_ENTRY "date_format_custom_entry"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET  "date_font_choice_combobox"
+/* date_column_autosize_checkbutton was removed; autosize is now triggered via buttons */
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_COLUMN_FITBTN_WIDGET     "date_column_autofit_button"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_COLUMN_SAVEBTN_WIDGET    "date_column_save_padding_button"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_ALTERNATING_ROWS_WIDGET      "list_view_alternating_rows_checkbutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_IMAGE_WIDGET "preview_image_combobox"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PREVIEW_FOLDER_WIDGET "preview_folder_combobox"
@@ -159,6 +165,7 @@ static const char * const date_format_values[] = {
 	"locale",
 	"iso",
 	"informal",
+	"custom",
 	NULL
 };
 
@@ -510,6 +517,9 @@ create_date_format_menu (GtkBuilder *builder)
 
 	gtk_combo_box_text_append_text (combo_box, _("Yesterday"));
 
+    /* "Custom" entry shows the current custom format as preview */
+    gtk_combo_box_text_append_text (combo_box, _("Custom…"));
+
 	g_date_time_unref (now);
 }
 
@@ -837,20 +847,55 @@ on_dialog_destroy (GtkWidget *widget,
 }
 
 static void
+on_date_column_autofit_button_clicked (GtkButton *button,
+                                       gpointer   user_data)
+{
+    gint current = g_settings_get_int (nemo_preferences,
+                                       NEMO_PREFERENCES_DATE_COLUMN_FIT_TRIGGER);
+    g_settings_set_int (nemo_preferences,
+                        NEMO_PREFERENCES_DATE_COLUMN_FIT_TRIGGER, current + 1);
+}
+
+static void
+on_date_column_save_padding_clicked (GtkButton *button,
+                                     gpointer   user_data)
+{
+    gint current = g_settings_get_int (nemo_preferences,
+                                       NEMO_PREFERENCES_DATE_COLUMN_SAVE_PADDING_TRIGGER);
+    g_settings_set_int (nemo_preferences,
+                        NEMO_PREFERENCES_DATE_COLUMN_SAVE_PADDING_TRIGGER, current + 1);
+}
+
+static void
+on_date_format_custom_entry_changed (GtkEntry *entry,
+                                     gpointer  user_data)
+{
+    const gchar *text = gtk_entry_get_text (entry);
+    g_settings_set_string (nemo_preferences, NEMO_PREFERENCES_DATE_FORMAT_CUSTOM, text);
+}
+
+static void
 on_date_format_combo_changed (GtkComboBox *widget,
                               gpointer     user_data)
 {
     GtkBuilder *builder = GTK_BUILDER (user_data);
     gint active = gtk_combo_box_get_active (widget);
+    GtkWidget *custom_box = GTK_WIDGET (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_CUSTOM_BOX));
 
     switch (active) {
         case NEMO_DATE_FORMAT_LOCALE:
         case NEMO_DATE_FORMAT_ISO:
             gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET)), TRUE);
+            gtk_widget_hide (custom_box);
+            break;
+        case NEMO_DATE_FORMAT_CUSTOM:
+            gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET)), TRUE);
+            gtk_widget_show (custom_box);
             break;
         case NEMO_DATE_FORMAT_INFORMAL:
         default:
             gtk_widget_set_sensitive (GTK_WIDGET (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET)), FALSE);
+            gtk_widget_hide (custom_box);
             break;
     }
 }
@@ -1020,6 +1065,13 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
                NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FONT_CHOICE_WIDGET,
                NEMO_PREFERENCES_DATE_FONT_CHOICE,
                (const char **) date_font_choice_values);
+    bind_builder_bool (builder, nemo_preferences,
+               NEMO_FILE_MANAGEMENT_PROPERTIES_ALTERNATING_ROWS_WIDGET,
+               NEMO_PREFERENCES_LIST_VIEW_ALTERNATING_ROWS);
+    g_signal_connect (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_COLUMN_FITBTN_WIDGET),
+                      "clicked", G_CALLBACK (on_date_column_autofit_button_clicked), NULL);
+    g_signal_connect (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_COLUMN_SAVEBTN_WIDGET),
+                      "clicked", G_CALLBACK (on_date_column_save_padding_clicked), NULL);
 	bind_builder_radio (builder, nemo_preferences,
 			    (const char **) click_behavior_components,
 			    NEMO_PREFERENCES_CLICK_POLICY,
@@ -1136,6 +1188,16 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 
     g_signal_connect (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_WIDGET), "changed",
                       G_CALLBACK (on_date_format_combo_changed), builder);
+
+    /* Initialise custom format entry from settings */
+    {
+        GtkEntry *custom_entry = GTK_ENTRY (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_CUSTOM_ENTRY));
+        gchar *stored = g_settings_get_string (nemo_preferences, NEMO_PREFERENCES_DATE_FORMAT_CUSTOM);
+        gtk_entry_set_text (custom_entry, stored);
+        g_free (stored);
+        g_signal_connect (custom_entry, "changed",
+                          G_CALLBACK (on_date_format_custom_entry_changed), NULL);
+    }
 
     on_date_format_combo_changed (GTK_COMBO_BOX (gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_WIDGET)),
                                   builder);

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -54,6 +54,7 @@
 #include <libnemo-private/nemo-dnd.h>
 #include <libnemo-private/nemo-file-dnd.h>
 #include <libnemo-private/nemo-file-utilities.h>
+#include <libnemo-private/nemo-file.h>
 #include <libnemo-private/nemo-ui-utilities.h>
 #include <libnemo-private/nemo-global-preferences.h>
 #include <libnemo-private/nemo-icon-dnd.h>
@@ -128,6 +129,8 @@ struct NemoListViewDetails {
     gint current_selection_count;
 
     gboolean overlay_scrolling;
+
+    GtkCssProvider *alternating_rows_provider;
 };
 
 struct SelectionForeachData {
@@ -2237,6 +2240,8 @@ apply_columns_settings (NemoListView *list_view,
     g_list_free (view_columns);
 }
 
+static void set_row_background (GtkCellRenderer *renderer, GtkTreeModel *model, GtkTreeIter *iter);
+
 static void
 filename_cell_data_func (GtkTreeViewColumn *column,
 			 GtkCellRenderer   *renderer,
@@ -2276,6 +2281,8 @@ filename_cell_data_func (GtkTreeViewColumn *column,
 		      NULL);
 
     g_free (text);
+
+    set_row_background (GTK_CELL_RENDERER (renderer), model, iter);
 }
 
 static gboolean
@@ -2493,8 +2500,7 @@ update_date_fonts (NemoListView *view)
                               "font", date_name,
                               NULL);
             }
-        }
-        else {
+        } else {
             g_object_set (GTK_CELL_RENDERER_TEXT (cell),
                           "font", font_name,
                           NULL);
@@ -2507,6 +2513,198 @@ update_date_fonts (NemoListView *view)
     g_free (font_name);
     g_free (date_family);
     g_free (date_name);
+}
+
+/* Measure the current date format string and set all date columns to that width.
+ * Columns remain in FIXED+resizable mode so the user can still adjust manually. */
+static void
+auto_fit_date_columns (NemoListView *view)
+{
+    g_return_if_fail (NEMO_IS_LIST_VIEW (view));
+
+    gchar *font_name = NULL;
+    GtkSettings *settings = gtk_settings_get_default ();
+    g_object_get (settings, "gtk-font-name", &font_name, NULL);
+
+    gchar *sample = nemo_file_get_sample_date_string ();
+    if (sample == NULL) {
+        g_free (font_name);
+        return;
+    }
+
+    PangoLayout *layout = gtk_widget_create_pango_layout (
+        GTK_WIDGET (view->details->tree_view), sample);
+    g_free (sample);
+
+    PangoFontDescription *desc = pango_font_description_from_string (font_name);
+    g_free (font_name);
+    pango_layout_set_font_description (layout, desc);
+    pango_font_description_free (desc);
+
+    gint text_width, text_height;
+    pango_layout_get_pixel_size (layout, &text_width, &text_height);
+    g_object_unref (layout);
+
+    gint padding = g_settings_get_int (nemo_preferences, NEMO_PREFERENCES_DATE_COLUMN_PADDING);
+    gint col_width = text_width + padding;
+    if (col_width < 30)
+        col_width = 30;
+
+    GList *l;
+    GList *combined = g_list_copy (view->details->cells);
+    combined = g_list_prepend (combined, view->details->file_name_cell);
+
+    for (l = combined; l != NULL; l = l->next) {
+        GtkCellRenderer *cell = GTK_CELL_RENDERER (l->data);
+        const gchar *column_id = g_object_get_data (G_OBJECT (cell), "column-id");
+
+        if (g_str_has_prefix (column_id, "date_")) {
+            GtkTreeViewColumn *col = g_hash_table_lookup (view->details->columns, column_id);
+            if (col != NULL) {
+                gtk_tree_view_column_set_sizing (col, GTK_TREE_VIEW_COLUMN_FIXED);
+                gtk_tree_view_column_set_resizable (col, TRUE);
+                gtk_tree_view_column_set_fixed_width (col, col_width);
+            }
+        }
+    }
+
+    g_list_free (combined);
+}
+
+/* Measure the current width of the first visible date column, compare it to
+ * the Pango text width, and save the difference as the new padding value. */
+static void
+save_date_column_padding (NemoListView *view)
+{
+    g_return_if_fail (NEMO_IS_LIST_VIEW (view));
+
+    /* Measure text width */
+    gchar *font_name = NULL;
+    GtkSettings *settings = gtk_settings_get_default ();
+    g_object_get (settings, "gtk-font-name", &font_name, NULL);
+
+    gchar *sample = nemo_file_get_sample_date_string ();
+    if (sample == NULL) {
+        g_free (font_name);
+        return;
+    }
+
+    PangoLayout *layout = gtk_widget_create_pango_layout (
+        GTK_WIDGET (view->details->tree_view), sample);
+    g_free (sample);
+
+    PangoFontDescription *desc = pango_font_description_from_string (font_name);
+    g_free (font_name);
+    pango_layout_set_font_description (layout, desc);
+    pango_font_description_free (desc);
+
+    gint text_width, text_height;
+    pango_layout_get_pixel_size (layout, &text_width, &text_height);
+    g_object_unref (layout);
+
+    /* Find the first visible date column and read its current width */
+    GList *l;
+    GList *combined = g_list_copy (view->details->cells);
+    combined = g_list_prepend (combined, view->details->file_name_cell);
+
+    for (l = combined; l != NULL; l = l->next) {
+        GtkCellRenderer *cell = GTK_CELL_RENDERER (l->data);
+        const gchar *column_id = g_object_get_data (G_OBJECT (cell), "column-id");
+
+        if (g_str_has_prefix (column_id, "date_")) {
+            GtkTreeViewColumn *col = g_hash_table_lookup (view->details->columns, column_id);
+            if (col != NULL && gtk_tree_view_column_get_visible (col)) {
+                /* Use fixed_width – this is always up-to-date even when the
+                 * Nemo window is behind the preferences dialog. */
+                gint col_width = gtk_tree_view_column_get_fixed_width (col);
+                if (col_width <= 0)
+                    col_width = gtk_tree_view_column_get_width (col);
+                gint padding = col_width - text_width;
+                g_settings_set_int (nemo_preferences,
+                                    NEMO_PREFERENCES_DATE_COLUMN_PADDING, padding);
+                /* Immediately apply the new padding so the effect is visible */
+                auto_fit_date_columns (view);
+                break;
+            }
+        }
+    }
+
+    g_list_free (combined);
+}
+
+/* Set or clear the cell-background property on a renderer based on row parity.
+ * Uses the GtkCellRenderer cell-background property which is the only reliable
+ * method for per-row coloring in GTK3 GtkTreeView. */
+static void
+set_row_background (GtkCellRenderer *renderer,
+                    GtkTreeModel    *model,
+                    GtkTreeIter     *iter)
+{
+    if (g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_LIST_VIEW_ALTERNATING_ROWS)) {
+        GtkTreePath *path = gtk_tree_model_get_path (model, iter);
+        gint *indices = gtk_tree_path_get_indices (path);
+        gint depth    = gtk_tree_path_get_depth (path);
+        gboolean odd  = (indices[depth - 1] % 2 != 0);
+        gtk_tree_path_free (path);
+
+        g_object_set (renderer,
+                      "cell-background",     odd ? "#ebebeb" : NULL,
+                      "cell-background-set", odd,
+                      NULL);
+    } else {
+        g_object_set (renderer, "cell-background-set", FALSE, NULL);
+    }
+}
+
+/* Cell data func for the icon renderer in the filename column. */
+static void
+icon_cell_data_func (GtkTreeViewColumn *column,
+                     GtkCellRenderer   *renderer,
+                     GtkTreeModel      *model,
+                     GtkTreeIter       *iter,
+                     gpointer           user_data)
+{
+    cairo_surface_t *surface = NULL;
+    gtk_tree_model_get (model, iter, NEMO_LIST_MODEL_SMALLEST_ICON_COLUMN, &surface, -1);
+    g_object_set (renderer, "surface", surface, NULL);
+    if (surface) {
+        cairo_surface_destroy (surface);
+    }
+    set_row_background (renderer, model, iter);
+}
+
+/* Cell data func for plain text columns (all non-filename columns). */
+static void
+text_cell_data_func (GtkTreeViewColumn *column,
+                     GtkCellRenderer   *renderer,
+                     GtkTreeModel      *model,
+                     GtkTreeIter       *iter,
+                     gpointer           user_data)
+{
+    gint col_num = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (renderer), "model-column-num"));
+    gchar *text  = NULL;
+    gint weight;
+
+    gtk_tree_model_get (model, iter,
+                        col_num, &text,
+                        NEMO_LIST_MODEL_TEXT_WEIGHT_COLUMN, &weight,
+                        -1);
+    g_object_set (renderer, "text", text, "weight", weight, NULL);
+    g_free (text);
+
+    set_row_background (renderer, model, iter);
+}
+
+/* Apply alternating row colors: simply queue a redraw so the cell data funcs
+ * above re-run for every visible row with the current setting. */
+static void
+update_alternating_rows (NemoListView *view)
+{
+    g_return_if_fail (NEMO_IS_LIST_VIEW (view));
+
+    if (view->details->tree_view != NULL) {
+        gtk_widget_queue_draw (GTK_WIDGET (view->details->tree_view));
+    }
 }
 
 static void
@@ -2691,10 +2889,8 @@ create_and_set_up_tree_view (NemoListView *view)
             gtk_tree_view_column_set_expand (view->details->file_name_column, TRUE);
 
 			gtk_tree_view_column_pack_start (view->details->file_name_column, cell, FALSE);
-			gtk_tree_view_column_set_attributes (view->details->file_name_column,
-							     cell,
-							     "surface", NEMO_LIST_MODEL_SMALLEST_ICON_COLUMN,
-							     NULL);
+			gtk_tree_view_column_set_cell_data_func (view->details->file_name_column, cell,
+			                                         icon_cell_data_func, NULL, NULL);
 
 			cell = gtk_cell_renderer_text_new ();
 			view->details->file_name_cell = (GtkCellRendererText *)cell;
@@ -2738,10 +2934,9 @@ create_and_set_up_tree_view (NemoListView *view)
 
             gtk_tree_view_column_set_title (column, label);
             gtk_tree_view_column_pack_start (column, cell, TRUE);
-            gtk_tree_view_column_set_attributes (column, cell,
-                                                 "text", column_num,
-                                                 "weight", NEMO_LIST_MODEL_TEXT_WEIGHT_COLUMN,
-                                                 NULL);
+            g_object_set_data (G_OBJECT (cell), "model-column-num", GINT_TO_POINTER (column_num));
+            gtk_tree_view_column_set_cell_data_func (column, cell,
+                                                     text_cell_data_func, NULL, NULL);
 
             gtk_tree_view_append_column (view->details->tree_view, column);
             gtk_tree_view_column_set_min_width (column, 30);
@@ -2767,7 +2962,15 @@ create_and_set_up_tree_view (NemoListView *view)
     GtkSettings *gtk_settings = gtk_settings_get_default ();
     g_signal_connect_swapped (gtk_settings, "notify::gtk-font-name", G_CALLBACK (update_date_fonts), view);
     g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_DATE_FONT_CHOICE, G_CALLBACK (update_date_fonts), view);
+    g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_DATE_FORMAT, G_CALLBACK (update_date_fonts), view);
+    g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_DATE_FORMAT_CUSTOM, G_CALLBACK (update_date_fonts), view);
     g_signal_connect_swapped (gnome_interface_preferences, "changed::" NEMO_PREFERENCES_MONO_FONT_NAME, G_CALLBACK (update_date_fonts), view);
+    g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_DATE_COLUMN_FIT_TRIGGER, G_CALLBACK (auto_fit_date_columns), view);
+    g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_DATE_COLUMN_SAVE_PADDING_TRIGGER, G_CALLBACK (save_date_column_padding), view);
+    g_signal_connect_swapped (nemo_preferences, "changed::" NEMO_PREFERENCES_LIST_VIEW_ALTERNATING_ROWS, G_CALLBACK (update_alternating_rows), view);
+
+    view->details->alternating_rows_provider = NULL;
+    update_alternating_rows (view);
 	nemo_column_list_free (nemo_columns);
 
 	default_visible_columns = g_settings_get_strv (nemo_list_view_preferences,


### PR DESCRIPTION
## Summary

This PR adds two new features to the Nemo list view:

### 1. Custom Date Format
A new \"Custom…\" option in the date format dropdown under
*Edit → Preferences → Display*.

When selected, a text field appears where the user can enter a
format string using the following tokens:

| Token | Meaning           | Example |
|-------|-------------------|---------|
| YYYY  | 4-digit year      | 2026    |
| YY    | 2-digit year      | 26      |
| MM    | Month 01–12       | 03      |
| DD    | Day 01–31         | 21      |
| HH    | Hour 00–23 (24h)  | 14      |
| hh    | Hour 01–12 (12h)  | 02      |
| mm    | Minute 00–59      | 35      |
| SS    | Second 00–59      | 07      |

Example: `YYYY.MM.DD HH:mm` → `2026.03.21 14:35`

Changes apply immediately without restarting Nemo.

Two additional buttons allow managing date column widths:
- **Auto-fit**: sets all date column widths to text width plus a saved padding value
- **Save padding**: saves the current padding as the new default for Auto-fit

### 2. Alternating Row Colors
A new checkbox *"Alternating row colors (white / light gray)"* under
*Edit → Preferences → Views → List View Defaults*.

When enabled, odd rows are displayed with a light gray background (`#ebebeb`) and even rows with the default background. This improves readability in long file lists.

Enabled by default.

**Implementation note:** CSS `nth-child` selectors are not reliable for `GtkTreeView` rows in GTK3 (row nodes are recycled dynamically). The alternating background is therefore implemented via `GtkCellRenderer::cell-background` using cell data functions, which is the only robust approach in GTK3.

## Changed files
- `libnemo-private/org.nemo.gschema.xml` – new keys: `date-format-custom`, `date-column-autosize`, `date-column-padding`, `list-view-alternating-rows`
- `libnemo-private/nemo-global-preferences.h/.c` – new preference constants and cached format string
- `libnemo-private/nemo-file.h/.c` – `nemo_custom_date_format_to_strftime()`, `nemo_file_get_sample_date_string()`, `NEMO_DATE_FORMAT_CUSTOM` case
- `src/nemo-file-management-properties.c` – custom format entry widget, Auto-fit and Save padding buttons, combo change handler
- `src/nemo-list-view.c` – `set_row_background()`, `icon_cell_data_func()`, `text_cell_data_func()` for alternating rows
- `gresources/nemo-file-management-properties.glade` – new widgets for custom format box, buttons, and alternating rows checkbox
- `po/de_custom.po` – German translations for all new UI strings