### PR TITLE
Add NemoSelectionProvider extension interface

### DIFF
--- a/libnemo-extension/meson.build
+++ b/libnemo-extension/meson.build
@@ -18,6 +18,7 @@ nemo_extension_sources = [
   'nemo-property-page-provider.c',
   'nemo-property-page.c',
   'nemo-menu.c',
+  'nemo-selection-provider.c',
   'nemo-simple-button.c',
 ]
 
@@ -35,6 +36,7 @@ nemo_extension_headers = [
   'nemo-property-page-provider.h',
   'nemo-property-page.h',
   'nemo-menu.h',
+  'nemo-selection-provider.h',
   'nemo-simple-button.h',
 ]
 

--- a/libnemo-extension/nemo-selection-provider.c
+++ b/libnemo-extension/nemo-selection-provider.c
@@ -1,0 +1,64 @@
+/*
+ *  nemo-selection-provider.c - Interface for Nemo extensions that
+ *                              want to be notified when the file
+ *                              selection changes.
+ *
+ *  Copyright (C) 2026
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Suite 500, MA 02110-1335, USA.
+ */
+
+#include <config.h>
+#include "nemo-selection-provider.h"
+#include <glib-object.h>
+
+/**
+ * SECTION:nemo-selection-provider
+ * @Title: NemoSelectionProvider
+ * @Short_description: Notifies extensions when the file selection changes.
+ *
+ * Extensions implementing this interface will have their selection_changed
+ * method called whenever the user changes the file selection in Nemo.
+ **/
+
+G_DEFINE_INTERFACE (NemoSelectionProvider, nemo_selection_provider, G_TYPE_OBJECT)
+
+static void
+nemo_selection_provider_default_init (NemoSelectionProviderInterface *klass)
+{
+    /* No signals needed — Nemo calls selection_changed() directly */
+}
+
+/**
+ * nemo_selection_provider_selection_changed:
+ * @provider: a #NemoSelectionProvider
+ * @window: the parent #GtkWidget window
+ * @files: (element-type NemoFileInfo): a list of currently selected #NemoFileInfo
+ *
+ * Called by Nemo when the file selection changes. Dispatches to the
+ * extension's selection_changed() implementation.
+ */
+void
+nemo_selection_provider_selection_changed (NemoSelectionProvider *provider,
+                                           GtkWidget             *window,
+                                           GList                 *files)
+{
+    g_return_if_fail (NEMO_IS_SELECTION_PROVIDER (provider));
+
+    if (NEMO_SELECTION_PROVIDER_GET_IFACE (provider)->selection_changed) {
+        NEMO_SELECTION_PROVIDER_GET_IFACE (provider)->selection_changed
+            (provider, window, files);
+    }
+}

--- a/libnemo-extension/nemo-selection-provider.h
+++ b/libnemo-extension/nemo-selection-provider.h
@@ -1,0 +1,61 @@
+/*
+ *  nemo-selection-provider.h - Interface for Nemo extensions that
+ *                              want to be notified when the file
+ *                              selection changes.
+ *
+ *  Copyright (C) 2026
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Suite 500, MA 02110-1335, USA.
+ */
+
+/* This interface is implemented by Nemo extensions that want to
+ * be notified when the user's file selection changes.  Extensions
+ * receive a list of NemoFileInfo objects representing the current
+ * selection, and the GtkWidget of the parent window. */
+
+#ifndef NEMO_SELECTION_PROVIDER_H
+#define NEMO_SELECTION_PROVIDER_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+#include "nemo-extension-types.h"
+#include "nemo-file-info.h"
+
+G_BEGIN_DECLS
+
+#define NEMO_TYPE_SELECTION_PROVIDER (nemo_selection_provider_get_type ())
+
+G_DECLARE_INTERFACE (NemoSelectionProvider, nemo_selection_provider,
+                     NEMO, SELECTION_PROVIDER,
+                     GObject)
+
+typedef NemoSelectionProviderInterface NemoSelectionProviderIface;
+
+struct _NemoSelectionProviderInterface {
+    GTypeInterface g_iface;
+
+    void (*selection_changed) (NemoSelectionProvider *provider,
+                               GtkWidget             *window,
+                               GList                 *files);
+};
+
+/* Called by Nemo when the selection changes. files is a list of NemoFileInfo. */
+void nemo_selection_provider_selection_changed (NemoSelectionProvider *provider,
+                                               GtkWidget             *window,
+                                               GList                 *files);
+
+G_END_DECLS
+
+#endif /* NEMO_SELECTION_PROVIDER_H */

--- a/src/nemo-view.c
+++ b/src/nemo-view.c
@@ -61,6 +61,7 @@
 #include <eel/eel-vfs-extensions.h>
 
 #include <libnemo-extension/nemo-menu-provider.h>
+#include <libnemo-extension/nemo-selection-provider.h>
 #include <libnemo-private/nemo-bookmark.h>
 #include <libnemo-private/nemo-clipboard.h>
 #include <libnemo-private/nemo-clipboard-monitor.h>
@@ -10310,6 +10311,33 @@ schedule_update_status (NemoView *view)
 	}
 }
 
+static void
+nemo_view_notify_selection_providers (NemoView *view)
+{
+    GList *providers, *l, *selection, *file_infos;
+    GtkWidget *window;
+
+    providers = nemo_module_get_extensions_for_type (NEMO_TYPE_SELECTION_PROVIDER);
+    if (providers == NULL)
+        return;
+
+    selection = nemo_view_get_selection (view);
+    window = GTK_WIDGET (nemo_view_get_containing_window (view));
+
+    file_infos = NULL;
+    for (l = selection; l != NULL; l = l->next)
+        file_infos = g_list_prepend (file_infos, NEMO_FILE_INFO (l->data));
+    file_infos = g_list_reverse (file_infos);
+
+    for (l = providers; l != NULL; l = l->next)
+        nemo_selection_provider_selection_changed (NEMO_SELECTION_PROVIDER (l->data),
+                                                   window, file_infos);
+
+    g_list_free (file_infos);
+    nemo_file_list_free (selection);
+    nemo_module_extension_list_free (providers);
+}
+
 /**
  * nemo_view_notify_selection_changed:
  *
@@ -10359,6 +10387,7 @@ nemo_view_notify_selection_changed (NemoView *view)
 		/* Schedule an update of menu item states to match selection */
         selection_changed_schedule_update_menus (view);
 	}
+    nemo_view_notify_selection_providers (view);
 }
 
 static void


### PR DESCRIPTION
Adds a new NemoSelectionProvider interface to libnemo-extension that allows extensions to be notified when the file selection changes.

- Add nemo-selection-provider.h/.c with the new interface
- Call nemo_view_notify_selection_providers() from nemo_view_notify_selection_changed() to notify all registered selection provider extensions