### PR TITLE
a proper drop shadow for nemo-desktop

### DIFF
--- a/gresources/nemo-style-application.css
+++ b/gresources/nemo-style-application.css
@@ -24,8 +24,8 @@ NemoDesktopWindow GtkPaned {
 }
 
 .nemo-desktop.nemo-canvas-item {
-    color: #eeeeee;
-    text-shadow: 1px 1px alpha(black, 0.8);
+	color: #eeeeee;
+    text-shadow: 2px 2px 3px alpha(black, 0.8);
 }
 
 .nemo-desktop.nemo-canvas-item:hover {


### PR DESCRIPTION
(hover over images to see their values) a few presets could be presented in GUI settings

<img width="202" height="91" title="stock" src="https://github.com/user-attachments/assets/db448122-9e92-440e-9b8c-f3c5da8dca92" />
<img width="180" height="93" title="2px 2px 3px 0.9" src="https://github.com/user-attachments/assets/897bc4d4-21fe-4cf9-809d-a831196a76ba" />
<img width="191" height="97" title="1px 1px 2px 0.9" src="https://github.com/user-attachments/assets/5195885b-2c16-4bde-8654-15871d77a086" />



i do this via `~/.config/gtk-3.0/gtk.css` :
```
/* Drop shadow for Nemo-desktop (Cinnamon) */
.nemo-desktop.nemo-canvas-item {
    text-shadow: 2px 2px 3px alpha(black, 0.8);
}
```

i had this tweak for some years and i think the time to bring it up has come.

<img width="378" height="512" title="font is the same" alt="png-bob" src="https://github.com/user-attachments/assets/9df0b961-4d07-4cae-82b4-bca6e41f32fe" />

everyone deserves some nice and clean drop shadows