### PR TITLE
Fix: Address issue #3677

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ debian/files
 *.debhelper
 
 obj-x86_64-linux-gnu
+
+# Ignore additional dev environment files 
+.vscode/
+.clang-format
+.clangd
+
+#Ignore .md files with "MY_" prefix
+MY_*.md

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1239,6 +1239,22 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+					                              <child>
+                                          <object class="GtkCheckButton" id="force_synchronous_file_operations_checkbutton">
+                                            <property name="label" translatable="yes">Force synchronous file operations</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
                                         <child>
                                           <object class="GtkCheckButton" id="start_with_dual_pane_checkbutton">
                                             <property name="label" translatable="yes">Always start in dual-pane view</property>
@@ -1253,7 +1269,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">3</property>
+                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1270,7 +1286,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">4</property>
+                                            <property name="position">5</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1286,7 +1302,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">5</property>
+                                            <property name="position">6</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/libnemo-private/meson.build
+++ b/libnemo-private/meson.build
@@ -40,6 +40,7 @@ nemo_private_sources = [
   'nemo-file-undo-operations.c',
   'nemo-file-utilities.c',
   'nemo-file.c',
+  'nemo-gfile.c',
   'nemo-global-preferences.c',
   'nemo-icon-canvas-item.c',
   'nemo-icon-container.c',

--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -70,6 +70,7 @@
 #include "nemo-file-undo-operations.h"
 #include "nemo-file-undo-manager.h"
 #include "nemo-job-queue.h"
+#include "nemo-gfile.h"
 
 /* TODO: TESTING!!! */
 
@@ -4544,28 +4545,56 @@ copy_move_file (CopyMoveJob *copy_job,
 		flags |= G_FILE_COPY_TARGET_DEFAULT_PERMS;
 	}
 
-	pdata.job = copy_job;
-	pdata.last_size = 0;
-	pdata.source_info = source_info;
-	pdata.transfer_info = transfer_info;
+    gboolean force_synchronous =
+        nemo_global_preferences_get_force_synchronous_file_operations ();
 
-	if (copy_job->is_move) {
-		res = g_file_move (src, dest,
-				   flags,
-				   job->cancellable,
-				   copy_file_progress_callback,
-				   &pdata,
-				   &error);
-	} else {
-		res = g_file_copy (src, dest,
-				   flags,
-				   job->cancellable,
-				   copy_file_progress_callback,
-				   &pdata,
-				   &error);
-	}
+    pdata.job = copy_job;
+    pdata.last_size = 0;
+    pdata.source_info = source_info;
+    pdata.transfer_info = transfer_info;
 
-	if (res) {
+    if (force_synchronous) {
+        if (copy_job->is_move) {
+            res = nemo_g_file_move_synchronous (src,
+                                                dest,
+                                                flags,
+                                                job->cancellable,
+                                                copy_file_progress_callback,
+                                                &pdata,
+                                                &error);
+        }
+        else {
+            res = nemo_g_file_copy_synchronous (src,
+                                                dest,
+                                                flags,
+                                                job->cancellable,
+                                                copy_file_progress_callback,
+                                                &pdata,
+                                                &error);
+        }
+    }
+    else {
+        if (copy_job->is_move) {
+            res = g_file_move (src,
+                               dest,
+                               flags,
+                               job->cancellable,
+                               copy_file_progress_callback,
+                               &pdata,
+                               &error);
+        }
+        else {
+            res = g_file_copy (src,
+                               dest,
+                               flags,
+                               job->cancellable,
+                               copy_file_progress_callback,
+                               &pdata,
+                               &error);
+        }
+    }
+
+    if (res) {
 		transfer_info->num_files ++;
 		report_copy_progress (copy_job, source_info, transfer_info);
 

--- a/libnemo-private/nemo-gfile.c
+++ b/libnemo-private/nemo-gfile.c
@@ -1,0 +1,583 @@
+/* nemo-gfile.c
+ *
+ * Copyright (C) 2006-2023 Red Hat, Inc.
+ * Copyright (C) 2026 Nemo Project
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+#include "nemo-gfile.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <gio/gio.h> /* For GIOError, g_io_error_from_errno, etc. */
+#include <glib.h>    /* For GError, g_set_error, etc. */
+#include <glib/gprintf.h>
+#include <glib/gstdio.h> /* For g_file_error_from_errno (deprecated, but included for compatibility) */
+#include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <utime.h>
+
+/* Helper function to safely call pathconf */
+static long
+safe_pathconf (const char *path, int name)
+{
+    long result = pathconf (path, name);
+    if (result == -1 && errno == 0) {
+        return -1; /* Parameter not supported */
+    }
+    return result;
+}
+
+/* Helper function to get the minimum recommended buffer size from the
+ * filesystem */
+static size_t
+get_min_buffer_size (const char *path)
+{
+    if (path == NULL) {
+        return NEMO_G_FILE_MIN_BUFFER_SIZE;
+    }
+
+    /* Try POSIX recommended increment for file transfers */
+    long rec_increment = safe_pathconf (path, _PC_REC_INCR_XFER_SIZE);
+    if (rec_increment > 0) {
+        return MAX (NEMO_G_FILE_MIN_BUFFER_SIZE, (size_t)rec_increment);
+    }
+
+    /* Try Linux-specific minimum allocation size */
+    long alloc_size_min = safe_pathconf (path, _PC_ALLOC_SIZE_MIN);
+    if (alloc_size_min > 0) {
+        return MAX (NEMO_G_FILE_MIN_BUFFER_SIZE, (size_t)alloc_size_min);
+    }
+
+    /* Fall back to statvfs */
+    struct statvfs fs_info;
+    if (statvfs (path, &fs_info) == 0) {
+        size_t block_size = fs_info.f_frsize; /* Filesystem fragment size */
+        return MAX (NEMO_G_FILE_MIN_BUFFER_SIZE,
+                    block_size * 256); /* At least 1MB, or 256x block size */
+    }
+
+    /* Final fallback */
+    return NEMO_G_FILE_MIN_BUFFER_SIZE;
+}
+
+/* Helper function to check if a file is a symlink */
+static gboolean
+file_is_symlink (GFile *file)
+{
+    return g_file_query_file_type (file,
+                                   G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                   NULL) == G_FILE_TYPE_SYMBOLIC_LINK;
+}
+
+/* Helper function to copy file metadata using GFileInfo */
+static gboolean
+copy_file_metadata (GFile *source,
+                    GFile *destination,
+                    GFileCopyFlags flags,
+                    GError **error)
+{
+    if (flags & G_FILE_COPY_ALL_METADATA) {
+        /* Query source file attributes */
+        GFileInfo *source_info = g_file_query_info (
+            source,
+            G_FILE_ATTRIBUTE_TIME_MODIFIED "," G_FILE_ATTRIBUTE_TIME_ACCESS
+                                           "," G_FILE_ATTRIBUTE_UNIX_MODE,
+            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+            NULL,
+            error);
+        if (!source_info) {
+            return FALSE;
+        }
+
+        GFileInfo *dest_info = g_file_info_new ();
+
+        if (g_file_info_has_attribute (source_info,
+                                       G_FILE_ATTRIBUTE_TIME_MODIFIED)) {
+            guint64 mtime = g_file_info_get_attribute_uint64 (
+                source_info,
+                G_FILE_ATTRIBUTE_TIME_MODIFIED);
+            g_file_info_set_attribute_uint64 (dest_info,
+                                              G_FILE_ATTRIBUTE_TIME_MODIFIED,
+                                              mtime);
+        }
+        if (g_file_info_has_attribute (source_info,
+                                       G_FILE_ATTRIBUTE_TIME_ACCESS)) {
+            guint64 atime =
+                g_file_info_get_attribute_uint64 (source_info,
+                                                  G_FILE_ATTRIBUTE_TIME_ACCESS);
+            g_file_info_set_attribute_uint64 (dest_info,
+                                              G_FILE_ATTRIBUTE_TIME_ACCESS,
+                                              atime);
+        }
+
+        /* Copy permissions if not using default */
+        if (!(flags & G_FILE_COPY_TARGET_DEFAULT_PERMS) &&
+            g_file_info_has_attribute (source_info,
+                                       G_FILE_ATTRIBUTE_UNIX_MODE)) {
+            guint32 mode =
+                g_file_info_get_attribute_uint32 (source_info,
+                                                  G_FILE_ATTRIBUTE_UNIX_MODE);
+            g_file_info_set_attribute_uint32 (dest_info,
+                                              G_FILE_ATTRIBUTE_UNIX_MODE,
+                                              mode);
+        }
+
+        /* Apply the metadata to the destination file */
+        if (!g_file_set_attributes_from_info (
+                destination,
+                dest_info,
+                G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                NULL,
+                error)) {
+            g_object_unref (source_info);
+            g_object_unref (dest_info);
+            return FALSE;
+        }
+
+        g_object_unref (source_info);
+        g_object_unref (dest_info);
+    }
+    return TRUE;
+}
+
+/* Helper function to check if two files are on the same filesystem */
+static gboolean
+files_on_same_filesystem (GFile *file1, GFile *file2, GError **error)
+{
+    struct stat stat1, stat2;
+
+    if (stat (g_file_get_path (file1), &stat1) != 0) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to stat source file: %s",
+                     g_strerror (errno));
+        return FALSE;
+    }
+
+    if (stat (g_file_get_path (file2), &stat2) != 0) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to stat destination file: %s",
+                     g_strerror (errno));
+        return FALSE;
+    }
+
+    return stat1.st_dev == stat2.st_dev;
+}
+
+/* Copy function with adaptive buffer sizing */
+gboolean
+nemo_g_file_copy_synchronous (GFile *source,
+                              GFile *destination,
+                              GFileCopyFlags flags,
+                              GCancellable *cancellable,
+                              NemoGFileProgressCallback progress_callback,
+                              gpointer progress_callback_data,
+                              GError **error)
+{
+    gchar *src_path, *dest_path;
+    int src_fd = -1, dest_fd = -1;
+    struct stat src_stat;
+    goffset total_size = 0;
+    goffset bytes_copied = 0;
+    guchar *buffer = NULL;
+    ssize_t bytes_read, bytes_written;
+    gboolean success = FALSE;
+
+    /* Adaptive buffer sizing */
+    const guint64 target_chunk_time_us = NEMO_G_FILE_TARGET_MAX_CHUNK_TIME_US;
+    guint64 last_progress_time_us = 0;
+    guint64 last_chunk_time_us = 0;
+    guint64 chunk_time_us = 0;
+    size_t buffer_size;
+    int buffer_adjustment_steps = 0;
+    const int max_buffer_adjustment_steps = 10;
+    gboolean buffer_size_found = FALSE;
+
+    /* Resolve paths */
+    src_path = g_file_get_path (source);
+    if (!src_path) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Source file is not a local file");
+        return FALSE;
+    }
+    dest_path = g_file_get_path (destination);
+    if (!dest_path) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Destination file is not a local file");
+        g_free (src_path);
+        return FALSE;
+    }
+
+    /* Check if source is a symlink and NOFOLLOW_SYMLINKS is set */
+    if ((flags & G_FILE_COPY_NOFOLLOW_SYMLINKS) && file_is_symlink (source)) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Source file is a symbolic link");
+        g_free (src_path);
+        g_free (dest_path);
+        return FALSE;
+    }
+
+    /* Check if destination is a symlink and NOFOLLOW_SYMLINKS is set */
+    if ((flags & G_FILE_COPY_NOFOLLOW_SYMLINKS) &&
+        g_file_query_exists (destination, NULL)) {
+        if (file_is_symlink (destination)) {
+            g_set_error (error,
+                         G_IO_ERROR,
+                         G_IO_ERROR_INVALID_FILENAME,
+                         "Destination file is a symbolic link");
+            g_free (src_path);
+            g_free (dest_path);
+            return FALSE;
+        }
+    }
+
+    /* Get minimum buffer size from filesystem */
+    buffer_size = get_min_buffer_size (dest_path);
+
+    /* Open source file */
+    src_fd = open (src_path, O_RDONLY);
+    if (src_fd == -1) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to open source file: %s",
+                     g_strerror (errno));
+        g_free (src_path);
+        g_free (dest_path);
+        return FALSE;
+    }
+
+    /* Get source file size */
+    if (fstat (src_fd, &src_stat) == -1) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to stat source file: %s",
+                     g_strerror (errno));
+        goto cleanup;
+    }
+    total_size = src_stat.st_size;
+
+    /* Open destination file */
+    int dest_flags = O_WRONLY | O_CREAT;
+    if (flags & G_FILE_COPY_OVERWRITE) {
+        dest_flags |= O_TRUNC;
+    }
+    else {
+        /* If not overwriting, fail if destination exists (already checked
+         * above) */
+        dest_flags |= O_EXCL;
+    }
+    if (flags & G_FILE_COPY_NOFOLLOW_SYMLINKS) {
+        dest_flags |= O_NOFOLLOW;
+    }
+    dest_flags |= O_SYNC; /* Synchronous writes */
+
+    /* Set destination file permissions */
+    mode_t dest_mode = (flags & G_FILE_COPY_TARGET_DEFAULT_PERMS)
+                           ? 0666
+                           : (src_stat.st_mode & 0777);
+    dest_fd = open (dest_path, dest_flags, dest_mode);
+    if (dest_fd == -1) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to open destination file: %s",
+                     g_strerror (errno));
+        goto cleanup;
+    }
+
+    /* Allocate buffer */
+    buffer = g_malloc (buffer_size);
+    if (!buffer) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_FAILED,
+                     "Failed to allocate buffer");
+        goto cleanup;
+    }
+
+    g_print ("Initial buffer size: %zu bytes (%zu MB)\n",
+             buffer_size,
+             buffer_size / 1024 / 1024);
+
+    last_progress_time_us = g_get_monotonic_time ();
+    last_chunk_time_us = last_progress_time_us;
+
+    /* Copy data in chunks */
+    while ((bytes_read = read (src_fd, buffer, buffer_size)) > 0) {
+        /* Check for cancellation */
+        if (cancellable &&
+            g_cancellable_set_error_if_cancelled (cancellable, error)) {
+            goto cleanup;
+        }
+
+        /* Handle partial writes */
+        size_t bytes_to_write = bytes_read;
+        size_t total_written = 0;
+        while (total_written < bytes_to_write) {
+            bytes_written = write (dest_fd,
+                                   buffer + total_written,
+                                   bytes_to_write - total_written);
+            if (bytes_written == -1) {
+                if (errno == EINTR) {
+                    continue; /* Retry on interrupt */
+                }
+                g_set_error (error,
+                             G_IO_ERROR,
+                             g_io_error_from_errno (errno),
+                             "Failed to write to destination: %s",
+                             g_strerror (errno));
+                goto cleanup;
+            }
+            total_written += bytes_written;
+        }
+        bytes_copied += total_written;
+
+        /* Measure chunk time and adapt buffer size */
+        guint64 current_time_us = g_get_monotonic_time ();
+        chunk_time_us = (current_time_us - last_chunk_time_us);
+        last_chunk_time_us = current_time_us;
+
+        /* Adaptive buffer sizing: Double buffer if chunk was too fast (<
+           target_chunk_time_us) and we haven't exceeded max steps */
+        if (!buffer_size_found && chunk_time_us < target_chunk_time_us &&
+            buffer_adjustment_steps < max_buffer_adjustment_steps &&
+            bytes_copied < total_size) {
+            /* Increase buffer size */
+            size_t new_buffer_size = buffer_size * 2;
+            g_free (buffer);
+            buffer = g_malloc (new_buffer_size);
+            if (!buffer) {
+                g_set_error (error,
+                             G_IO_ERROR,
+                             G_IO_ERROR_FAILED,
+                             "Failed to reallocate buffer");
+                goto cleanup;
+            }
+            buffer_size = new_buffer_size;
+            buffer_adjustment_steps++;
+        }
+        else {
+            buffer_size_found = TRUE; /* Stop further increases */
+        }
+
+        if (progress_callback && buffer_size_found) {
+            guint64 elapsed_us = current_time_us - last_progress_time_us;
+            if (elapsed_us >= target_chunk_time_us ||
+                bytes_copied == total_size) {
+                progress_callback (bytes_copied,
+                                   total_size,
+                                   progress_callback_data);
+                last_progress_time_us = current_time_us;
+            }
+        }
+    }
+
+    if (bytes_read == -1) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     g_io_error_from_errno (errno),
+                     "Failed to read from source: %s",
+                     g_strerror (errno));
+        goto cleanup;
+    }
+
+    /* Copy metadata if requested */
+    if (!copy_file_metadata (source, destination, flags, error)) {
+        goto cleanup;
+    }
+
+    success = TRUE;
+
+    /* Print final buffer size used */
+    g_print ("Final buffer size used: %zu bytes (%zu MB)\n",
+             buffer_size,
+             buffer_size / 1024 / 1024);
+
+cleanup:
+    if (src_fd != -1)
+        close (src_fd);
+    if (dest_fd != -1) {
+        if (!success)
+            close (dest_fd);
+        else
+            fsync (dest_fd), close (dest_fd);
+    }
+    g_free (buffer);
+    g_free (src_path);
+    g_free (dest_path);
+    return success;
+}
+
+/* Move function with full GLib compatibility */
+gboolean
+nemo_g_file_move_synchronous (GFile *source,
+                              GFile *destination,
+                              GFileCopyFlags flags,
+                              GCancellable *cancellable,
+                              NemoGFileProgressCallback progress_callback,
+                              gpointer progress_callback_data,
+                              GError **error)
+{
+    gchar *src_path, *dest_path;
+    gboolean same_filesystem = FALSE;
+    gboolean success = FALSE;
+
+    /* Resolve paths */
+    src_path = g_file_get_path (source);
+    if (!src_path) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Source file is not a local file");
+        return FALSE;
+    }
+    dest_path = g_file_get_path (destination);
+    if (!dest_path) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Destination file is not a local file");
+        g_free (src_path);
+        return FALSE;
+    }
+
+    /* Check if source is a symlink and NOFOLLOW_SYMLINKS is set */
+    if ((flags & G_FILE_COPY_NOFOLLOW_SYMLINKS) && file_is_symlink (source)) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_INVALID_FILENAME,
+                     "Source file is a symbolic link");
+        g_free (src_path);
+        g_free (dest_path);
+        return FALSE;
+    }
+
+    /* Check if destination is a symlink and NOFOLLOW_SYMLINKS is set */
+    if ((flags & G_FILE_COPY_NOFOLLOW_SYMLINKS) &&
+        g_file_query_exists (destination, NULL)) {
+        if (file_is_symlink (destination)) {
+            g_set_error (error,
+                         G_IO_ERROR,
+                         G_IO_ERROR_INVALID_FILENAME,
+                         "Destination file is a symbolic link");
+            g_free (src_path);
+            g_free (dest_path);
+            return FALSE;
+        }
+    }
+
+    /* Check if destination exists and OVERWRITE is not set */
+    if (g_file_query_exists (destination, NULL) &&
+        !(flags & G_FILE_COPY_OVERWRITE)) {
+        g_set_error (error,
+                     G_IO_ERROR,
+                     G_IO_ERROR_EXISTS,
+                     "Destination file already exists");
+        g_free (src_path);
+        g_free (dest_path);
+        return FALSE;
+    }
+
+    /* Check if files are on the same filesystem */
+    same_filesystem = files_on_same_filesystem (source, destination, error);
+    if (error && *error) {
+        g_free (src_path);
+        g_free (dest_path);
+        return FALSE;
+    }
+
+    if (!same_filesystem) {
+        /* Cross-device move: fall back to copy + delete */
+        success = nemo_g_file_copy_synchronous (source,
+                                                destination,
+                                                flags,
+                                                cancellable,
+                                                progress_callback,
+                                                progress_callback_data,
+                                                error);
+        if (!success) {
+            goto cleanup;
+        }
+
+        /* Delete the source file */
+        if (!g_file_delete (source, cancellable, error)) {
+            goto cleanup;
+        }
+    }
+    else {
+        /* Same filesystem: use rename for atomic move */
+        if (rename (src_path, dest_path) == -1) {
+            if (errno == EXDEV) {
+                /* Cross-device link: fall back to copy + delete */
+                success = nemo_g_file_copy_synchronous (source,
+                                                        destination,
+                                                        flags,
+                                                        cancellable,
+                                                        progress_callback,
+                                                        progress_callback_data,
+                                                        error);
+                if (!success) {
+                    goto cleanup;
+                }
+                if (!g_file_delete (source, cancellable, error)) {
+                    goto cleanup;
+                }
+            }
+            else {
+                g_set_error (error,
+                             G_IO_ERROR,
+                             g_io_error_from_errno (errno),
+                             "Failed to move file: %s",
+                             g_strerror (errno));
+                goto cleanup;
+            }
+        }
+
+        /* Report progress if callback is provided (100% complete) */
+        if (progress_callback) {
+            struct stat stat_buf;
+            if (stat (dest_path, &stat_buf) == 0) {
+                progress_callback (stat_buf.st_size,
+                                   stat_buf.st_size,
+                                   progress_callback_data);
+            }
+        }
+    }
+
+    success = TRUE;
+cleanup:
+    g_free (src_path);
+    g_free (dest_path);
+    return success;
+}

--- a/libnemo-private/nemo-gfile.h
+++ b/libnemo-private/nemo-gfile.h
@@ -1,0 +1,57 @@
+/* nemo-gfile.h
+ *
+ * Copyright (C) 2006-2023 Red Hat, Inc.
+ * Copyright (C) 2026 Nemo Project
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __NEMO_GFILE_H__
+#define __NEMO_GFILE_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+/* Target progress update frequency (1 update in 1 second) */
+#define NEMO_G_FILE_TARGET_MAX_CHUNK_TIME_US 1000000
+#define NEMO_G_FILE_MIN_BUFFER_SIZE 1024 * 1024
+
+typedef void (*NemoGFileProgressCallback) (goffset current_num_bytes,
+                                           goffset total_num_bytes,
+                                           gpointer user_data);
+
+gboolean
+nemo_g_file_copy_synchronous (GFile *source,
+                              GFile *destination,
+                              GFileCopyFlags flags,
+                              GCancellable *cancellable,
+                              NemoGFileProgressCallback progress_callback,
+                              gpointer progress_callback_data,
+                              GError **error);
+
+gboolean
+nemo_g_file_move_synchronous (GFile *source,
+                              GFile *destination,
+                              GFileCopyFlags flags,
+                              GCancellable *cancellable,
+                              NemoGFileProgressCallback progress_callback,
+                              gpointer progress_callback_data,
+                              GError **error);
+
+G_END_DECLS
+
+#endif /* __NEMO_GFILE_H__ */

--- a/libnemo-private/nemo-global-preferences.c
+++ b/libnemo-private/nemo-global-preferences.c
@@ -35,6 +35,7 @@
 #include <eel/eel-debug.h>
 #include <glib/gi18n.h>
 #include <gio/gdesktopappinfo.h>
+#include <glib/gi18n.h>
 
 #define DEBUG_FLAG NEMO_DEBUG_PREFERENCES
 #include <libnemo-private/nemo-debug.h>
@@ -80,21 +81,21 @@ GFileMonitor *tz_mon;
 char *
 nemo_global_preferences_get_default_folder_viewer_preference_as_iid (void)
 {
-	int preference_value;
-	const char *viewer_iid;
+    int preference_value;
+    const char *viewer_iid;
 
-	preference_value =
+    preference_value =
 		g_settings_get_enum (nemo_preferences, NEMO_PREFERENCES_DEFAULT_FOLDER_VIEWER);
 
-	if (preference_value == NEMO_DEFAULT_FOLDER_VIEWER_LIST_VIEW) {
-		viewer_iid = NEMO_LIST_VIEW_IID;
+    if (preference_value == NEMO_DEFAULT_FOLDER_VIEWER_LIST_VIEW) {
+        viewer_iid = NEMO_LIST_VIEW_IID;
 	} else if (preference_value == NEMO_DEFAULT_FOLDER_VIEWER_COMPACT_VIEW) {
-		viewer_iid = NEMO_COMPACT_VIEW_IID;
+        viewer_iid = NEMO_COMPACT_VIEW_IID;
 	} else {
-		viewer_iid = NEMO_ICON_VIEW_IID;
-	}
+        viewer_iid = NEMO_ICON_VIEW_IID;
+    }
 
-	return g_strdup (viewer_iid);
+    return g_strdup (viewer_iid);
 }
 
 gboolean
@@ -119,13 +120,13 @@ int
 nemo_global_preferences_get_size_prefix_preference (void)
 {
     switch (size_prefixes_preference) {
-        case 0: // base-10
-            return G_FORMAT_SIZE_DEFAULT;
-        case 1: // base-10 full
+    case 0: // base-10
+        return G_FORMAT_SIZE_DEFAULT;
+    case 1: // base-10 full
             return G_FORMAT_SIZE_DEFAULT |                           G_FORMAT_SIZE_LONG_FORMAT;
-        case 2: // base-2
-            return G_FORMAT_SIZE_DEFAULT | G_FORMAT_SIZE_IEC_UNITS;
-        case 3: // base-2 full
+    case 2: // base-2
+        return G_FORMAT_SIZE_DEFAULT | G_FORMAT_SIZE_IEC_UNITS;
+    case 3: // base-2 full
             return G_FORMAT_SIZE_DEFAULT | G_FORMAT_SIZE_IEC_UNITS | G_FORMAT_SIZE_LONG_FORMAT;
     }
 
@@ -407,6 +408,12 @@ nemo_global_preferences_get_mono_font_family_match (const gchar *in_family_name)
     return g_strdup (best);
 }
 
+gboolean
+nemo_global_preferences_get_force_synchronous_file_operations (void)
+{
+    return g_settings_get_boolean (nemo_preferences,
+                                   "force-synchronous-file-operations");
+}
 
 static void
 on_time_data_changed (gpointer user_data)
@@ -452,13 +459,13 @@ setup_cached_time_data (void)
 void
 nemo_global_preferences_init (void)
 {
-	static gboolean initialized = FALSE;
+    static gboolean initialized = FALSE;
 
-	if (initialized) {
-		return;
-	}
+    if (initialized) {
+        return;
+    }
 
-	initialized = TRUE;
+    initialized = TRUE;
 
 	nemo_preferences = g_settings_new("org.nemo.preferences");
 	nemo_window_state = g_settings_new("org.nemo.window-state");
@@ -468,7 +475,7 @@ nemo_global_preferences_init (void)
 	nemo_desktop_preferences = g_settings_new("org.nemo.desktop");
     /* Some settings such as show hidden files are shared between Nautilus and GTK file chooser */
     gtk_filechooser_preferences = g_settings_new_with_path ("org.gtk.Settings.FileChooser",
-                                                            "/org/gtk/settings/file-chooser/");
+                                  "/org/gtk/settings/file-chooser/");
 	nemo_tree_sidebar_preferences = g_settings_new("org.nemo.sidebar-panels.tree");
     nemo_plugin_preferences = g_settings_new("org.nemo.plugins");
     nemo_menu_config_preferences = g_settings_new("org.nemo.preferences.menu-config");
@@ -480,7 +487,8 @@ nemo_global_preferences_init (void)
     cinnamon_privacy_preferences = g_settings_new("org.cinnamon.desktop.privacy");
 	cinnamon_interface_preferences = g_settings_new ("org.cinnamon.desktop.interface");
     // System mono font
-    gnome_interface_preferences = g_settings_new ("org.gnome.desktop.interface");
+    gnome_interface_preferences =
+        g_settings_new ("org.gnome.desktop.interface");
 
     setup_cached_pref_keys ();
     setup_cached_time_data ();

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -53,9 +53,9 @@ G_BEGIN_DECLS
 
 typedef enum
 {
-	NEMO_DATE_FORMAT_LOCALE,
-	NEMO_DATE_FORMAT_ISO,
-	NEMO_DATE_FORMAT_INFORMAL
+    NEMO_DATE_FORMAT_LOCALE,
+    NEMO_DATE_FORMAT_ISO,
+    NEMO_DATE_FORMAT_INFORMAL
 } NemoDateFormat;
 
 typedef enum
@@ -67,8 +67,8 @@ typedef enum
 
 typedef enum
 {
-	NEMO_NEW_TAB_POSITION_AFTER_CURRENT_TAB,
-	NEMO_NEW_TAB_POSITION_END,
+    NEMO_NEW_TAB_POSITION_AFTER_CURRENT_TAB,
+    NEMO_NEW_TAB_POSITION_END,
 } NemoNewTabPosition;
 
 /* Sidebar panels  */
@@ -155,10 +155,10 @@ typedef enum
 
 enum
 {
-	NEMO_DEFAULT_FOLDER_VIEWER_ICON_VIEW,
-	NEMO_DEFAULT_FOLDER_VIEWER_COMPACT_VIEW,
-	NEMO_DEFAULT_FOLDER_VIEWER_LIST_VIEW,
-	NEMO_DEFAULT_FOLDER_VIEWER_OTHER
+    NEMO_DEFAULT_FOLDER_VIEWER_ICON_VIEW,
+    NEMO_DEFAULT_FOLDER_VIEWER_COMPACT_VIEW,
+    NEMO_DEFAULT_FOLDER_VIEWER_LIST_VIEW,
+    NEMO_DEFAULT_FOLDER_VIEWER_OTHER
 };
 
 /* These IIDs are used by the preferences code and in nemo-application.c */
@@ -196,21 +196,21 @@ enum
 
 enum
 {
-	NEMO_CLICK_POLICY_SINGLE,
-	NEMO_CLICK_POLICY_DOUBLE
+    NEMO_CLICK_POLICY_SINGLE,
+    NEMO_CLICK_POLICY_DOUBLE
 };
 
 enum
 {
-	NEMO_EXECUTABLE_TEXT_LAUNCH,
-	NEMO_EXECUTABLE_TEXT_DISPLAY,
-	NEMO_EXECUTABLE_TEXT_ASK
+    NEMO_EXECUTABLE_TEXT_LAUNCH,
+    NEMO_EXECUTABLE_TEXT_DISPLAY,
+    NEMO_EXECUTABLE_TEXT_ASK
 };
 
 typedef enum
 {
-	NEMO_SPEED_TRADEOFF_ALWAYS,
-	NEMO_SPEED_TRADEOFF_LOCAL_ONLY,
+    NEMO_SPEED_TRADEOFF_ALWAYS,
+    NEMO_SPEED_TRADEOFF_LOCAL_ONLY,
     NEMO_SPEED_TRADEOFF_NEVER
 } NemoSpeedTradeoffValue;
 
@@ -277,7 +277,8 @@ typedef enum
 #define NEMO_PREFERENCES_LAST_SERVER_CONNECT_METHOD "last-server-connect-method"
 
 /* File operations queue */
-#define NEMO_PREFERENCES_NEVER_QUEUE_FILE_OPS          "never-queue-file-ops"
+#define NEMO_PREFERENCES_NEVER_QUEUE_FILE_OPS "never-queue-file-ops"
+#define NEMO_PREFERENCES_FORCE_SYNCHRONOUS_FILE_OPERATIONS "force-synchronous-file-operations"
 
 #define NEMO_PREFERENCES_CLICK_DOUBLE_PARENT_FOLDER    "click-double-parent-folder"
 #define NEMO_PREFERENCES_EXPAND_ROW_ON_DND_DWELL       "expand-row-on-dnd-dwell"
@@ -311,6 +312,7 @@ gchar **nemo_global_preferences_get_fileroller_mimetypes (void);
 
 gchar *nemo_global_preferences_get_mono_system_font (void);
 gchar *nemo_global_preferences_get_mono_font_family_match (const gchar *in_family);
+gboolean nemo_global_preferences_get_force_synchronous_file_operations (void);
 
 extern GSettings *nemo_preferences;
 extern GSettings *nemo_icon_view_preferences;

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -448,6 +448,10 @@
       <default>-1</default>
       <summary>Number of threads to dedicate to thumbnailing. -1 to let the program decide. The maximum allowed threads is half the number of logical processors, regardless of what is set here. If you change this setting you must restart Nemo for it to take effect.</summary>
     </key>
+    <key name="force-synchronous-file-operations" type="b">
+      <default>false</default>
+      <summary>Write synchronously and show progress dialog</summary>
+    </key>
   </schema>
 
   <schema id="org.nemo.icon-view" path="/org/nemo/icon-view/" gettext-domain="nemo">

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -117,6 +117,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_TOOLTIP_FULL_PATH_WIDGET "tt_show_full_path_checkbutton"
 
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_SKIP_FILE_OP_QUEUE_WIDGET "skip_file_op_queue_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_FORCE_SYNCHRONOUS_FILE_OPERATIONS "force_synchronous_file_operations_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET "click_double_parent_folder_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_EXPAND_ROW_ON_DND_DWELL_WIDGET "expand_row_on_dnd_dwell_checkbutton"
 
@@ -1119,6 +1120,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_SKIP_FILE_OP_QUEUE_WIDGET,
                        NEMO_PREFERENCES_NEVER_QUEUE_FILE_OPS);
+
+	bind_builder_bool(builder, nemo_preferences,
+					  NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_FORCE_SYNCHRONOUS_FILE_OPERATIONS,
+					  NEMO_PREFERENCES_FORCE_SYNCHRONOUS_FILE_OPERATIONS);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_NEMO_PREFERENCES_CLICK_DBL_PARENT_FOLDER_WIDGET,


### PR DESCRIPTION
I added an option under Edit / Preferences / Behavior  "Force synchronous file operations".
When activated, nemo uses synchronous (O_SYNC) writing and a buffer size adjustment logic to ensure the progress dialog is shown during a file write operation and that the dialog is updated frequently.