### PR TITLE
Bugfix: rename replaces parent directory (issue #3750)

### DIFF
--- a/libnemo-private/nemo-file-conflict-dialog.c
+++ b/libnemo-private/nemo-file-conflict-dialog.c
@@ -622,6 +622,7 @@ nemo_file_conflict_dialog_class_init (NemoFileConflictDialogClass *klass)
 char *
 nemo_file_conflict_dialog_get_new_name (NemoFileConflictDialog *dialog)
 {
+	g_assert(gtk_entry_get_text_length (GTK_ENTRY (dialog->details->entry)) > 0);
 	return g_strdup (gtk_entry_get_text
 			 (GTK_ENTRY (dialog->details->entry)));
 }

--- a/libnemo-private/nemo-file-conflict-dialog.c
+++ b/libnemo-private/nemo-file-conflict-dialog.c
@@ -566,6 +566,7 @@ nemo_file_conflict_dialog_init (NemoFileConflictDialog *fcd)
 				       _("Re_name"),
 				       CONFLICT_RESPONSE_RENAME);
 	gtk_widget_hide (details->rename_button);
+	gtk_widget_set_no_show_all(details->rename_button, TRUE);
 
 	details->replace_button =
 		gtk_dialog_add_button (dialog,


### PR DESCRIPTION
This protects against the issue described in https://github.com/linuxmint/nemo/issues/3750 by asserting that the new name used when resolving a conflict via rename cannot be blank. Also ensure that the Rename button is actually hidden prior to `file_list_ready_cb()` so as to create an initial state consistent with the show/hide logic around the replace/rename buttons in `entry_text_changed_cb()` and `checkbox_toggled_cb()`.

It kind of looks like this problem was foreseen as the `details->rename_button` button widget is hidden after creation, but that looks to be undone by the subsequent `gtk_widget_show_all()` call.

Unfortunately I wasn't actually able to test this on master as I cannot get that to run on my computer. This was fixed and tested against the v6.4.5 tag which matches my distro's current stable package. I did run `git diff master libnemo-private/nemo-file-conflict-dialog.c` while on the 6.4.5 tag and do not see anything that changes the picture. Appreciate this is not an ideal way to submit a PR, but given the changes are so trivial am hoping to get away with it...

I dare say that the whole half-baked conflict dialog while the directory scan runs is a bit odd from a UX perspective. For example, it might state in the empty space atop the dialog that the directory is still being enumerated. The expander might also be disabled until the dialog is fully valid (as it will show a blank entry, which is confusing although I think it will now at least be safe).

Am happy to further develop this PR to include such things if desired, but felt it made sense to start with a minimum fix.