### PR TITLE
List view: show expander when a previously empty folder gets items

### DIFF
--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -1107,6 +1107,9 @@ update_dummy_row (NemoListModel *model,
     got_count = nemo_file_get_directory_item_count (file, &count, &unreadable);
 
     if ((got_count && count == 0) || (!got_count && unreadable)) {
+        /* The directory doesn't have any items in it, so we want to
+         * hide the the expander. Check if there is any dummy entry
+         * (which would force its appearence) and remove it. */
         files = file_entry->files;
         if (g_sequence_get_length (files) == 1) {
             GSequenceIter *dummy_ptr = g_sequence_get_iter_at_pos (files, 0);
@@ -1129,6 +1132,15 @@ update_dummy_row (NemoListModel *model,
                 }
             }
         }
+    } else if (got_count && count > 0) {
+        /* The directory does have items in it. We want an expander present,
+         * so check if there are any entries, and if not add a dummy one. */
+        files = file_entry->files;
+
+        if (g_sequence_get_length (files) == 0) {
+            add_dummy_row (model, file_entry);
+			changed = TRUE;
+		}
     }
 
     file_entry->expanding = FALSE;


### PR DESCRIPTION
In the same way that we remove the dummy row when we know the folder doesn't have any items in it, do add one when we know that it does have items.

---

This addresses the OP's initial concern in #2537. There are a bunch of issues around the list view and when to show expanders, with perhaps the most problematic one being when the change occurs in an unexpanded/unwatched folder.

This PR does not attempt to fix all these issues, only the simplest of them: When an previously empty folder gets an item and nemo *does* know about it, e.g. because nemo itself did it, add a dummy row to trigger showing an expander. This doesn't 'watch' the folder, and clicking on the expander will still cause nemo to 'load' its items. This is the same behavior as if the folder was non-empty when we first opened the view.