### PR TITLE
Fix hang when primary org.Nemo instance is frozen

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build file
 
 # https://github.com/linuxmint/nemo
-project('nemo', 'c', version : '6.7.2', meson_version : '>=0.64.0')
+project('nemo', 'c', version : '6.7.3', meson_version : '>=0.64.0')
 
 # 1. If the library code has changed at all since last release, then increment revision.
 # 2. If any interfaces have been added, then increment current and set revision to 0.

--- a/src/nemo-main-application.c
+++ b/src/nemo-main-application.c
@@ -853,6 +853,38 @@ do_perform_self_checks (gint *exit_status)
 }
 
 static gboolean
+check_remote_responsive (GError **error)
+{
+	GDBusConnection *connection;
+	GVariant *result;
+
+	connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
+	if (connection == NULL) {
+		return FALSE;
+	}
+
+	result = g_dbus_connection_call_sync (connection,
+					      "org.Nemo",
+					      "/org/Nemo",
+					      "org.freedesktop.DBus.Peer",
+					      "Ping",
+					      NULL,
+					      NULL,
+					      G_DBUS_CALL_FLAGS_NO_AUTO_START,
+					      1000, /* 1000 ms timeout */
+					      NULL,
+					      error);
+
+	g_object_unref (connection);
+
+	if (result != NULL) {
+		g_variant_unref (result);
+	}
+
+	return *error == NULL;
+}
+
+static gboolean
 nemo_main_application_local_command_line (GApplication *application,
 					 gchar ***arguments,
 					 gint *exit_status)
@@ -985,6 +1017,26 @@ nemo_main_application_local_command_line (GApplication *application,
         g_clear_error (&error);
     } else {
         goto post_registration;
+    }
+
+    /* If service registration failed, check if the remote instance is responsive */
+    {
+        GError *ping_error = NULL;
+        if (!check_remote_responsive (&ping_error)) {
+            g_warning ("The process holding org.Nemo is frozen or unresponsive (%s). Falling back to non-unique local mode.",
+                       ping_error ? ping_error->message : "unknown error");
+            g_clear_error (&ping_error);
+
+            g_application_set_flags (application, init_flags | G_APPLICATION_NON_UNIQUE);
+            g_application_register (application, NULL, &error);
+            if (error != NULL) {
+                g_printerr ("Could not register nemo in non-unique mode: %s\n", error->message);
+                g_clear_error (&error);
+                *exit_status = EXIT_FAILURE;
+                goto out;
+            }
+            goto post_registration;
+        }
     }
 
     /* If service registration failed, try to connect to the existing instance */

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,3 +26,13 @@ test('Copy test',
   ),
   args: []
 )
+
+test('DBus Fallback test',
+  find_program('dbus-run-session'),
+  args: [
+    '--',
+    find_program('python3'),
+    files('test-dbus-fallback.py'),
+    nemo
+  ]
+)

--- a/test/test-dbus-fallback.py
+++ b/test/test-dbus-fallback.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import sys
+import subprocess
+import time
+import os
+import signal
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: test-dbus-fallback.py <nemo-binary>")
+        sys.exit(1)
+
+    nemo_bin = sys.argv[1]
+    print(f"Using nemo binary: {nemo_bin}")
+
+    # Start primary nemo instance in background
+    # (Since we are inside dbus-run-session, we have our own isolated session bus)
+    print("Starting primary Nemo instance...")
+    primary = subprocess.Popen([nemo_bin, "--no-default-window"])
+
+    # Give it some time to register on DBus
+    time.sleep(2)
+
+    # Suspend the primary instance (simulate frozen desktop/nemo process)
+    print(f"Suspending primary Nemo instance (PID: {primary.pid})...")
+    os.kill(primary.pid, signal.SIGSTOP)
+
+    # Now launch the second instance to test the fallback
+    print("Launching second Nemo instance (should fallback and exit)...")
+    try:
+        # We run it with timeout to make sure it doesn't hang if the fallback fails.
+        result = subprocess.run(
+            [nemo_bin, "--no-default-window"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        print("Second instance output (stdout):")
+        print(result.stdout)
+        print("Second instance output (stderr):")
+        print(result.stderr)
+
+        # Resume and clean up primary
+        print("Cleaning up primary instance...")
+        os.kill(primary.pid, signal.SIGCONT)
+        primary.terminate()
+        primary.wait()
+
+        # Check stderr for the fallback warning
+        expected_warning = "The process holding org.Nemo is frozen or unresponsive"
+        if expected_warning not in result.stderr:
+            print(f"Error: Expected warning not found in stderr. Stderr was:\n{result.stderr}")
+            sys.exit(1)
+
+        print("Test passed: Fallback warning was successfully logged and the application did not hang.")
+
+    except subprocess.TimeoutExpired:
+        print("Error: Second instance hung (timed out after 5 seconds)!")
+        # Make sure to cleanup primary
+        os.kill(primary.pid, signal.SIGCONT)
+        primary.terminate()
+        primary.wait()
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If service registration fails (indicating another instance owns the bus name), we check if the remote instance is responsive by sending a D-Bus Peer Ping with a 1-second timeout. If the remote instance does not respond, we log a warning and fall back to registering as G_APPLICATION_NON_UNIQUE to run locally instead of hanging indefinitely on g_application_open.