### PR TITLE
Implement a filtered view for interactive-search.

### DIFF
--- a/config.h.meson.in
+++ b/config.h.meson.in
@@ -17,8 +17,6 @@
 #mesondefine HAVE_EXIF
 // Define if libselinux is available
 #mesondefine HAVE_SELINUX
-// Define to enable pango-1.44 fixes
-#mesondefine HAVE_PANGO_144
 // Define to use gtk-layer-shell
 #mesondefine HAVE_GTK_LAYER_SHELL
 

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  libgtk-3-doc,
  libgtk-layer-shell-dev,
  libjson-glib-dev (>= 1.6),
- libpango1.0-dev,
+ libpango1.0-dev (>= 1.44.0),
  libx11-dev,
  libxapp-dev (>= 2.0.0),
  libxext-dev,

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -998,9 +998,7 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
       if (label->font_desc != NULL)
 	pango_layout_set_font_description (label->layout, label->font_desc);
       
-#ifdef HAVE_PANGO_144
       pango_attr_list_insert (tmp_attrs, pango_attr_insert_hyphens_new (FALSE));
-#endif    
       pango_layout_set_attributes (label->layout, tmp_attrs);
       
       if (preedit_string)

--- a/libnemo-private/fzy-bonus.h
+++ b/libnemo-private/fzy-bonus.h
@@ -1,0 +1,132 @@
+/*
+ * fzy fuzzy matching algorithm - bonus scoring tables
+ *
+ * Copyright (c) 2014 John Hawthorn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FZY_BONUS_H
+#define FZY_BONUS_H
+
+#include "fzy-match.h"
+
+#define ASSIGN_LOWER(v) \
+    ['a'] = (v), \
+    ['b'] = (v), \
+    ['c'] = (v), \
+    ['d'] = (v), \
+    ['e'] = (v), \
+    ['f'] = (v), \
+    ['g'] = (v), \
+    ['h'] = (v), \
+    ['i'] = (v), \
+    ['j'] = (v), \
+    ['k'] = (v), \
+    ['l'] = (v), \
+    ['m'] = (v), \
+    ['n'] = (v), \
+    ['o'] = (v), \
+    ['p'] = (v), \
+    ['q'] = (v), \
+    ['r'] = (v), \
+    ['s'] = (v), \
+    ['t'] = (v), \
+    ['u'] = (v), \
+    ['v'] = (v), \
+    ['w'] = (v), \
+    ['x'] = (v), \
+    ['y'] = (v), \
+    ['z'] = (v)
+
+#define ASSIGN_UPPER(v) \
+    ['A'] = (v), \
+    ['B'] = (v), \
+    ['C'] = (v), \
+    ['D'] = (v), \
+    ['E'] = (v), \
+    ['F'] = (v), \
+    ['G'] = (v), \
+    ['H'] = (v), \
+    ['I'] = (v), \
+    ['J'] = (v), \
+    ['K'] = (v), \
+    ['L'] = (v), \
+    ['M'] = (v), \
+    ['N'] = (v), \
+    ['O'] = (v), \
+    ['P'] = (v), \
+    ['Q'] = (v), \
+    ['R'] = (v), \
+    ['S'] = (v), \
+    ['T'] = (v), \
+    ['U'] = (v), \
+    ['V'] = (v), \
+    ['W'] = (v), \
+    ['X'] = (v), \
+    ['Y'] = (v), \
+    ['Z'] = (v)
+
+#define ASSIGN_DIGIT(v) \
+    ['0'] = (v), \
+    ['1'] = (v), \
+    ['2'] = (v), \
+    ['3'] = (v), \
+    ['4'] = (v), \
+    ['5'] = (v), \
+    ['6'] = (v), \
+    ['7'] = (v), \
+    ['8'] = (v), \
+    ['9'] = (v)
+
+const score_t bonus_states[3][256] = {
+    { 0 },
+    {
+        ['/'] = SCORE_MATCH_SLASH,
+        ['-'] = SCORE_MATCH_WORD,
+        ['_'] = SCORE_MATCH_WORD,
+        [' '] = SCORE_MATCH_WORD,
+        ['.'] = SCORE_MATCH_DOT,
+    },
+    {
+        ['/'] = SCORE_MATCH_SLASH,
+        ['-'] = SCORE_MATCH_WORD,
+        ['_'] = SCORE_MATCH_WORD,
+        [' '] = SCORE_MATCH_WORD,
+        ['.'] = SCORE_MATCH_DOT,
+
+        /* ['a' ... 'z'] = SCORE_MATCH_CAPITAL, */
+        ASSIGN_LOWER(SCORE_MATCH_CAPITAL)
+    }
+};
+
+const size_t bonus_index[256] = {
+    /* ['A' ... 'Z'] = 2 */
+    ASSIGN_UPPER(2),
+
+    /* ['a' ... 'z'] = 1 */
+    ASSIGN_LOWER(1),
+
+    /* ['0' ... '9'] = 1 */
+    ASSIGN_DIGIT(1)
+};
+
+#define COMPUTE_BONUS(last_ch, ch) (bonus_states[bonus_index[(unsigned char)(ch)]][(unsigned char)(last_ch)])
+
+#endif

--- a/libnemo-private/fzy-match.c
+++ b/libnemo-private/fzy-match.c
@@ -1,0 +1,256 @@
+/*
+ * fzy fuzzy matching algorithm
+ *
+ * Copyright (c) 2014 John Hawthorn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include <strings.h>
+#include <stdio.h>
+#include <float.h>
+#include <math.h>
+#include <stdlib.h>
+
+#include "fzy-match.h"
+
+#define SCORE_GAP_LEADING -0.005
+#define SCORE_GAP_TRAILING -0.005
+#define SCORE_GAP_INNER -0.01
+#define SCORE_MATCH_CONSECUTIVE 1.0
+#define SCORE_MATCH_SLASH 0.9
+#define SCORE_MATCH_WORD 0.8
+#define SCORE_MATCH_CAPITAL 0.7
+#define SCORE_MATCH_DOT 0.6
+
+#include "fzy-bonus.h"
+
+char *strcasechr(const char *s, char c) {
+    const char accept[3] = {c, toupper(c), 0};
+    return strpbrk(s, accept);
+}
+
+int has_match(const char *needle, const char *haystack) {
+    while (*needle) {
+        char nch = *needle++;
+
+        if (!(haystack = strcasechr(haystack, nch))) {
+            return 0;
+        }
+        haystack++;
+    }
+    return 1;
+}
+
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+
+struct match_struct {
+    int needle_len;
+    int haystack_len;
+
+    char lower_needle[MATCH_MAX_LEN];
+    char lower_haystack[MATCH_MAX_LEN];
+
+    score_t match_bonus[MATCH_MAX_LEN];
+};
+
+static void precompute_bonus(const char *haystack, score_t *match_bonus) {
+    /* Which positions are beginning of words */
+    char last_ch = '/';
+    for (int i = 0; haystack[i]; i++) {
+        char ch = haystack[i];
+        match_bonus[i] = COMPUTE_BONUS(last_ch, ch);
+        last_ch = ch;
+    }
+}
+
+static void setup_match_struct(struct match_struct *match, const char *needle, const char *haystack) {
+    match->needle_len = strlen(needle);
+    match->haystack_len = strlen(haystack);
+
+    if (match->haystack_len > MATCH_MAX_LEN || match->needle_len > match->haystack_len) {
+        return;
+    }
+
+    for (int i = 0; i < match->needle_len; i++)
+        match->lower_needle[i] = tolower(needle[i]);
+
+    for (int i = 0; i < match->haystack_len; i++)
+        match->lower_haystack[i] = tolower(haystack[i]);
+
+    precompute_bonus(haystack, match->match_bonus);
+}
+
+static inline void match_row(const struct match_struct *match, int row, score_t *curr_D, score_t *curr_M, const score_t *last_D, const score_t *last_M) {
+    int n = match->needle_len;
+    int m = match->haystack_len;
+    int i = row;
+
+    const char *lower_needle = match->lower_needle;
+    const char *lower_haystack = match->lower_haystack;
+    const score_t *match_bonus = match->match_bonus;
+
+    score_t prev_score = SCORE_MIN;
+    score_t gap_score = i == n - 1 ? SCORE_GAP_TRAILING : SCORE_GAP_INNER;
+
+    /* These will not be used with this value, but not all compilers see it */
+    score_t prev_M = SCORE_MIN, prev_D = SCORE_MIN;
+
+    for (int j = 0; j < m; j++) {
+        if (lower_needle[i] == lower_haystack[j]) {
+            score_t score = SCORE_MIN;
+            if (!i) {
+                score = (j * SCORE_GAP_LEADING) + match_bonus[j];
+            } else if (j) { /* i > 0 && j > 0*/
+                score = max(
+                        prev_M + match_bonus[j],
+
+                        /* consecutive match, doesn't stack with match_bonus */
+                        prev_D + SCORE_MATCH_CONSECUTIVE);
+            }
+            prev_D = last_D[j];
+            prev_M = last_M[j];
+            curr_D[j] = score;
+            curr_M[j] = prev_score = max(score, prev_score + gap_score);
+        } else {
+            prev_D = last_D[j];
+            prev_M = last_M[j];
+            curr_D[j] = SCORE_MIN;
+            curr_M[j] = prev_score = prev_score + gap_score;
+        }
+    }
+}
+
+score_t match(const char *needle, const char *haystack) {
+    if (!*needle)
+        return SCORE_MIN;
+
+    struct match_struct match;
+    setup_match_struct(&match, needle, haystack);
+
+    int n = match.needle_len;
+    int m = match.haystack_len;
+
+    if (m > MATCH_MAX_LEN || n > m) {
+        /*
+         * Unreasonably large candidate: return no score
+         * If it is a valid match it will still be returned, it will
+         * just be ranked below any reasonably sized candidates
+         */
+        return SCORE_MIN;
+    } else if (n == m) {
+        /* Since this method can only be called with a haystack which
+         * matches needle. If the lengths of the strings are equal the
+         * strings themselves must also be equal (ignoring case).
+         */
+        return SCORE_MAX;
+    }
+
+    /*
+     * D[][] Stores the best score for this position ending with a match.
+     * M[][] Stores the best possible score at this position.
+     */
+    score_t D[MATCH_MAX_LEN], M[MATCH_MAX_LEN];
+
+    for (int i = 0; i < n; i++) {
+        match_row(&match, i, D, M, D, M);
+    }
+
+    return M[m - 1];
+}
+
+score_t match_positions(const char *needle, const char *haystack, size_t *positions) {
+    if (!*needle)
+        return SCORE_MIN;
+
+    struct match_struct match;
+    setup_match_struct(&match, needle, haystack);
+
+    int n = match.needle_len;
+    int m = match.haystack_len;
+
+    if (m > MATCH_MAX_LEN || n > m) {
+        /*
+         * Unreasonably large candidate: return no score
+         * If it is a valid match it will still be returned, it will
+         * just be ranked below any reasonably sized candidates
+         */
+        return SCORE_MIN;
+    } else if (n == m) {
+        /* Since this method can only be called with a haystack which
+         * matches needle. If the lengths of the strings are equal the
+         * strings themselves must also be equal (ignoring case).
+         */
+        if (positions)
+            for (int i = 0; i < n; i++)
+                positions[i] = i;
+        return SCORE_MAX;
+    }
+
+    /*
+     * D[][] Stores the best score for this position ending with a match.
+     * M[][] Stores the best possible score at this position.
+     */
+    score_t (*D)[MATCH_MAX_LEN], (*M)[MATCH_MAX_LEN];
+    M = malloc(sizeof(score_t) * MATCH_MAX_LEN * n);
+    D = malloc(sizeof(score_t) * MATCH_MAX_LEN * n);
+
+    match_row(&match, 0, D[0], M[0], D[0], M[0]);
+    for (int i = 1; i < n; i++) {
+        match_row(&match, i, D[i], M[i], D[i - 1], M[i - 1]);
+    }
+
+    /* backtrace to find the positions of optimal matching */
+    if (positions) {
+        int match_required = 0;
+        for (int i = n - 1, j = m - 1; i >= 0; i--) {
+            for (; j >= 0; j--) {
+                /*
+                 * There may be multiple paths which result in
+                 * the optimal weight.
+                 *
+                 * For simplicity, we will pick the first one
+                 * we encounter, the latest in the candidate
+                 * string.
+                 */
+                if (D[i][j] != SCORE_MIN &&
+                    (match_required || D[i][j] == M[i][j])) {
+                    /* If this score was determined using
+                     * SCORE_MATCH_CONSECUTIVE, the
+                     * previous character MUST be a match
+                     */
+                    match_required =
+                        i && j &&
+                        M[i][j] == D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE;
+                    positions[i] = j--;
+                    break;
+                }
+            }
+        }
+    }
+
+    score_t result = M[n - 1][m - 1];
+
+    free(M);
+    free(D);
+
+    return result;
+}

--- a/libnemo-private/fzy-match.h
+++ b/libnemo-private/fzy-match.h
@@ -1,0 +1,41 @@
+/*
+ * fzy fuzzy matching algorithm
+ *
+ * Copyright (c) 2014 John Hawthorn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FZY_MATCH_H
+#define FZY_MATCH_H
+
+#include <math.h>
+#include <stddef.h>
+
+typedef double score_t;
+#define SCORE_MAX INFINITY
+#define SCORE_MIN -INFINITY
+
+#define MATCH_MAX_LEN 1024
+
+int has_match(const char *needle, const char *haystack);
+score_t match_positions(const char *needle, const char *haystack, size_t *positions);
+score_t match(const char *needle, const char *haystack);
+
+#endif

--- a/libnemo-private/meson.build
+++ b/libnemo-private/meson.build
@@ -31,6 +31,8 @@ nemo_private_sources = [
   'nemo-directory.c',
   'nemo-dnd.c',
   'nemo-entry.c',
+  'fzy-match.c',
+  'nemo-fzy-utils.c',
   'nemo-file-changes-queue.c',
   'nemo-file-conflict-dialog.c',
   'nemo-file-dnd.c',

--- a/libnemo-private/nemo-fzy-utils.c
+++ b/libnemo-private/nemo-fzy-utils.c
@@ -1,0 +1,183 @@
+/* nemo-fzy-utils.c - Fuzzy matching utilities for Nemo
+ *
+ * Copyright (C) 2026 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nemo-fzy-utils.h"
+#include "fzy-match.h"
+
+/**
+ * nemo_fzy_strip_combining_marks:
+ * @str: a UTF-8 string, or %NULL
+ * @nfkd_out: (out) (optional) (transfer full): return location for the
+ *   intermediate NFKD-normalized form, or %NULL
+ *
+ * Strips Unicode combining marks after NFKD decomposition, allowing
+ * accent-insensitive matching (e.g. "resume" matches "resumé").
+ *
+ * Returns: (transfer full): a newly allocated string with combining
+ *   marks removed, or %NULL if @str is %NULL
+ */
+char *
+nemo_fzy_strip_combining_marks (const char *str, char **nfkd_out)
+{
+    g_autofree char *nfkd = NULL;
+    GString *result;
+    const char *p;
+
+    if (nfkd_out != NULL) {
+        *nfkd_out = NULL;
+    }
+
+    if (str == NULL) {
+        return NULL;
+    }
+
+    nfkd = g_utf8_normalize (str, -1, G_NORMALIZE_ALL);
+    if (nfkd == NULL) {
+        return g_strdup (str);
+    }
+
+    result = g_string_new (NULL);
+
+    for (p = nfkd; *p != '\0'; p = g_utf8_next_char (p)) {
+        gunichar ch = g_utf8_get_char (p);
+
+        if (!g_unichar_ismark (ch)) {
+            g_string_append_unichar (result, ch);
+        }
+    }
+
+    if (nfkd_out != NULL) {
+        *nfkd_out = g_steal_pointer (&nfkd);
+    }
+
+    return g_string_free (result, FALSE);
+}
+
+/**
+ * nemo_fzy_match_attrs:
+ * @needle: the filter text to match
+ * @haystack: the text to match against (e.g. a filename)
+ *
+ * Performs a fuzzy match of @needle against @haystack with
+ * accent-insensitive matching and returns a #PangoAttrList with
+ * %PANGO_WEIGHT_BOLD attributes at the matched character positions.
+ *
+ * Returns: (transfer full) (nullable): a new #PangoAttrList with bold
+ *   attributes for matched positions, or %NULL if there is no match.
+ *   Free with pango_attr_list_unref().
+ */
+PangoAttrList *
+nemo_fzy_match_attrs (const char *needle, const char *haystack)
+{
+    g_autofree char *stripped_needle = NULL;
+    g_autofree char *stripped_haystack = NULL;
+    g_autofree char *nfkd = NULL;
+    g_autofree int *orig_offsets = NULL;
+    size_t positions[MATCH_MAX_LEN];
+    int needle_len, stripped_len, haystack_len;
+    PangoAttrList *attrs;
+    const char *sp, *hp;
+
+    if (needle == NULL || needle[0] == '\0' || haystack == NULL) {
+        return NULL;
+    }
+
+    stripped_needle = nemo_fzy_strip_combining_marks (needle, NULL);
+    stripped_haystack = nemo_fzy_strip_combining_marks (haystack, &nfkd);
+
+    if (!has_match (stripped_needle, stripped_haystack)) {
+        return NULL;
+    }
+
+    needle_len = strlen (stripped_needle);
+    stripped_len = strlen (stripped_haystack);
+    haystack_len = strlen (haystack);
+
+    if (match_positions (stripped_needle, stripped_haystack, positions) == SCORE_MIN) {
+        return NULL;
+    }
+
+    /* Build stripped byte offset → original byte offset map.
+     * The stripped text was created by NFKD-decomposing then removing
+     * combining marks. Walk the NFKD form to find base characters
+     * (which correspond 1:1 with stripped characters), and track
+     * which original character each one came from. */
+    orig_offsets = g_new (int, stripped_len + 1);
+
+    {
+        const char *np = nfkd ? nfkd : haystack;
+
+        sp = stripped_haystack;
+        hp = haystack;
+
+        while (*np != '\0' && *sp != '\0') {
+            gunichar nch = g_utf8_get_char (np);
+
+            if (g_unichar_ismark (nch)) {
+                np = g_utf8_next_char (np);
+                continue;
+            }
+
+            int s_off = sp - stripped_haystack;
+            int h_off = hp - haystack;
+            int s_bytes = g_utf8_next_char (sp) - sp;
+
+            for (int b = 0; b < s_bytes && (s_off + b) < stripped_len; b++) {
+                orig_offsets[s_off + b] = h_off;
+            }
+
+            sp = g_utf8_next_char (sp);
+            np = g_utf8_next_char (np);
+
+            while (*np != '\0' && g_unichar_ismark (g_utf8_get_char (np))) {
+                np = g_utf8_next_char (np);
+            }
+
+            hp = g_utf8_next_char (hp);
+        }
+
+        orig_offsets[stripped_len] = haystack_len;
+    }
+
+    attrs = pango_attr_list_new ();
+
+    for (int i = 0; i < needle_len; ) {
+        int run_end = i;
+        int orig_start, orig_end;
+        PangoAttribute *attr;
+
+        while (run_end + 1 < needle_len &&
+               positions[run_end + 1] == positions[run_end] + 1) {
+            run_end++;
+        }
+
+        orig_start = orig_offsets[positions[i]];
+        orig_end = (positions[run_end] + 1 <= (size_t) stripped_len)
+                   ? orig_offsets[positions[run_end] + 1]
+                   : haystack_len;
+
+        attr = pango_attr_weight_new (PANGO_WEIGHT_BOLD);
+        attr->start_index = orig_start;
+        attr->end_index = orig_end;
+        pango_attr_list_insert (attrs, attr);
+
+        i = run_end + 1;
+    }
+
+    return attrs;
+}

--- a/libnemo-private/nemo-fzy-utils.h
+++ b/libnemo-private/nemo-fzy-utils.h
@@ -1,0 +1,31 @@
+/* nemo-fzy-utils.h - Fuzzy matching utilities for Nemo
+ *
+ * Copyright (C) 2026 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NEMO_FZY_UTILS_H
+#define NEMO_FZY_UTILS_H
+
+#include <glib.h>
+#include <pango/pango.h>
+
+char *nemo_fzy_strip_combining_marks (const char *str,
+                                      char      **nfkd_out);
+
+PangoAttrList *nemo_fzy_match_attrs (const char *needle,
+                                     const char *haystack);
+
+#endif /* NEMO_FZY_UTILS_H */

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -31,6 +31,7 @@
 #include "nemo-file-utilities.h"
 #include "nemo-global-preferences.h"
 #include "nemo-icon-private.h"
+#include "nemo-fzy-utils.h"
 #include <eel/eel-art-extensions.h>
 #include <eel/eel-gdk-extensions.h>
 #include <eel/eel-glib-extensions.h>
@@ -1398,6 +1399,36 @@ nemo_icon_canvas_item_draw (EelCanvasItem *item,
 #define ZERO_WIDTH_SPACE "\xE2\x80\x8B"
 
 
+static void
+add_filter_highlight_attrs (PangoAttrList *attr_list,
+                            const char *zeroified_text,
+                            const char *filter_text)
+{
+    PangoAttrList *match_attrs;
+    PangoAttrIterator *iter;
+
+    /* Match against the zeroified text directly. The zero-width spaces
+     * are invisible to the user and fzy skips over them naturally as
+     * non-matching characters. The returned positions are byte offsets
+     * into the zeroified text, which is what the PangoLayout uses -
+     * no remapping needed. */
+    match_attrs = nemo_fzy_match_attrs (filter_text, zeroified_text);
+    if (match_attrs == NULL) {
+        return;
+    }
+
+    iter = pango_attr_list_get_iterator (match_attrs);
+    do {
+        PangoAttribute *a = pango_attr_iterator_get (iter, PANGO_ATTR_WEIGHT);
+        if (a != NULL) {
+            pango_attr_list_change (attr_list, pango_attribute_copy (a));
+        }
+    } while (pango_attr_iterator_next (iter));
+
+    pango_attr_iterator_destroy (iter);
+    pango_attr_list_unref (match_attrs);
+}
+
 static PangoLayout *
 create_label_layout (NemoIconCanvasItem *item,
 		     const char *text)
@@ -1407,17 +1438,17 @@ create_label_layout (NemoIconCanvasItem *item,
 	PangoFontDescription *desc;
 	NemoIconContainer *container;
 	EelCanvasItem *canvas_item;
+	PangoAttrList *attr_list;
 	GString *str;
 	char *zeroified_text;
 	const char *p;
- 	PangoAttrList *attr_list;
 
 	canvas_item = EEL_CANVAS_ITEM (item);
 
 	container = NEMO_ICON_CONTAINER (canvas_item->canvas);
 	context = gtk_widget_get_pango_context (GTK_WIDGET (canvas_item->canvas));
 	layout = pango_layout_new (context);
- 	attr_list = pango_attr_list_new ();
+	attr_list = pango_attr_list_new ();
 
 	zeroified_text = NULL;
 
@@ -1453,8 +1484,12 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_spacing (layout, LABEL_LINE_SPACING);
 	pango_layout_set_wrap (layout, PANGO_WRAP_WORD_CHAR);
 
- 	pango_attr_list_insert (attr_list, pango_attr_insert_hyphens_new (FALSE));
- 	pango_layout_set_attributes (layout, attr_list);
+	pango_attr_list_insert (attr_list, pango_attr_insert_hyphens_new (FALSE));
+
+	add_filter_highlight_attrs (attr_list, zeroified_text,
+	                            nemo_icon_container_get_filter_highlight (container));
+
+	pango_layout_set_attributes (layout, attr_list);
 
 	/* Create a font description */
 	if (container->details->font && g_strcmp0 (container->details->font, "") != 0) {
@@ -1480,7 +1515,7 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_font_description (layout, desc);
 	pango_font_description_free (desc);
 	g_free (zeroified_text);
- 	pango_attr_list_unref (attr_list);
+	pango_attr_list_unref (attr_list);
 
 	return layout;
 }

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1410,18 +1410,14 @@ create_label_layout (NemoIconCanvasItem *item,
 	GString *str;
 	char *zeroified_text;
 	const char *p;
-#ifdef HAVE_PANGO_144
  	PangoAttrList *attr_list;
-#endif
 
 	canvas_item = EEL_CANVAS_ITEM (item);
 
 	container = NEMO_ICON_CONTAINER (canvas_item->canvas);
 	context = gtk_widget_get_pango_context (GTK_WIDGET (canvas_item->canvas));
 	layout = pango_layout_new (context);
-#ifdef HAVE_PANGO_144
  	attr_list = pango_attr_list_new ();
-#endif
 
 	zeroified_text = NULL;
 
@@ -1457,10 +1453,8 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_spacing (layout, LABEL_LINE_SPACING);
 	pango_layout_set_wrap (layout, PANGO_WRAP_WORD_CHAR);
 
-#ifdef HAVE_PANGO_144
  	pango_attr_list_insert (attr_list, pango_attr_insert_hyphens_new (FALSE));
  	pango_layout_set_attributes (layout, attr_list);
-#endif
 
 	/* Create a font description */
 	if (container->details->font && g_strcmp0 (container->details->font, "") != 0) {
@@ -1486,9 +1480,7 @@ create_label_layout (NemoIconCanvasItem *item,
 	pango_layout_set_font_description (layout, desc);
 	pango_font_description_free (desc);
 	g_free (zeroified_text);
-#ifdef HAVE_PANGO_144
  	pango_attr_list_unref (attr_list);
-#endif
 
 	return layout;
 }

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -198,6 +198,7 @@ enum {
 	ICON_REMOVED,
 	CLEARED,
     GET_TOOLTIP_TEXT,
+    CHECK_FILTER_EVENT,
 	LAST_SIGNAL
 };
 
@@ -2770,6 +2771,7 @@ finalize (GObject *object)
 	details->icon_set = NULL;
 
 	g_free (details->font);
+	g_free (details->filter_highlight_text);
 
 	if (details->a11y_item_action_queue != NULL) {
 		while (!g_queue_is_empty (details->a11y_item_action_queue)) {
@@ -4261,6 +4263,14 @@ key_press_event (GtkWidget *widget,
 			}
 			break;
 		case GDK_KEY_space:
+			if (!nemo_icon_container_get_is_desktop (container)) {
+				gboolean filter_handled = FALSE;
+				g_signal_emit (container, signals[CHECK_FILTER_EVENT], 0, (GdkEvent *) event, &filter_handled);
+				if (filter_handled) {
+					handled = TRUE;
+					break;
+				}
+			}
 			keyboard_space (container, event);
 			handled = TRUE;
 			break;
@@ -4321,64 +4331,64 @@ key_press_event (GtkWidget *widget,
 		handled = GTK_WIDGET_CLASS (nemo_icon_container_parent_class)->key_press_event (widget, event);
 	}
 
-	/* We pass the event to the search_entry.  If its text changes, then we
-	 * start the typeahead find capabilities.
-	 * Copied from NemoIconContainer */
+	/* For non-desktop containers, forward keypresses to the filter bar.
+	 * The signal handler validates the keypress and returns TRUE if handled.
+	 * Desktop containers keep the old interactive search behavior. */
 	if (!handled &&
-		event->keyval != GDK_KEY_asciitilde &&
-		event->keyval != GDK_KEY_KP_Divide &&
-	    event->keyval != GDK_KEY_slash /* don't steal slash key events, used for "go to" */ &&
-	    event->keyval != GDK_KEY_BackSpace &&
+	    event->keyval != GDK_KEY_asciitilde &&
+	    event->keyval != GDK_KEY_KP_Divide &&
+	    event->keyval != GDK_KEY_slash &&
 	    event->keyval != GDK_KEY_Delete) {
-		GdkEvent *new_event;
-		GdkWindow *window;
-		char *old_text;
-		const char *new_text;
-		gboolean retval;
-		gboolean text_modified;
-		gulong popup_menu_id;
 
-		nemo_icon_container_ensure_interactive_directory (container);
+	    if (!nemo_icon_container_get_is_desktop (container)) {
+	        g_signal_emit (container, signals[CHECK_FILTER_EVENT], 0, (GdkEvent *) event, &handled);
+	    } else {
+	        /* Desktop: old interactive search behavior */
+	        GdkEvent *new_event;
+	        GdkWindow *window;
+	        char *old_text;
+	        const char *new_text;
+	        gboolean retval;
+	        gboolean text_modified;
+	        gulong popup_menu_id;
 
-		/* Make a copy of the current text */
-		old_text = g_strdup (gtk_entry_get_text (GTK_ENTRY (container->details->search_entry)));
-		new_event = gdk_event_copy ((GdkEvent *) event);
-		window = ((GdkEventKey *) new_event)->window;
-		((GdkEventKey *) new_event)->window = gtk_widget_get_window (container->details->search_entry);
-		gtk_widget_realize (container->details->search_window);
+	        nemo_icon_container_ensure_interactive_directory (container);
 
-		popup_menu_id = g_signal_connect (container->details->search_entry,
-						  "popup_menu", G_CALLBACK (gtk_true), NULL);
+	        old_text = g_strdup (gtk_entry_get_text (GTK_ENTRY (container->details->search_entry)));
+	        new_event = gdk_event_copy ((GdkEvent *) event);
+	        window = ((GdkEventKey *) new_event)->window;
+	        ((GdkEventKey *) new_event)->window = gtk_widget_get_window (container->details->search_entry);
+	        gtk_widget_realize (container->details->search_window);
 
-		gtk_widget_show (container->details->search_window);
+	        popup_menu_id = g_signal_connect (container->details->search_entry,
+	                          "popup_menu", G_CALLBACK (gtk_true), NULL);
 
-		/* Send the event to the window.  If the preedit_changed signal is emitted
-		 * during this event, we will set priv->imcontext_changed  */
-		container->details->imcontext_changed = FALSE;
-		retval = gtk_widget_event (container->details->search_entry, new_event);
-		gtk_widget_hide (container->details->search_window);
+	        gtk_widget_show (container->details->search_window);
 
-		g_signal_handler_disconnect (container->details->search_entry,
-					     popup_menu_id);
+	        container->details->imcontext_changed = FALSE;
+	        retval = gtk_widget_event (container->details->search_entry, new_event);
+	        gtk_widget_hide (container->details->search_window);
 
-		/* We check to make sure that the entry tried to handle the text, and that
-		 * the text has changed. */
-		new_text = gtk_entry_get_text (GTK_ENTRY (container->details->search_entry));
-		text_modified = strcmp (old_text, new_text) != 0;
-		g_free (old_text);
-		if (container->details->imcontext_changed ||    /* we're in a preedit */
-		    (retval && text_modified)) {                /* ...or the text was modified */
-			if (nemo_icon_container_start_interactive_search (container)) {
-				gtk_widget_grab_focus (GTK_WIDGET (container));
-				return TRUE;
-			} else {
-				gtk_entry_set_text (GTK_ENTRY (container->details->search_entry), "");
-				return FALSE;
-			}
-		}
+	        g_signal_handler_disconnect (container->details->search_entry,
+	                         popup_menu_id);
 
-		((GdkEventKey *) new_event)->window = window;
-		gdk_event_free (new_event);
+	        new_text = gtk_entry_get_text (GTK_ENTRY (container->details->search_entry));
+	        text_modified = strcmp (old_text, new_text) != 0;
+	        g_free (old_text);
+	        if (container->details->imcontext_changed ||
+	            (retval && text_modified)) {
+	            if (nemo_icon_container_start_interactive_search (container)) {
+	                gtk_widget_grab_focus (GTK_WIDGET (container));
+	                return TRUE;
+	            } else {
+	                gtk_entry_set_text (GTK_ENTRY (container->details->search_entry), "");
+	                return FALSE;
+	            }
+	        }
+
+	        ((GdkEventKey *) new_event)->window = window;
+	        gdk_event_free (new_event);
+	    }
 	}
 
 	return handled;
@@ -4868,6 +4878,16 @@ nemo_icon_container_class_init (NemoIconContainerClass *class)
                         NULL,
                         G_TYPE_STRING, 1,
                         G_TYPE_POINTER);
+
+    signals[CHECK_FILTER_EVENT]
+        = g_signal_new ("check-filter-event",
+                        G_TYPE_FROM_CLASS (class),
+                        G_SIGNAL_RUN_LAST,
+                        0,
+                        g_signal_accumulator_true_handled, NULL,
+                        g_cclosure_marshal_generic,
+                        G_TYPE_BOOLEAN, 1,
+                        GDK_TYPE_EVENT);
 
 	/* GtkWidget class.  */
 
@@ -7183,6 +7203,26 @@ nemo_icon_container_set_is_desktop (NemoIconContainer *container,
                                   G_CALLBACK (text_ellipsis_limit_changed_container_callback),
                                   container);
     }
+}
+
+void
+nemo_icon_container_set_filter_highlight (NemoIconContainer *container,
+                                          const char *filter_text)
+{
+    g_return_if_fail (NEMO_IS_ICON_CONTAINER (container));
+
+    g_free (container->details->filter_highlight_text);
+    container->details->filter_highlight_text = g_strdup (filter_text);
+
+    nemo_icon_container_invalidate_labels (container);
+    nemo_icon_container_request_update_all (container);
+}
+
+const char *
+nemo_icon_container_get_filter_highlight (NemoIconContainer *container)
+{
+    g_return_val_if_fail (NEMO_IS_ICON_CONTAINER (container), NULL);
+    return container->details->filter_highlight_text;
 }
 
 void

--- a/libnemo-private/nemo-icon-container.h
+++ b/libnemo-private/nemo-icon-container.h
@@ -338,6 +338,10 @@ void              nemo_icon_container_set_is_desktop                (NemoIconCon
 gboolean          nemo_icon_container_get_show_desktop_tooltips     (NemoIconContainer *container);
 void              nemo_icon_container_set_show_desktop_tooltips     (NemoIconContainer *container,
                                                                               gboolean  show_tooltips);
+void              nemo_icon_container_set_filter_highlight          (NemoIconContainer  *container,
+									 const char             *filter_text);
+const char       *nemo_icon_container_get_filter_highlight          (NemoIconContainer  *container);
+
 void              nemo_icon_container_reset_scroll_region           (NemoIconContainer  *container);
 void              nemo_icon_container_set_font                      (NemoIconContainer  *container,
 									 const char             *font); 

--- a/libnemo-private/nemo-icon-private.h
+++ b/libnemo-private/nemo-icon-private.h
@@ -261,6 +261,8 @@ struct NemoIconContainerDetails {
     gboolean show_desktop_tooltips;
     gboolean show_icon_view_tooltips;
 
+    gchar *filter_highlight_text;
+
 	/* Ignore the visible area the next time the scroll region is recomputed */
 	gboolean reset_scroll_region_trigger;
 	

--- a/meson.build
+++ b/meson.build
@@ -147,14 +147,7 @@ if gtk_layer_shell_enabled
 endif
 
 # make sure pango development files are installed
-pango = dependency('pango', version: '>=1.40.0')
-# check for newer pango for necessary workarounds
-new_pango = dependency('pango', version: '>=1.44.0', required: false)
-if new_pango.found()
-  conf.set('HAVE_PANGO_144', true)
-else
-  message('................using pango @0@ instead'.format(new_pango.version()))
-endif
+pango = dependency('pango', version: '>=1.44.0')
 
 enableEmptyView = get_option('empty_view')
 conf.set10('ENABLE_EMPTY_VIEW', enableEmptyView)

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,7 @@ nemoCommon_sources = [
   'nemo-error-reporting.c',
   'nemo-extension-config-widget.c',
   'nemo-file-management-properties.c',
+  'nemo-filter-bar.c',
   'nemo-floating-bar.c',
   'nemo-freedesktop-dbus.c',
   'nemo-icon-view-container.c',

--- a/src/nemo-filter-bar.c
+++ b/src/nemo-filter-bar.c
@@ -1,0 +1,107 @@
+/* nemo-filter-bar.c
+ *
+ * Copyright (C) 2026 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nemo-filter-bar.h"
+#include <glib/gi18n.h>
+
+enum {
+    CANCEL,
+    LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0 };
+
+struct _NemoFilterBar {
+    GtkBox parent_instance;
+
+    GtkWidget *entry;
+    GtkWidget *clear_button;
+};
+
+G_DEFINE_TYPE (NemoFilterBar, nemo_filter_bar, GTK_TYPE_BOX)
+
+static void
+clear_button_clicked_cb (GtkButton *button, NemoFilterBar *bar)
+{
+    g_signal_emit (bar, signals[CANCEL], 0);
+}
+
+static void
+nemo_filter_bar_init (NemoFilterBar *bar)
+{
+    GtkStyleContext *context;
+
+    gtk_orientable_set_orientation (GTK_ORIENTABLE (bar), GTK_ORIENTATION_HORIZONTAL);
+    gtk_box_set_spacing (GTK_BOX (bar), 6);
+    gtk_widget_set_margin_start (GTK_WIDGET (bar), 6);
+    gtk_widget_set_margin_end (GTK_WIDGET (bar), 6);
+    gtk_widget_set_margin_top (GTK_WIDGET (bar), 4);
+    gtk_widget_set_margin_bottom (GTK_WIDGET (bar), 4);
+
+    context = gtk_widget_get_style_context (GTK_WIDGET (bar));
+    gtk_style_context_add_class (context, GTK_STYLE_CLASS_INFO);
+
+    bar->entry = gtk_entry_new ();
+    gtk_widget_set_hexpand (bar->entry, TRUE);
+    gtk_widget_set_can_focus (bar->entry, FALSE);
+    gtk_box_pack_start (GTK_BOX (bar), bar->entry, TRUE, TRUE, 0);
+    gtk_widget_show (bar->entry);
+
+    bar->clear_button = gtk_button_new_from_icon_name ("window-close-symbolic", GTK_ICON_SIZE_MENU);
+    gtk_button_set_relief (GTK_BUTTON (bar->clear_button), GTK_RELIEF_NONE);
+    gtk_widget_set_can_focus (bar->clear_button, FALSE);
+    gtk_box_pack_end (GTK_BOX (bar), bar->clear_button, FALSE, FALSE, 0);
+    gtk_widget_show (bar->clear_button);
+
+    g_signal_connect (bar->clear_button, "clicked",
+                      G_CALLBACK (clear_button_clicked_cb), bar);
+}
+
+static void
+nemo_filter_bar_class_init (NemoFilterBarClass *klass)
+{
+
+    signals[CANCEL] =
+        g_signal_new ("cancel",
+                      G_TYPE_FROM_CLASS (klass),
+                      G_SIGNAL_RUN_LAST,
+                      0,
+                      NULL, NULL,
+                      g_cclosure_marshal_VOID__VOID,
+                      G_TYPE_NONE, 0);
+}
+
+GtkWidget *
+nemo_filter_bar_new (void)
+{
+    return g_object_new (NEMO_TYPE_FILTER_BAR, NULL);
+}
+
+const char *
+nemo_filter_bar_get_text (NemoFilterBar *bar)
+{
+    g_return_val_if_fail (NEMO_IS_FILTER_BAR (bar), NULL);
+    return gtk_entry_get_text (GTK_ENTRY (bar->entry));
+}
+
+void
+nemo_filter_bar_set_text (NemoFilterBar *bar, const char *text)
+{
+    g_return_if_fail (NEMO_IS_FILTER_BAR (bar));
+    gtk_entry_set_text (GTK_ENTRY (bar->entry), text ? text : "");
+}

--- a/src/nemo-filter-bar.h
+++ b/src/nemo-filter-bar.h
@@ -1,0 +1,33 @@
+/* nemo-filter-bar.h
+ *
+ * Copyright (C) 2026 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NEMO_FILTER_BAR_H
+#define NEMO_FILTER_BAR_H
+
+#include <gtk/gtk.h>
+
+#define NEMO_TYPE_FILTER_BAR nemo_filter_bar_get_type ()
+
+G_DECLARE_FINAL_TYPE (NemoFilterBar, nemo_filter_bar, NEMO, FILTER_BAR, GtkBox)
+
+GtkWidget  *nemo_filter_bar_new             (void);
+const char *nemo_filter_bar_get_text        (NemoFilterBar *bar);
+void        nemo_filter_bar_set_text        (NemoFilterBar *bar,
+                                             const char    *text);
+
+#endif /* NEMO_FILTER_BAR_H */

--- a/src/nemo-icon-view.c
+++ b/src/nemo-icon-view.c
@@ -1770,6 +1770,19 @@ nemo_icon_view_compare_files (NemoIconView   *icon_view,
 				  NemoFile *a,
 				  NemoFile *b)
 {
+	NemoView *view = NEMO_VIEW (icon_view);
+	NemoIconContainer *container = nemo_icon_view_get_icon_container (icon_view);
+
+	if (container != NULL &&
+	    nemo_icon_container_get_filter_highlight (container) != NULL) {
+		gint pos_a = nemo_view_get_filter_match (view, a);
+		gint pos_b = nemo_view_get_filter_match (view, b);
+
+		if (pos_a != pos_b) {
+			return (pos_a < pos_b) ? -1 : 1;
+		}
+	}
+
 	return nemo_file_compare_for_sort
 		(a, b, icon_view->details->sort->sort_type,
 		 /* Use type-unsafe cast for performance */
@@ -2355,6 +2368,26 @@ button_press_callback (GtkWidget *widget, GdkEventFocus *event, gpointer user_da
     return GDK_EVENT_PROPAGATE;
 }
 
+static void
+nemo_icon_view_update_filter_text (NemoView   *view,
+                                   const char *filter_text)
+{
+    NemoIconContainer *container;
+
+    container = nemo_icon_view_get_icon_container (NEMO_ICON_VIEW (view));
+    if (container != NULL) {
+        nemo_icon_container_set_filter_highlight (container, filter_text);
+    }
+}
+
+static gboolean
+icon_container_activate_filter_cb (NemoIconContainer *container,
+                                   GdkEvent *event,
+                                   NemoIconView *icon_view)
+{
+    return nemo_view_activate_filter (NEMO_VIEW (icon_view), (GdkEventKey *) event);
+}
+
 static NemoIconContainer *
 create_icon_container (NemoIconView *icon_view)
 {
@@ -2424,6 +2457,8 @@ create_icon_container (NemoIconView *icon_view)
 				 G_CALLBACK (get_stored_layout_timestamp), icon_view, 0);
 	g_signal_connect_object (icon_container, "store_layout_timestamp",
 				 G_CALLBACK (store_layout_timestamp), icon_view, 0);
+	g_signal_connect_object (icon_container, "check-filter-event",
+				 G_CALLBACK (icon_container_activate_filter_cb), icon_view, 0);
 
 	gtk_container_add (GTK_CONTAINER (icon_view),
 			   GTK_WIDGET (icon_container));
@@ -2732,6 +2767,7 @@ nemo_icon_view_class_init (NemoIconViewClass *klass)
 	nemo_view_class->set_selection = nemo_icon_view_set_selection;
 	nemo_view_class->invert_selection = nemo_icon_view_invert_selection;
 	nemo_view_class->compare_files = compare_files;
+	nemo_view_class->update_filter_text = nemo_icon_view_update_filter_text;
 	nemo_view_class->zoom_to_level = nemo_icon_view_zoom_to_level;
 	nemo_view_class->get_zoom_level = nemo_icon_view_get_zoom_level;
         nemo_view_class->click_policy_changed = nemo_icon_view_click_policy_changed;

--- a/src/nemo-list-model.c
+++ b/src/nemo-list-model.c
@@ -42,6 +42,7 @@
 enum {
 	SUBDIRECTORY_UNLOADED,
     GET_ICON_SCALE,
+    GET_FILTER_MATCH,
 	LAST_SIGNAL
 };
 
@@ -86,6 +87,8 @@ struct NemoListModelDetails {
 	GList *highlight_files;
     gboolean temp_unsorted;
     gboolean expansion_enabled;
+
+    gboolean filter_active;
 };
 
 typedef struct {
@@ -252,6 +255,17 @@ nemo_list_model_get_path (GtkTreeModel *tree_model, GtkTreeIter *iter)
 	}
 
 	return path;
+}
+
+static gint
+nemo_list_model_get_filter_match (NemoListModel *model, NemoFile *file)
+{
+    gint retval = -1;
+
+    g_signal_emit (model, list_model_signals[GET_FILTER_MATCH], 0,
+                   file, &retval);
+
+    return retval;
 }
 
 static gint
@@ -722,6 +736,15 @@ nemo_list_model_file_entry_compare_func (gconstpointer a,
 	file_entry2 = (FileEntry *)b;
 
 	if (file_entry1->file != NULL && file_entry2->file != NULL) {
+		if (model->details->filter_active) {
+			gint match1 = nemo_list_model_get_filter_match (model, file_entry1->file);
+			gint match2 = nemo_list_model_get_filter_match (model, file_entry2->file);
+
+			if (match1 != match2) {
+				return (match1 < match2) ? -1 : 1;
+			}
+		}
+
 		result = nemo_file_compare_for_sort_by_attribute_q (file_entry1->file, file_entry2->file,
 									model->details->sort_attribute,
 									model->details->sort_directories_first,
@@ -1016,7 +1039,9 @@ nemo_list_model_add_file (NemoListModel *model, NemoFile *file,
 	}
 
 	if (ptr != NULL) {
-		g_warning ("file already in tree (parent_ptr: %p)!!!\n", parent_ptr);
+		if (!model->details->filter_active) {
+			g_warning ("file already in tree (parent_ptr: %p)!!!", parent_ptr);
+		}
 		return FALSE;
 	}
 
@@ -1686,6 +1711,24 @@ nemo_list_model_finalize (GObject *object)
 	G_OBJECT_CLASS (nemo_list_model_parent_class)->finalize (object);
 }
 
+void
+nemo_list_model_set_filter_active (NemoListModel *model,
+                                   gboolean       active)
+{
+	g_return_if_fail (NEMO_IS_LIST_MODEL (model));
+
+	model->details->filter_active = active;
+
+	nemo_list_model_sort (model);
+}
+
+gboolean
+nemo_list_model_get_filter_active (NemoListModel *model)
+{
+	g_return_val_if_fail (NEMO_IS_LIST_MODEL (model), FALSE);
+	return model->details->filter_active;
+}
+
 static void
 nemo_list_model_init (NemoListModel *model)
 {
@@ -1725,10 +1768,19 @@ nemo_list_model_class_init (NemoListModelClass *klass)
       list_model_signals[GET_ICON_SCALE] =
         g_signal_new ("get-icon-scale",
                       NEMO_TYPE_LIST_MODEL,
-                      G_SIGNAL_RUN_FIRST | G_SIGNAL_RUN_LAST,
+                      G_SIGNAL_RUN_LAST,
                       0, NULL, NULL,
                       NULL,
                       G_TYPE_INT, 0);
+
+     list_model_signals[GET_FILTER_MATCH] =
+        g_signal_new ("get-filter-match",
+                      NEMO_TYPE_LIST_MODEL,
+                      G_SIGNAL_RUN_LAST,
+                      0, NULL, NULL,
+                      NULL,
+                      G_TYPE_INT, 1,
+                      NEMO_TYPE_FILE);
 }
 
 static void

--- a/src/nemo-list-model.h
+++ b/src/nemo-list-model.h
@@ -141,4 +141,9 @@ gboolean          nemo_list_model_get_temporarily_disable_sort (NemoListModel *m
 void              nemo_list_model_set_expanding                (NemoListModel *model, NemoDirectory *directory);
 void              nemo_list_model_set_view_directory           (NemoListModel *model, NemoDirectory *dir);
 void              nemo_list_model_set_expansion_enabled        (NemoListModel *model, gboolean enabled);
+
+void              nemo_list_model_set_filter_active           (NemoListModel *model,
+                                                               gboolean       active);
+gboolean          nemo_list_model_get_filter_active           (NemoListModel *model);
+
 #endif /* NEMO_LIST_MODEL_H */

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -30,6 +30,7 @@
 
 #include "nemo-application.h"
 #include "nemo-list-model.h"
+#include <libnemo-private/nemo-fzy-utils.h>
 #include "nemo-error-reporting.h"
 #include "nemo-view-dnd.h"
 #include "nemo-view-factory.h"
@@ -271,6 +272,8 @@ get_default_sort_order (NemoFile *file, gboolean *reversed)
 
 	return retval;
 }
+
+static void nemo_list_view_update_filter_text (NemoView *view, const char *filter_text);
 
 static void
 tooltip_prefs_changed_callback (NemoListView *view)
@@ -1527,6 +1530,10 @@ key_press_callback (GtkWidget *widget, GdkEventKey *event, gpointer callback_dat
 		handled = TRUE;
 		break;
 	case GDK_KEY_space:
+		if (nemo_view_activate_filter (view, event)) {
+			handled = TRUE;
+			break;
+		}
 		if (event->state & GDK_CONTROL_MASK) {
 			handled = FALSE;
 			break;
@@ -1560,6 +1567,10 @@ key_press_callback (GtkWidget *widget, GdkEventKey *event, gpointer callback_dat
 
 	default:
 		handled = FALSE;
+	}
+
+	if (!handled) {
+		handled = nemo_view_activate_filter (view, event);
 	}
 
 	return handled;
@@ -2259,11 +2270,50 @@ filename_cell_data_func (GtkTreeViewColumn *column,
 		underline = PANGO_UNDERLINE_NONE;
 	}
 
-	g_object_set (G_OBJECT (renderer),
-		      "text", text,
-		      "underline", underline,
-              "weight", weight,
-		      NULL);
+	if (text != NULL && nemo_list_model_get_filter_active (view->details->model)) {
+		const char *filter_text = nemo_view_get_filter_text (NEMO_VIEW (view));
+		PangoAttrList *match_attrs = nemo_fzy_match_attrs (filter_text, text);
+
+		if (match_attrs != NULL) {
+			PangoAttrList *attrs = pango_attr_list_new ();
+			PangoAttribute *base = pango_attr_weight_new (weight);
+			PangoAttrIterator *iter;
+
+			pango_attr_list_insert (attrs, base);
+
+			iter = pango_attr_list_get_iterator (match_attrs);
+			do {
+				PangoAttribute *a = pango_attr_iterator_get (iter, PANGO_ATTR_WEIGHT);
+				if (a != NULL) {
+					pango_attr_list_change (attrs, pango_attribute_copy (a));
+				}
+			} while (pango_attr_iterator_next (iter));
+			pango_attr_iterator_destroy (iter);
+			pango_attr_list_unref (match_attrs);
+
+			g_object_set (G_OBJECT (renderer),
+			              "text", text,
+			              "underline", underline,
+			              "weight-set", FALSE,
+			              "attributes", attrs,
+			              NULL);
+			pango_attr_list_unref (attrs);
+		} else {
+			g_object_set (G_OBJECT (renderer),
+			              "text", text,
+			              "underline", underline,
+			              "weight", weight,
+			              "attributes", NULL,
+			              NULL);
+		}
+	} else {
+		g_object_set (G_OBJECT (renderer),
+		              "text", text,
+		              "underline", underline,
+		              "weight", weight,
+		              "attributes", NULL,
+		              NULL);
+	}
 
     g_free (text);
 }
@@ -2383,6 +2433,14 @@ get_icon_scale_callback (NemoListModel *model,
                          NemoListView  *view)
 {
    return gtk_widget_get_scale_factor (GTK_WIDGET (view->details->tree_view));
+}
+
+static gint
+get_filter_match_callback (NemoListModel *model,
+                           NemoFile      *file,
+                           NemoListView  *view)
+{
+    return nemo_view_get_filter_match (NEMO_VIEW (view), file);
 }
 
 static void
@@ -2527,7 +2585,7 @@ create_and_set_up_tree_view (NemoListView *view)
 							(GDestroyNotify) g_free,
 							NULL);
 
-	gtk_tree_view_set_enable_search (view->details->tree_view, TRUE);
+	gtk_tree_view_set_enable_search (view->details->tree_view, FALSE);
 
 	/* Don't handle backspace key. It's used to open the parent folder. */
 	binding_set = gtk_binding_set_by_class (GTK_WIDGET_GET_CLASS (view->details->tree_view));
@@ -2617,6 +2675,8 @@ create_and_set_up_tree_view (NemoListView *view)
 
     g_signal_connect_object (view->details->model, "get-icon-scale",
                  G_CALLBACK (get_icon_scale_callback), view, 0);
+    g_signal_connect_object (view->details->model, "get-filter-match",
+                 G_CALLBACK (get_filter_match_callback), view, 0);
 
 	gtk_tree_selection_set_mode (gtk_tree_view_get_selection (view->details->tree_view), GTK_SELECTION_MULTIPLE);
 	gtk_tree_view_set_rules_hint (view->details->tree_view, TRUE);
@@ -4346,6 +4406,7 @@ nemo_list_view_class_init (NemoListViewClass *class)
 	nemo_view_class->set_selection = nemo_list_view_set_selection;
 	nemo_view_class->invert_selection = nemo_list_view_invert_selection;
 	nemo_view_class->compare_files = nemo_list_view_compare_files;
+	nemo_view_class->update_filter_text = nemo_list_view_update_filter_text;
 	nemo_view_class->sort_directories_first_changed = nemo_list_view_sort_directories_first_changed;
 	nemo_view_class->sort_favorites_first_changed = nemo_list_view_sort_favorites_first_changed;
 	nemo_view_class->start_renaming_file = nemo_list_view_start_renaming_file;
@@ -4505,4 +4566,14 @@ GtkTreeView*
 nemo_list_view_get_tree_view (NemoListView *list_view)
 {
 	return list_view->details->tree_view;
+}
+
+static void
+nemo_list_view_update_filter_text (NemoView   *view,
+                                   const char *filter_text)
+{
+    NemoListView *list_view = NEMO_LIST_VIEW (view);
+
+    nemo_list_model_set_filter_active (list_view->details->model,
+                                       filter_text != NULL && filter_text[0] != '\0');
 }

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -74,6 +74,8 @@
 #include <libnemo-private/nemo-file-dnd.h>
 #include <libnemo-private/nemo-file-operations.h>
 #include <libnemo-private/nemo-file-utilities.h>
+#include <libnemo-private/fzy-match.h>
+#include <libnemo-private/nemo-fzy-utils.h>
 #include <libnemo-private/nemo-file-private.h>
 #include <libnemo-private/nemo-global-preferences.h>
 #include <libnemo-private/nemo-link.h>
@@ -168,6 +170,7 @@ enum {
 	SELECTION_CHANGED,
 	TRASH,
 	DELETE,
+    ACTIVATE_FILTER,
 	LAST_SIGNAL
 };
 
@@ -306,6 +309,14 @@ struct NemoViewDetails
     GTimer *load_timer;
 
     char *detail_string;
+
+    /* Type-to-filter */
+    gchar *filter_text;
+    gchar *filter_text_stripped;
+    gboolean filter_active;
+    gboolean filter_navigation_blocked;
+    guint filter_debounce_id;
+    GHashTable *filter_score_cache;
 };
 
 typedef struct {
@@ -328,6 +339,9 @@ static void     trash_or_delete_files                          (GtkWindow       
 								NemoView      *view);
 static void     load_directory                                 (NemoView      *view,
 								NemoDirectory    *directory);
+static void     nemo_view_apply_filter                         (NemoView      *view);
+static void     reset_filter_state                             (NemoView      *view);
+
 static void     nemo_view_merge_menus                      (NemoView      *view);
 static void     nemo_view_unmerge_menus                    (NemoView      *view);
 static void     nemo_view_init_show_hidden_files           (NemoView      *view);
@@ -2716,6 +2730,9 @@ nemo_view_init (NemoView *view)
 				       (GDestroyNotify)file_and_directory_free,
 				       NULL);
 
+	view->details->filter_score_cache =
+		g_hash_table_new (g_direct_hash, g_direct_equal);
+
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (view),
 					GTK_POLICY_AUTOMATIC,
 					GTK_POLICY_AUTOMATIC);
@@ -2954,6 +2971,8 @@ nemo_view_destroy (GtkWidget *object)
 		view->details->delayed_rename_file_id = 0;
 	}
 
+	reset_filter_state (view);
+
 	if (view->details->model) {
 		nemo_directory_unref (view->details->model);
 		view->details->model = NULL;
@@ -3009,7 +3028,10 @@ nemo_view_finalize (GObject *object)
 
     g_clear_pointer (&view->details->detail_string, g_free);
 
+    reset_filter_state (view);
+
 	g_hash_table_destroy (view->details->non_ready_files);
+	g_hash_table_destroy (view->details->filter_score_cache);
 
 	G_OBJECT_CLASS (nemo_view_parent_class)->finalize (object);
 }
@@ -3731,6 +3753,8 @@ process_old_files (NemoView *view)
 
 		for (node = files_changed; node != NULL; node = node->next) {
 			pending = node->data;
+			g_hash_table_remove (view->details->filter_score_cache,
+			                     pending->file);
 			g_signal_emit (view,
 				       signals[still_should_show_file (view, pending->file, pending->directory)
 					       ? FILE_CHANGED : REMOVE_FILE], 0,
@@ -10333,6 +10357,10 @@ nemo_view_notify_selection_changed (NemoView *view)
 
 	view->details->selection_was_removed = FALSE;
 
+	if (view->details->filter_navigation_blocked && !view->details->filter_active) {
+		view->details->filter_navigation_blocked = FALSE;
+	}
+
 	if (!view->details->selection_change_is_due_to_shell) {
 		view->details->send_selection_change_to_shell = TRUE;
 	}
@@ -10393,6 +10421,15 @@ load_directory (NemoView *view,
 	g_assert (NEMO_IS_DIRECTORY (directory));
 
 	nemo_view_stop_loading (view);
+
+    /* Clear any active filter when navigating to a new directory */
+    view->details->filter_navigation_blocked = FALSE;
+
+    if (view->details->filter_active) {
+        reset_filter_state (view);
+        NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->update_filter_text (view, NULL);
+    }
+
 	g_signal_emit (view, signals[CLEAR], 0);
 
 	view->details->loading = TRUE;
@@ -10722,9 +10759,261 @@ real_is_read_only (NemoView *view)
 gboolean
 nemo_view_should_show_file (NemoView *view, NemoFile *file)
 {
-	return nemo_file_should_show (file,
-					  view->details->show_hidden_files,
-					  view->details->show_foreign_files);
+    if (!nemo_file_should_show (file,
+                                view->details->show_hidden_files,
+                                view->details->show_foreign_files))
+    {
+        return FALSE;
+    }
+
+    if (view->details->filter_active &&
+        nemo_view_get_filter_match (view, file) == NEMO_FILTER_NO_MATCH)
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+gint
+nemo_view_get_filter_match (NemoView *view, NemoFile *file)
+{
+    char *display_name, *stripped;
+    score_t score;
+    gint result;
+    gpointer cached;
+
+    g_return_val_if_fail (NEMO_IS_VIEW (view), NEMO_FILTER_NO_MATCH);
+
+    if (!view->details->filter_active || view->details->filter_text_stripped == NULL) {
+        return 0;
+    }
+
+    if (g_hash_table_lookup_extended (view->details->filter_score_cache,
+                                      file, NULL, &cached))
+    {
+        return GPOINTER_TO_INT (cached);
+    }
+
+    display_name = nemo_file_get_display_name (file);
+    if (display_name == NULL) {
+        result = NEMO_FILTER_NO_MATCH;
+        g_hash_table_insert (view->details->filter_score_cache,
+                             file, GINT_TO_POINTER (result));
+        return result;
+    }
+
+    stripped = nemo_fzy_strip_combining_marks (display_name, NULL);
+    g_free (display_name);
+
+    if (!has_match (view->details->filter_text_stripped, stripped)) {
+        g_free (stripped);
+        result = NEMO_FILTER_NO_MATCH;
+        g_hash_table_insert (view->details->filter_score_cache,
+                             file, GINT_TO_POINTER (result));
+        return result;
+    }
+
+    score = match (view->details->filter_text_stripped, stripped);
+    g_free (stripped);
+
+    /* Convert fzy score (higher=better) to our sort rank (lower=better).
+     * Scale by 1000 to preserve meaningful precision in the integer. */
+    if (score == SCORE_MAX) {
+        result = G_MININT;
+    } else if (score == SCORE_MIN) {
+        result = G_MAXINT - 1;
+    } else {
+        result = (gint) CLAMP (-score * 1000.0, (double) G_MININT + 1, (double) G_MAXINT - 2);
+    }
+
+    g_hash_table_insert (view->details->filter_score_cache,
+                         file, GINT_TO_POINTER (result));
+
+    return result;
+}
+
+gboolean
+nemo_view_get_filter_active (NemoView *view)
+{
+    g_return_val_if_fail (NEMO_IS_VIEW (view), FALSE);
+    return view->details->filter_active;
+}
+
+const char *
+nemo_view_get_filter_text (NemoView *view)
+{
+    g_return_val_if_fail (NEMO_IS_VIEW (view), NULL);
+    return view->details->filter_text;
+}
+
+static void
+reset_filter_state (NemoView *view)
+{
+    if (view->details->filter_debounce_id != 0) {
+        g_source_remove (view->details->filter_debounce_id);
+        view->details->filter_debounce_id = 0;
+    }
+
+    g_clear_pointer (&view->details->filter_text, g_free);
+    g_clear_pointer (&view->details->filter_text_stripped, g_free);
+    g_hash_table_remove_all (view->details->filter_score_cache);
+    view->details->filter_active = FALSE;
+}
+
+static gboolean
+apply_filter_debounce_cb (gpointer data)
+{
+    NemoView *view = NEMO_VIEW (data);
+
+    view->details->filter_debounce_id = 0;
+
+    NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->update_filter_text (view, view->details->filter_text);
+    nemo_view_apply_filter (view);
+
+    /* Re-emit so the slot can update the "no matching files" indicator
+     * now that apply_filter has updated the view contents. */
+    g_signal_emit (view, signals[ACTIVATE_FILTER], 0, view->details->filter_text);
+
+    return G_SOURCE_REMOVE;
+}
+
+void
+nemo_view_set_filter_text (NemoView *view, const char *text)
+{
+    g_return_if_fail (NEMO_IS_VIEW (view));
+
+    reset_filter_state (view);
+
+    if (text != NULL && text[0] != '\0') {
+        view->details->filter_text = g_strdup (text);
+        view->details->filter_text_stripped = nemo_fzy_strip_combining_marks (text, NULL);
+        view->details->filter_navigation_blocked = TRUE;
+        view->details->filter_active = TRUE;
+    }
+
+    g_signal_emit (view, signals[ACTIVATE_FILTER], 0, view->details->filter_text);
+
+    view->details->filter_debounce_id = g_timeout_add (100, apply_filter_debounce_cb, view);
+}
+
+void
+nemo_view_clear_filter (NemoView *view)
+{
+    g_return_if_fail (NEMO_IS_VIEW (view));
+
+    if (!view->details->filter_active) {
+        return;
+    }
+
+    reset_filter_state (view);
+
+    g_signal_emit (view, signals[ACTIVATE_FILTER], 0, NULL);
+
+    nemo_view_apply_filter (view);
+
+    NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->update_filter_text (view, NULL);
+}
+
+gboolean
+nemo_view_activate_filter (NemoView *view, GdkEventKey *event)
+{
+    guint32 unicode_ch;
+
+    g_return_val_if_fail (NEMO_IS_VIEW (view), FALSE);
+
+    if (event == NULL) {
+        return FALSE;
+    }
+
+    if ((event->state & (GDK_CONTROL_MASK | GDK_MOD1_MASK)) != 0) {
+        return FALSE;
+    }
+
+    /* Escape clears an active filter */
+    if (event->keyval == GDK_KEY_Escape && view->details->filter_active) {
+        nemo_view_clear_filter (view);
+        return TRUE;
+    }
+
+    /* Backspace removes the last character from the filter, or is
+     * consumed (no-op) while navigation is blocked after filtering. */
+    if (event->keyval == GDK_KEY_BackSpace &&
+        (view->details->filter_active || view->details->filter_navigation_blocked)) {
+
+        if (!view->details->filter_active) {
+            return TRUE;
+        }
+        const char *text = view->details->filter_text;
+        glong len = g_utf8_strlen (text, -1);
+
+        if (len <= 1) {
+            nemo_view_clear_filter (view);
+        } else {
+            gchar *new_text = g_strndup (text, g_utf8_offset_to_pointer (text, len - 1) - text);
+            nemo_view_set_filter_text (view, new_text);
+            g_free (new_text);
+        }
+
+        return TRUE;
+    }
+
+    /* Printable characters append to the filter.
+     * Space only appends if filter is already active. */
+    unicode_ch = gdk_keyval_to_unicode (event->keyval);
+
+    if (unicode_ch != 0 && g_unichar_isprint (unicode_ch) &&
+        (unicode_ch != ' ' || view->details->filter_active)) {
+        gchar buf[6];
+        gint char_len;
+        gchar *new_text;
+
+        char_len = g_unichar_to_utf8 (unicode_ch, buf);
+        buf[char_len] = '\0';
+
+        if (view->details->filter_text != NULL) {
+            new_text = g_strconcat (view->details->filter_text, buf, NULL);
+        } else {
+            new_text = g_strdup (buf);
+        }
+
+        nemo_view_set_filter_text (view, new_text);
+        g_free (new_text);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static void
+nemo_view_apply_filter (NemoView *view)
+{
+    NemoDirectory *directory;
+    GList *all_files, *l;
+
+    directory = view->details->model;
+
+    if (directory == NULL) {
+        return;
+    }
+
+    all_files = nemo_directory_get_file_list (directory);
+
+    g_signal_emit (view, signals[BEGIN_FILE_CHANGES], 0);
+
+    for (l = all_files; l != NULL; l = l->next) {
+        NemoFile *file = l->data;
+
+        if (nemo_view_should_show_file (view, file)) {
+            g_signal_emit (view, signals[ADD_FILE], 0, file, directory);
+        } else {
+            g_signal_emit (view, signals[REMOVE_FILE], 0, file, directory);
+        }
+    }
+
+    g_signal_emit (view, signals[END_FILE_CHANGES], 0);
+
+    nemo_file_list_free (all_files);
 }
 
 static gboolean
@@ -10733,6 +11022,11 @@ real_using_manual_layout (NemoView *view)
 	g_return_val_if_fail (NEMO_IS_VIEW (view), FALSE);
 
 	return FALSE;
+}
+
+static void
+real_update_filter_text (NemoView *view, const char *filter_text)
+{
 }
 
 static void
@@ -11173,6 +11467,14 @@ nemo_view_class_init (NemoViewClass *klass)
 			      g_signal_accumulator_true_handled, NULL,
 			      g_cclosure_marshal_generic,
 			      G_TYPE_BOOLEAN, 0);
+    signals[ACTIVATE_FILTER] =
+        g_signal_new ("activate-filter",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL,
+                  g_cclosure_marshal_VOID__STRING,
+                  G_TYPE_NONE, 1, G_TYPE_STRING);
 
 	klass->get_selected_icon_locations = real_get_selected_icon_locations;
 	klass->is_read_only = real_is_read_only;
@@ -11184,6 +11486,7 @@ nemo_view_class_init (NemoViewClass *klass)
         klass->merge_menus = real_merge_menus;
         klass->unmerge_menus = real_unmerge_menus;
         klass->update_menus = real_update_menus;
+	klass->update_filter_text = real_update_filter_text;
 	klass->trash = real_trash;
 	klass->delete = real_delete;
 

--- a/src/nemo-view.h
+++ b/src/nemo-view.h
@@ -31,6 +31,8 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 
+#define NEMO_FILTER_NO_MATCH G_MAXINT
+
 #include <libnemo-private/nemo-directory.h>
 #include <libnemo-private/nemo-file.h>
 #include <libnemo-private/nemo-icon-container.h>
@@ -312,6 +314,9 @@ struct NemoViewClass {
 	void           (* scroll_to_file)	  (NemoView          *view,
 						   const char            *uri);
 
+	void    (* update_filter_text)             (NemoView *view,
+						   const char  *filter_text);
+
         /* Signals used only for keybindings */
         gboolean (* trash)                         (NemoView *view);
         gboolean (* delete)                        (NemoView *view);
@@ -376,6 +381,17 @@ void                nemo_view_unfreeze_updates                 (NemoView  *view)
 gboolean            nemo_view_get_is_renaming                  (NemoView  *view);
 void                nemo_view_set_is_renaming                  (NemoView  *view,
 								    gboolean       renaming);
+
+/* Type-to-filter */
+void                nemo_view_set_filter_text                  (NemoView  *view,
+                                                                    const char    *text);
+void                nemo_view_clear_filter                     (NemoView  *view);
+gboolean            nemo_view_get_filter_active                (NemoView  *view);
+const char         *nemo_view_get_filter_text                  (NemoView  *view);
+gint                nemo_view_get_filter_match                 (NemoView  *view,
+                                                                    NemoFile  *file);
+gboolean            nemo_view_activate_filter                  (NemoView  *view,
+                                                                    GdkEventKey   *event);
 void                nemo_view_add_subdirectory                (NemoView  *view,
 								   NemoDirectory*directory);
 void                nemo_view_remove_subdirectory             (NemoView  *view,

--- a/src/nemo-window-slot.c
+++ b/src/nemo-window-slot.c
@@ -28,6 +28,7 @@
 
 #include "nemo-actions.h"
 #include "nemo-desktop-window.h"
+#include "nemo-filter-bar.h"
 #include "nemo-floating-bar.h"
 #include "nemo-window-private.h"
 #include "nemo-window-manage-views.h"
@@ -276,8 +277,8 @@ floating_bar_action_cb (NemoFloatingBar *floating_bar,
 	}
 }
 
-static GtkWidget *
-create_nsr_box (void)
+static void
+create_nsr_box (NemoWindowSlot *slot)
 {
     GtkWidget *box;
     GtkWidget *widget;
@@ -288,7 +289,7 @@ create_nsr_box (void)
     widget = gtk_image_new_from_icon_name ("xsi-search-symbolic", GTK_ICON_SIZE_DIALOG);
     gtk_box_pack_start (GTK_BOX (box), widget, FALSE, FALSE, 0);
 
-    widget = gtk_label_new (_("No files found"));
+    widget = gtk_label_new ("");
     attrs = pango_attr_list_new ();
     pango_attr_list_insert (attrs, pango_attr_size_new (20 * PANGO_SCALE));
     gtk_label_set_attributes (GTK_LABEL (widget), attrs);
@@ -301,7 +302,69 @@ create_nsr_box (void)
     gtk_widget_show_all (box);
     gtk_widget_set_no_show_all (box, TRUE);
     gtk_widget_hide (box);
-    return box;
+
+    slot->no_search_results_box = box;
+    slot->no_results_label = widget;
+}
+
+static void
+view_begin_loading_cb (NemoView       *view,
+                       NemoWindowSlot *slot)
+{
+    if (gtk_revealer_get_reveal_child (GTK_REVEALER (slot->filter_bar_revealer))) {
+        gtk_revealer_set_reveal_child (GTK_REVEALER (slot->filter_bar_revealer), FALSE);
+        nemo_filter_bar_set_text (NEMO_FILTER_BAR (slot->filter_bar), "");
+    }
+
+    nemo_view_grab_focus (view);
+}
+
+static void
+filter_bar_cancel_cb (NemoFilterBar *bar,
+                      NemoWindowSlot *slot)
+{
+    if (slot->content_view != NULL) {
+        nemo_view_clear_filter (slot->content_view);
+    }
+}
+
+static void
+view_activate_filter_cb (NemoView   *view,
+                         const char *filter_text,
+                         NemoWindowSlot *slot)
+{
+    if (filter_text != NULL && filter_text[0] != '\0') {
+        gtk_revealer_set_reveal_child (GTK_REVEALER (slot->filter_bar_revealer), TRUE);
+        nemo_filter_bar_set_text (NEMO_FILTER_BAR (slot->filter_bar), filter_text);
+
+        if (NEMO_VIEW_CLASS (G_OBJECT_GET_CLASS (view))->is_empty (view)) {
+            gtk_label_set_text (GTK_LABEL (slot->no_results_label), _("No matching files"));
+            gtk_widget_show (slot->no_search_results_box);
+        } else {
+            gtk_widget_hide (slot->no_search_results_box);
+        }
+    } else {
+        gtk_widget_hide (slot->no_search_results_box);
+        nemo_window_slot_hide_filter_bar (slot);
+    }
+}
+
+void
+nemo_window_slot_hide_filter_bar (NemoWindowSlot *slot)
+{
+    g_return_if_fail (NEMO_IS_WINDOW_SLOT (slot));
+
+    if (!gtk_revealer_get_reveal_child (GTK_REVEALER (slot->filter_bar_revealer))) {
+        return;
+    }
+
+    gtk_revealer_set_reveal_child (GTK_REVEALER (slot->filter_bar_revealer), FALSE);
+    nemo_filter_bar_set_text (NEMO_FILTER_BAR (slot->filter_bar), "");
+
+    if (slot->content_view != NULL) {
+        nemo_view_clear_filter (slot->content_view);
+        nemo_view_grab_focus (slot->content_view);
+    }
 }
 
 static void
@@ -335,7 +398,7 @@ nemo_window_slot_init (NemoWindowSlot *slot)
 	gtk_overlay_add_overlay (GTK_OVERLAY (slot->view_overlay),
 				 slot->floating_bar);
 
-    slot->no_search_results_box = create_nsr_box ();
+    create_nsr_box (slot);
     gtk_overlay_add_overlay (GTK_OVERLAY (slot->view_overlay),
                              slot->no_search_results_box);
 
@@ -343,6 +406,18 @@ nemo_window_slot_init (NemoWindowSlot *slot)
 			  G_CALLBACK (floating_bar_action_cb), slot);
 
     slot->cache_bar = NULL;
+
+    slot->filter_bar = nemo_filter_bar_new ();
+    slot->filter_bar_revealer = gtk_revealer_new ();
+    gtk_revealer_set_transition_type (GTK_REVEALER (slot->filter_bar_revealer),
+                                      GTK_REVEALER_TRANSITION_TYPE_SLIDE_UP);
+    gtk_revealer_set_transition_duration (GTK_REVEALER (slot->filter_bar_revealer), 150);
+    gtk_container_add (GTK_CONTAINER (slot->filter_bar_revealer), slot->filter_bar);
+    gtk_box_pack_start (GTK_BOX (slot), slot->filter_bar_revealer, FALSE, FALSE, 0);
+    gtk_widget_show_all (slot->filter_bar_revealer);
+
+    g_signal_connect (slot->filter_bar, "cancel",
+                      G_CALLBACK (filter_bar_cancel_cb), slot);
 
 	slot->title = g_strdup (_("Loading..."));
 }
@@ -362,10 +437,10 @@ view_end_loading_cb (NemoView       *view,
 
         if (NEMO_IS_SEARCH_DIRECTORY (directory)) {
             if (!nemo_directory_is_not_empty (directory)) {
+                gtk_label_set_text (GTK_LABEL (slot->no_results_label), _("No files found"));
                 gtk_widget_show (slot->no_search_results_box);
             } else {
                 gtk_widget_hide (slot->no_search_results_box);
-
             }
         }
 
@@ -632,6 +707,12 @@ nemo_window_slot_set_content_view_widget (NemoWindowSlot *slot,
 	if (slot->content_view != NULL) {
 		/* disconnect old view */
         g_signal_handlers_disconnect_by_func (slot->content_view, G_CALLBACK (view_end_loading_cb), slot);
+        g_signal_handlers_disconnect_by_func (slot->content_view, G_CALLBACK (view_begin_loading_cb), slot);
+
+        if (slot->filter_activate_handler_id > 0) {
+            g_signal_handler_disconnect (slot->content_view, slot->filter_activate_handler_id);
+            slot->filter_activate_handler_id = 0;
+        }
 
 		nemo_window_disconnect_content_view (window, slot->content_view);
 
@@ -640,6 +721,9 @@ nemo_window_slot_set_content_view_widget (NemoWindowSlot *slot,
 		g_object_unref (slot->content_view);
 		slot->content_view = NULL;
 	}
+
+    /* Hide filter bar when switching views */
+    nemo_window_slot_hide_filter_bar (slot);
 
 	if (new_view != NULL) {
 		widget = GTK_WIDGET (new_view);
@@ -650,6 +734,11 @@ nemo_window_slot_set_content_view_widget (NemoWindowSlot *slot,
 		g_object_ref (slot->content_view);
 
 		g_signal_connect (new_view, "end_loading", G_CALLBACK (view_end_loading_cb), slot);
+		g_signal_connect (new_view, "begin_loading", G_CALLBACK (view_begin_loading_cb), slot);
+
+        slot->filter_activate_handler_id =
+            g_signal_connect (new_view, "activate-filter",
+                              G_CALLBACK (view_activate_filter_cb), slot);
 
 		/* connect new view */
 		nemo_window_connect_content_view (window, new_view);

--- a/src/nemo-window-slot.h
+++ b/src/nemo-window-slot.h
@@ -70,6 +70,11 @@ struct NemoWindowSlot {
 	GtkWidget *floating_bar;
     GtkWidget *cache_bar;
     GtkWidget *no_search_results_box;
+    GtkWidget *no_results_label;
+
+    GtkWidget *filter_bar;
+    GtkWidget *filter_bar_revealer;
+    gulong filter_activate_handler_id;
 
 	guint set_status_timeout_id;
 	guint loading_timeout_id;
@@ -191,4 +196,7 @@ void nemo_window_slot_check_bad_cache_bar (NemoWindowSlot *slot);
 
 void nemo_window_slot_set_show_thumbnails (NemoWindowSlot *slot,
                                            gboolean show_thumbnails);
+
+void nemo_window_slot_hide_filter_bar (NemoWindowSlot *slot);
+
 #endif /* NEMO_WINDOW_SLOT_H */


### PR DESCRIPTION
This would replace the current interactive search feature (typing to restrict selection to filenames beginning with the typed text), except for the desktop view.

Instead, typing would show an entry as before, but now:

- The view will actively filter out non-matching files.
- Matches will by made and scored using the 'fzy' matching algorithm based on https://github.com/jhawthorn/fzy.
- Matching characters will be highlighted (bold) within the filename in the resulting list.
- Focus/navigation remains in the view so keyboard navigation can still be performed while the filter is active.
- Deleting (backspace) all text from the filter hides the filter and restores the normal view.

ref: #3714, https://github.com/linuxmint/nemo/issues/507