### PR TITLE
actions: Don't show in the places-sidebar menu, unless Conditions allow it.

### DIFF
--- a/files/usr/share/nemo/action-info.md
+++ b/files/usr/share/nemo/action-info.md
@@ -160,6 +160,8 @@ Can be one or more of:
 - `gsettings <schema> <boolean key>`: The boolean key in the given schema must be true.
 - `gsettings <schema> <key> <key-type> <[eq|ne|gt|lt]> <value>`: The value of `<key>` is [`equal|not equal|greater than|less than`] `<value>`. The `<key-types>` must match, but the comparisons are not clearly defined for non-numerical types.
 - `exec <program>`: Run `<program>` (absolute path or PATH executable) and interpret its exit code as 0 for passing, and non-0 for failure.
+- `sidebar-allow`: Also show this action in the places sidebar's context menu. By default, actions are hidden from the sidebar. Cannot be used with `sidebar-only`. (6.8)
+- `sidebar-only`: Only show this action in the places sidebar's context menu, never in normal file views. Useful with actions that only make sense against sidebar entries (bookmarks, mounts, etc). Cannot be used with `sidebar-allow` (6.8)
 
 **Terminal** (optional): Set to true to execute the Exec line in a spawned terminal window.
   
@@ -239,7 +241,7 @@ Separator=,
 Quote=single|double|backtick
 Dependencies=notify-send;!zenity;
 UriScheme=sftp
-Conditions=desktop;dbus <name>;gsettings foo_schema foo_boolkey;removable;exec <program>;
+Conditions=desktop;dbus <name>;gsettings foo_schema foo_boolkey;removable;exec <program>;sidebar-allow;sidebar-only;
 Terminal=true|false
 Files=.bash*;!.bashrc;
 Locations=.*;!.config;

--- a/files/usr/share/nemo/actions/sample.nemo_action
+++ b/files/usr/share/nemo/actions/sample.nemo_action
@@ -93,6 +93,11 @@ Extensions=any;
 #     "dbus <name>" exists
 #     "exec <program>" run program and check its exit code (0 is pass, non-0 is fail).
 #                      Enclose in < > if the program resides in the action's folder.
+#     "sidebar-allow" also show this action in the places sidebar context menu (by
+#                     default, actions are hidden from the sidebar). Cannot be used
+#                     with sidebar-only. (6.8)
+#     "sidebar-only"  only show this action in the places sidebar context menu, not
+#                     in normal file views. Cannot be used with sidebar-allow. (6.8)
 
 #Conditions=desktop;
 

--- a/libnemo-private/nemo-action.c
+++ b/libnemo-private/nemo-action.c
@@ -59,6 +59,8 @@ typedef struct {
     gboolean escape_underscores;
     gboolean escape_space;
     gboolean show_in_blank_desktop;
+    gboolean sidebar_allow;
+    gboolean sidebar_only;
     gboolean run_in_terminal;
     gchar *uri_scheme;
 
@@ -831,6 +833,8 @@ nemo_action_constructed (GObject *object)
     g_strfreev (files);
 
     gboolean is_desktop = FALSE;
+    gboolean sidebar_allow = FALSE;
+    gboolean sidebar_only = FALSE;
 
     if (conditions && condition_count > 0) {
         guint j;
@@ -856,6 +860,14 @@ nemo_action_constructed (GObject *object)
             if (g_strcmp0 (condition, "removable") == 0) {
                 /* this is handled in nemo_action_get_visibility() */
             }
+            else
+            if (g_strcmp0 (condition, "sidebar-allow") == 0) {
+                sidebar_allow = TRUE;
+            }
+            else
+            if (g_strcmp0 (condition, "sidebar-only") == 0) {
+                sidebar_only = TRUE;
+            }
             else {
                 g_warning ("Ignoring invalid condition: %s."
                            " See sample action at /usr/share/nemo/actions/sample.nemo_action", condition);
@@ -870,6 +882,16 @@ nemo_action_constructed (GObject *object)
     g_free (exec_raw);
 
     TokenType token_type;
+
+    if (sidebar_allow && sidebar_only) {
+        g_warning ("Action '%s' specifies both 'sidebar-allow' and 'sidebar-only' conditions;"
+                   " ignoring both.", action->key_file_path);
+        sidebar_allow = FALSE;
+        sidebar_only = FALSE;
+    }
+
+    priv->sidebar_allow = sidebar_allow;
+    priv->sidebar_only = sidebar_only;
 
     priv->show_in_blank_desktop = is_desktop &&
                                     type == SELECTION_NONE &&
@@ -1865,6 +1887,15 @@ get_visibility (NemoAction *action,
                 GtkWindow  *window)
 {
     NemoActionPrivate *priv = nemo_action_get_instance_private (action);
+
+    if (for_places) {
+        if (!priv->sidebar_allow && !priv->sidebar_only)
+            return FALSE;
+    } else {
+        if (priv->sidebar_only)
+            return FALSE;
+    }
+
     // Check DBUS
     if (!priv->dbus_satisfied)
         return FALSE;


### PR DESCRIPTION
By default, actions will no longer appear in context menus for places-sidebar entries.

To opt back in to sidebar visibility, two new Conditions are added:
- sidebar-allow: Display in the sidebar, along with any other valid locations assuming all conditions are met (consider this 'legacy' behavior).
- sidebar-only: The action will only be shown in the sidebar, provided other Conditions are met, and nowhere else. Use this for actions that only make sense when applied to sidebar items (bookmarks, mounts, etc...).