### PR TITLE
feat: add option to show real filenames

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -230,14 +230,6 @@ nemo_file_set_display_name (NemoFile *file,
 {
 	gboolean changed;
 
-	/* When enabled, always show the actual filename instead of any custom
-	 * display name (e.g. the Name field inside .desktop files). */
-	if (custom &&
-	    file->details->name != NULL &&
-	    g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_REAL_FILENAME)) {
-		return FALSE;
-	}
-
 	if (custom && display_name == NULL) {
 		/* We're re-setting a custom display name, invalidate it if
 		   we already set it so that the old one is re-read */
@@ -4162,6 +4154,13 @@ nemo_file_peek_display_name (NemoFile *file)
 							FALSE);
 			g_free (escaped_name);
 		}
+	}
+
+	/* When enabled, always show the actual filename instead of any custom
+	 * display name (e.g. the Name field inside .desktop files). */
+	if (file->details->name != NULL &&
+	    g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_REAL_FILENAME)) {
+		return file->details->name;
 	}
 
 	return file->details->display_name;

--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -230,6 +230,14 @@ nemo_file_set_display_name (NemoFile *file,
 {
 	gboolean changed;
 
+	/* When enabled, always show the actual filename instead of any custom
+	 * display name (e.g. the Name field inside .desktop files). */
+	if (custom &&
+	    file->details->name != NULL &&
+	    g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_SHOW_REAL_FILENAME)) {
+		return FALSE;
+	}
+
 	if (custom && display_name == NULL) {
 		/* We're re-setting a custom display name, invalidate it if
 		   we already set it so that the old one is re-read */

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -41,6 +41,7 @@ G_BEGIN_DECLS
 
 /* Display  */
 #define NEMO_PREFERENCES_SHOW_HIDDEN_FILES			"show-hidden-files"
+#define NEMO_PREFERENCES_SHOW_REAL_FILENAME			"show-real-filename"
 #define NEMO_PREFERENCES_SHOW_ADVANCED_PERMISSIONS		"show-advanced-permissions"
 #define NEMO_PREFERENCES_DATE_FORMAT            "date-format"
 #define NEMO_PREFERENCES_DATE_FONT_CHOICE  "date-font-choice"

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -321,6 +321,11 @@
       <summary>Whether to show hidden files</summary>
       <description>If set to true, then hidden files are shown by default in the file manager.  Hidden files are either dotfiles, listed in the folder's .hidden file or backup files ending with a tilde (~).</description>
     </key>
+    <key name="show-real-filename" type="b">
+      <default>false</default>
+      <summary>Whether to show files by their actual filename</summary>
+      <description>If set to true, all files will be displayed using their actual filename instead of any custom display name (such as the Name field inside .desktop files).</description>
+    </key>
     <key name="show-full-path-titles" type="b">
       <default>false</default>
       <summary>Whether to show the full path of the current view in the title bar and tab bars</summary>


### PR DESCRIPTION
This pull request adds an option to allow Nemo to display real filenames - a feature I’ve personally wanted for a long time, and one that others have requested as well:
* https://github.com/linuxmint/nemo/issues/2456
* https://forums.linuxmint.com/viewtopic.php?t=224160
* Maybe even this: https://github.com/linuxmint/nemo/issues/1404

This also solves issue of having multiple files appear with the same name, in some cases, and other issues.

The feature is **optional** and **disabled by default**, so it won’t affect existing users. It can be enabled with:
```
gsettings set org.nemo.preferences show-real-filename true
```