### PR TITLE
Add Native File Chooser Dialog integration for Nemo and XDG Desktop Portals

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -43,6 +43,12 @@ dbusFiles = [
     output: 'nemo.FileManager1.service',
     configuration: dataConf,
   ),
+
+  configure_file(
+    input : 'org.Nemo.FileChooser.service.in',
+    output: 'org.Nemo.FileChooser.service',
+    configuration: dataConf,
+  ),
 ]
 
 install_data(dbusFiles,

--- a/data/org.Nemo.FileChooser.service.in
+++ b/data/org.Nemo.FileChooser.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.Nemo.FileChooser
+Exec=@bindir@/nemo --no-default-window

--- a/data/org.Nemo.FileChooser.xml
+++ b/data/org.Nemo.FileChooser.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="org.Nemo.FileChooser">
+    <method name="OpenFile">
+      <arg type="s" name="title" direction="in"/>
+      <arg type="as" name="filters" direction="in"/>
+      <arg type="b" name="multiselect" direction="in"/>
+      <arg type="b" name="directory" direction="in"/>
+      <arg type="s" name="initial_folder" direction="in"/>
+      <arg type="as" name="results" direction="out"/>
+    </method>
+    <method name="SaveFile">
+      <arg type="s" name="title" direction="in"/>
+      <arg type="s" name="initial_folder" direction="in"/>
+      <arg type="s" name="suggested_name" direction="in"/>
+      <arg type="s" name="result" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/gresources/nemo-file-chooser-dialog.glade
+++ b/gresources/nemo-file-chooser-dialog.glade
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with Glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="nemo_file_chooser_dialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Select File</property>
+    <property name="default-width">900</property>
+    <property name="default-height">550</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="cancel_button">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok_button">
+                <property name="label" translatable="yes">_Open</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <!-- Custom Header / Tool Bar -->
+          <object class="GtkBox" id="header_box">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">10</property>
+            <property name="margin-right">10</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkBox" id="navigation_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkButton" id="back_button">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">go_back_image</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="forward_button">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">go_forward_image</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="up_button">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Parent Folder</property>
+                    <property name="image">go_up_image</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="create_folder_button">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Create Folder</property>
+                    <property name="image">folder_new_image</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <!-- Breadcrumb/Path Bar Container -->
+              <object class="GtkBox" id="path_bar_container">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="hexpand">True</property>
+                <child>
+                  <object class="GtkStack" id="path_stack">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
+                    <child>
+                      <object class="GtkLabel" id="path_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="ellipsize">middle</property>
+                      </object>
+                      <packing>
+                        <property name="name">label</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="path_entry">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="name">entry</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="location_toggle_button">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="has-tooltip">True</property>
+                <property name="tooltip-text" translatable="yes">Toggle Location Entry</property>
+                <property name="image">edit_symbolic_image</property>
+              </object>
+            </child>
+            <child>
+              <!-- View Toggle Buttons -->
+              <object class="GtkBox" id="view_buttons_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <style>
+                  <class name="linked"/>
+                </style>
+                <child>
+                  <object class="GtkRadioButton" id="grid_view_toggle">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Grid View</property>
+                    <property name="draw-indicator">False</property>
+                    <property name="image">grid_view_image</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="list_view_toggle">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">List View</property>
+                    <property name="draw-indicator">False</property>
+                    <property name="group">grid_view_toggle</property>
+                    <property name="image">list_view_image</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="compact_view_toggle">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Compact View</property>
+                    <property name="draw-indicator">False</property>
+                    <property name="group">grid_view_toggle</property>
+                    <property name="image">compact_view_image</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <!-- Main Content Area split in 3 columns -->
+          <object class="GtkPaned" id="main_paned">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <!-- Left Sidebar: Places -->
+              <object class="GtkScrolledWindow" id="sidebar_scrolled">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="min-content-width">180</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">False</property>
+                <property name="shrink">False</property>
+              </packing>
+            </child>
+            <child>
+              <!-- Split between File Browser and Preview Pane -->
+              <object class="GtkPaned" id="content_paned">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child>
+                  <!-- Center: File Browser Area -->
+                  <object class="GtkBox" id="browser_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <!-- Stack to hold List/Grid Scrolled Windows -->
+                       <object class="GtkStack" id="browser_stack">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkScrolledWindow" id="tree_scrolled">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">list</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScrolledWindow" id="icon_scrolled">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">grid</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScrolledWindow" id="compact_scrolled">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">compact</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <!-- Bottom path entry + filter dropdown -->
+                      <object class="GtkBox" id="bottom_controls_box">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="margin">6</property>
+                        <child>
+                          <object class="GtkEntry" id="filename_entry">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="hexpand">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="filter_combo">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="resize">True</property>
+                    <property name="shrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- Right: Interactive Preview Sidebar -->
+                  <object class="GtkBox" id="preview_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="width-request">220</property>
+                    <property name="spacing">8</property>
+                    <property name="margin">8</property>
+                    <child>
+                      <object class="GtkImage" id="preview_image">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="pixel-size">128</property>
+                        <property name="icon-name">image-missing</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="preview_name_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">No File Selected</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkGrid" id="preview_meta_grid">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="row-spacing">4</property>
+                        <property name="column-spacing">10</property>
+                        <child>
+                          <object class="GtkLabel" id="label_meta_size">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Size:</property>
+                            <property name="halign">start</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="preview_size_val">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">-</property>
+                            <property name="halign">start</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="resize">False</property>
+                    <property name="shrink">False</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">True</property>
+                <property name="shrink">False</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">cancel_button</action-widget>
+      <action-widget response="-5">ok_button</action-widget>
+    </action-widgets>
+  </object>
+  <!-- Resource Icons -->
+  <object class="GtkImage" id="go_back_image">
+    <property name="visible">True</property>
+    <property name="icon-name">go-previous-symbolic</property>
+  </object>
+  <object class="GtkImage" id="go_forward_image">
+    <property name="visible">True</property>
+    <property name="icon-name">go-next-symbolic</property>
+  </object>
+  <object class="GtkImage" id="grid_view_image">
+    <property name="visible">True</property>
+    <property name="icon-name">view-grid-symbolic</property>
+  </object>
+  <object class="GtkImage" id="list_view_image">
+    <property name="visible">True</property>
+    <property name="icon-name">view-list-symbolic</property>
+  </object>
+  <object class="GtkImage" id="compact_view_image">
+    <property name="visible">True</property>
+    <property name="icon-name">view-compact-symbolic</property>
+  </object>
+  <object class="GtkImage" id="folder_new_image">
+    <property name="visible">True</property>
+    <property name="icon-name">folder-new-symbolic</property>
+  </object>
+  <object class="GtkImage" id="edit_symbolic_image">
+    <property name="visible">True</property>
+    <property name="icon-name">document-edit-symbolic</property>
+  </object>
+  <object class="GtkImage" id="go_up_image">
+    <property name="visible">True</property>
+    <property name="icon-name">go-up-symbolic</property>
+  </object>
+</interface>

--- a/gresources/nemo.gresource.xml
+++ b/gresources/nemo.gresource.xml
@@ -6,6 +6,7 @@
     <file>nemo-desktop-preferences.glade</file>
     <file>nemo-file-management-properties.glade</file>
     <file>nemo-search-bar.glade</file>
+    <file>nemo-file-chooser-dialog.glade</file>
 
     <file>nemo-shortcuts.ui</file>
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,9 +14,18 @@ nemoBuiltSources = gnome.gdbus_codegen(
   object_manager: true
 )
 
+nemoFileChooserBuiltSources = gnome.gdbus_codegen(
+  'nemo-file-chooser-generated',
+  join_paths(meson.project_source_root(), 'data', 'org.Nemo.FileChooser.xml'),
+  interface_prefix: 'org.Nemo.',
+  namespace: 'Nemo',
+  object_manager: false
+)
+
 nemoCommon_sources = [
   dbusBuiltSources,
   nemoBuiltSources,
+  nemoFileChooserBuiltSources,
   'nemo-action-config-widget.c',
   'nemo-application.c',
   'nemo-blank-desktop-window.c',
@@ -36,6 +45,8 @@ nemoCommon_sources = [
   'nemo-file-management-properties.c',
   'nemo-filter-bar.c',
   'nemo-floating-bar.c',
+  'nemo-file-chooser-dbus.c',
+  'nemo-file-chooser-dialog.c',
   'nemo-freedesktop-dbus.c',
   'nemo-icon-view-container.c',
   'nemo-icon-view-grid-container.c',

--- a/src/nemo-file-chooser-dbus.c
+++ b/src/nemo-file-chooser-dbus.c
@@ -5,6 +5,7 @@
 #include <config.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
+#include <glib/gi18n.h>
 
 #include "nemo-application.h"
 #include "nemo-file-chooser-dbus.h"
@@ -96,6 +97,26 @@ on_save_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data
 
     if (response_id == GTK_RESPONSE_ACCEPT || response_id == GTK_RESPONSE_OK) {
         result = nemo_file_chooser_dialog_get_selected_uri (dialog);
+        if (result && *result) {
+            g_autoptr(GFile) file = g_file_new_for_uri (result);
+            if (g_file_query_exists (file, NULL)) {
+                g_autofree gchar *basename = g_file_get_basename (file);
+                GtkWidget *msg_dialog = gtk_message_dialog_new (GTK_WINDOW (dialog),
+                                                                GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                                GTK_MESSAGE_QUESTION,
+                                                                GTK_BUTTONS_YES_NO,
+                                                                _("A file named \"%s\" already exists. Do you want to replace it?"),
+                                                                basename);
+                gtk_window_set_title (GTK_WINDOW (msg_dialog), _("Replace File"));
+                gint res = gtk_dialog_run (GTK_DIALOG (msg_dialog));
+                gtk_widget_destroy (msg_dialog);
+                
+                if (res != GTK_RESPONSE_YES) {
+                    g_free (result);
+                    return;
+                }
+            }
+        }
     }
 
     nemo_file_chooser_complete_save_file (data->skeleton, data->invocation, result ? result : "");

--- a/src/nemo-file-chooser-dbus.c
+++ b/src/nemo-file-chooser-dbus.c
@@ -35,10 +35,13 @@ on_open_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data
     ResponseData *data = user_data;
     GPtrArray *results = g_ptr_array_new_with_free_func (g_free);
 
-    if (response_id == GTK_RESPONSE_ACCEPT) {
+    g_message ("Nemo Open Dialog Response ID: %d", response_id);
+
+    if (response_id == GTK_RESPONSE_ACCEPT || response_id == GTK_RESPONSE_OK) {
         GSList *uris = nemo_file_chooser_dialog_get_selected_uris (dialog);
         GSList *l;
         for (l = uris; l != NULL; l = l->next) {
+            g_message ("Nemo Dialog selected URI: %s", (const gchar *)l->data);
             g_ptr_array_add (results, g_strdup (l->data));
         }
         g_slist_free_full (uris, g_free);
@@ -65,6 +68,9 @@ handle_open_file_cb (NemoFileChooser *object,
 {
     GtkWidget *dialog;
 
+    g_message ("handle_open_file_cb: title='%s', multiselect=%d, directory=%d, initial_folder='%s'",
+               title ? title : "", multiselect, directory, initial_folder ? initial_folder : "");
+
     dialog = nemo_file_chooser_dialog_new (title,
                                           directory ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN,
                                           multiselect,
@@ -88,7 +94,7 @@ on_save_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data
     ResponseData *data = user_data;
     gchar *result = NULL;
 
-    if (response_id == GTK_RESPONSE_ACCEPT) {
+    if (response_id == GTK_RESPONSE_ACCEPT || response_id == GTK_RESPONSE_OK) {
         result = nemo_file_chooser_dialog_get_selected_uri (dialog);
     }
 

--- a/src/nemo-file-chooser-dbus.c
+++ b/src/nemo-file-chooser-dbus.c
@@ -54,6 +54,7 @@ on_open_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data
     
     g_ptr_array_unref (results);
     gtk_widget_destroy (GTK_WIDGET (dialog));
+    g_application_release (g_application_get_default ());
     g_free (data);
 }
 
@@ -85,6 +86,7 @@ handle_open_file_cb (NemoFileChooser *object,
 
     g_signal_connect (dialog, "response", G_CALLBACK (on_open_dialog_response), data);
     gtk_widget_show_all (dialog);
+    g_application_hold (g_application_get_default ());
 
     return TRUE;
 }
@@ -123,6 +125,7 @@ on_save_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data
     
     g_free (result);
     gtk_widget_destroy (GTK_WIDGET (dialog));
+    g_application_release (g_application_get_default ());
     g_free (data);
 }
 
@@ -149,6 +152,7 @@ handle_save_file_cb (NemoFileChooser *object,
 
     g_signal_connect (dialog, "response", G_CALLBACK (on_save_dialog_response), data);
     gtk_widget_show_all (dialog);
+    g_application_hold (g_application_get_default ());
 
     return TRUE;
 }

--- a/src/nemo-file-chooser-dbus.c
+++ b/src/nemo-file-chooser-dbus.c
@@ -1,0 +1,203 @@
+/*
+ * nemo-file-chooser-dbus: D-Bus service provider for org.Nemo.FileChooser
+ */
+
+#include <config.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+
+#include "nemo-application.h"
+#include "nemo-file-chooser-dbus.h"
+#include "nemo-file-chooser-dialog.h"
+#include "nemo-file-chooser-generated.h"
+
+struct _NemoFileChooserDBus {
+    GObject parent;
+    guint owner_id;
+    NemoFileChooser *skeleton;
+};
+
+struct _NemoFileChooserDBusClass {
+    GObjectClass parent_class;
+};
+
+G_DEFINE_TYPE (NemoFileChooserDBus, nemo_file_chooser_dbus, G_TYPE_OBJECT);
+
+typedef struct {
+    GDBusMethodInvocation *invocation;
+    GtkWidget *dialog;
+    NemoFileChooser *skeleton;
+} ResponseData;
+
+static void
+on_open_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data)
+{
+    ResponseData *data = user_data;
+    GPtrArray *results = g_ptr_array_new_with_free_func (g_free);
+
+    if (response_id == GTK_RESPONSE_ACCEPT) {
+        GSList *uris = nemo_file_chooser_dialog_get_selected_uris (dialog);
+        GSList *l;
+        for (l = uris; l != NULL; l = l->next) {
+            g_ptr_array_add (results, g_strdup (l->data));
+        }
+        g_slist_free_full (uris, g_free);
+    }
+
+    g_ptr_array_add (results, NULL); // NULL terminator for const gchar *const * parameter
+
+    nemo_file_chooser_complete_open_file (data->skeleton, data->invocation, (const gchar *const *)results->pdata);
+    
+    g_ptr_array_unref (results);
+    gtk_widget_destroy (GTK_WIDGET (dialog));
+    g_free (data);
+}
+
+static gboolean
+handle_open_file_cb (NemoFileChooser *object,
+                     GDBusMethodInvocation *invocation,
+                     const gchar *title,
+                     const gchar *const *filters,
+                     gboolean multiselect,
+                     gboolean directory,
+                     const gchar *initial_folder,
+                     gpointer user_data)
+{
+    GtkWidget *dialog;
+
+    dialog = nemo_file_chooser_dialog_new (title,
+                                          directory ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN,
+                                          multiselect,
+                                          initial_folder,
+                                          NULL);
+
+    ResponseData *data = g_new0 (ResponseData, 1);
+    data->invocation = invocation;
+    data->dialog = dialog;
+    data->skeleton = object;
+
+    g_signal_connect (dialog, "response", G_CALLBACK (on_open_dialog_response), data);
+    gtk_widget_show_all (dialog);
+
+    return TRUE;
+}
+
+static void
+on_save_dialog_response (GtkDialog *dialog, gint response_id, gpointer user_data)
+{
+    ResponseData *data = user_data;
+    gchar *result = NULL;
+
+    if (response_id == GTK_RESPONSE_ACCEPT) {
+        result = nemo_file_chooser_dialog_get_selected_uri (dialog);
+    }
+
+    nemo_file_chooser_complete_save_file (data->skeleton, data->invocation, result ? result : "");
+    
+    g_free (result);
+    gtk_widget_destroy (GTK_WIDGET (dialog));
+    g_free (data);
+}
+
+static gboolean
+handle_save_file_cb (NemoFileChooser *object,
+                     GDBusMethodInvocation *invocation,
+                     const gchar *title,
+                     const gchar *initial_folder,
+                     const gchar *suggested_name,
+                     gpointer user_data)
+{
+    GtkWidget *dialog;
+
+    dialog = nemo_file_chooser_dialog_new (title,
+                                          GTK_FILE_CHOOSER_ACTION_SAVE,
+                                          FALSE,
+                                          initial_folder,
+                                          suggested_name);
+
+    ResponseData *data = g_new0 (ResponseData, 1);
+    data->invocation = invocation;
+    data->dialog = dialog;
+    data->skeleton = object;
+
+    g_signal_connect (dialog, "response", G_CALLBACK (on_save_dialog_response), data);
+    gtk_widget_show_all (dialog);
+
+    return TRUE;
+}
+
+static void
+bus_acquired_cb (GDBusConnection *conn,
+                 const gchar     *name,
+                 gpointer         user_data)
+{
+    NemoFileChooserDBus *self = user_data;
+
+    self->skeleton = nemo_file_chooser_skeleton_new ();
+
+    g_signal_connect (self->skeleton, "handle-open-file",
+                      G_CALLBACK (handle_open_file_cb), self);
+    g_signal_connect (self->skeleton, "handle-save-file",
+                      G_CALLBACK (handle_save_file_cb), self);
+
+    g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (self->skeleton), conn, "/org/Nemo/FileChooser", NULL);
+}
+
+static void
+name_acquired_cb (GDBusConnection *connection,
+                  const gchar     *name,
+                  gpointer         user_data)
+{
+}
+
+static void
+name_lost_cb (GDBusConnection *connection,
+              const gchar     *name,
+              gpointer         user_data)
+{
+}
+
+static void
+nemo_file_chooser_dbus_dispose (GObject *object)
+{
+    NemoFileChooserDBus *self = (NemoFileChooserDBus *) object;
+
+    if (self->owner_id != 0) {
+        g_bus_unown_name (self->owner_id);
+        self->owner_id = 0;
+    }
+
+    if (self->skeleton != NULL) {
+        g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->skeleton));
+        g_object_unref (self->skeleton);
+        self->skeleton = NULL;
+    }
+
+    G_OBJECT_CLASS (nemo_file_chooser_dbus_parent_class)->dispose (object);
+}
+
+static void
+nemo_file_chooser_dbus_class_init (NemoFileChooserDBusClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+    object_class->dispose = nemo_file_chooser_dbus_dispose;
+}
+
+static void
+nemo_file_chooser_dbus_init (NemoFileChooserDBus *self)
+{
+    self->owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
+                                    "org.Nemo.FileChooser",
+                                    G_BUS_NAME_OWNER_FLAGS_NONE,
+                                    bus_acquired_cb,
+                                    name_acquired_cb,
+                                    name_lost_cb,
+                                    self,
+                                    NULL);
+}
+
+NemoFileChooserDBus *
+nemo_file_chooser_dbus_new (void)
+{
+    return g_object_new (nemo_file_chooser_dbus_get_type (), NULL);
+}

--- a/src/nemo-file-chooser-dbus.h
+++ b/src/nemo-file-chooser-dbus.h
@@ -1,0 +1,28 @@
+/*
+ * nemo-file-chooser-dbus: Implementation for the org.Nemo FileChooser D-Bus interface
+ */
+
+#ifndef __NEMO_FILE_CHOOSER_DBUS_H__
+#define __NEMO_FILE_CHOOSER_DBUS_H__
+
+#include <glib-object.h>
+
+#define NEMO_TYPE_FILE_CHOOSER_DBUS nemo_file_chooser_dbus_get_type()
+#define NEMO_FILE_CHOOSER_DBUS(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), NEMO_TYPE_FILE_CHOOSER_DBUS, NemoFileChooserDBus))
+#define NEMO_FILE_CHOOSER_DBUS_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), NEMO_TYPE_FILE_CHOOSER_DBUS, NemoFileChooserDBusClass))
+#define NEMO_IS_FILE_CHOOSER_DBUS(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), NEMO_TYPE_FILE_CHOOSER_DBUS))
+#define NEMO_IS_FILE_CHOOSER_DBUS_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), NEMO_TYPE_FILE_CHOOSER_DBUS))
+#define NEMO_FILE_CHOOSER_DBUS_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), NEMO_TYPE_FILE_CHOOSER_DBUS, NemoFileChooserDBusClass))
+
+typedef struct _NemoFileChooserDBus NemoFileChooserDBus;
+typedef struct _NemoFileChooserDBusClass NemoFileChooserDBusClass;
+
+GType nemo_file_chooser_dbus_get_type (void);
+NemoFileChooserDBus * nemo_file_chooser_dbus_new (void);
+
+#endif /* __NEMO_FILE_CHOOSER_DBUS_H__ */

--- a/src/nemo-file-chooser-dialog.c
+++ b/src/nemo-file-chooser-dialog.c
@@ -1,0 +1,1376 @@
+/*
+ * nemo-file-chooser-dialog: Custom layout file picker dialog implementation
+ */
+
+#include <config.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "nemo-file-chooser-dialog.h"
+
+typedef struct {
+    GtkBuilder *builder;
+    GtkWidget *dialog;
+    
+    GtkFileChooserAction action;
+    gboolean select_multiple;
+    
+    GFile *current_folder;
+    GList *history_back;
+    GList *history_forward;
+    
+    GtkListStore *list_store;
+    GtkWidget *tree_view;
+    GtkWidget *icon_view;
+    GtkWidget *compact_view;
+    
+    GtkWidget *places_sidebar;
+    GtkWidget *path_bar_label;
+    GtkWidget *filename_entry;
+    GtkWidget *filter_combo;
+    
+    GtkWidget *preview_image;
+    GtkWidget *preview_name_label;
+    GtkWidget *preview_size_val;
+    
+    GSList *selected_uris;
+    gchar *selected_uri;
+
+    gint small_icon_size;
+    gint large_icon_size;
+    gboolean show_hidden;
+    
+    GtkWidget *path_stack;
+    GtkWidget *path_entry;
+} DialogData;
+
+enum {
+    COL_NAME,
+    COL_ICON,
+    COL_GRID_ICON,
+    COL_SIZE,
+    COL_SIZE_STR,
+    COL_TYPE,
+    COL_MODIFIED_TIME,
+    COL_MODIFIED_STR,
+    COL_IS_DIR,
+    COL_URI,
+    COL_GICON,
+    COL_THUMBNAIL_PATH,
+    COL_NUM_COLUMNS
+};
+
+static void load_directory (DialogData *data, GFile *folder);
+
+static gint
+compare_rows_folders_first (GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, gpointer user_data)
+{
+    gint sort_col_id = GPOINTER_TO_INT (user_data);
+    gboolean is_dir_a, is_dir_b;
+    
+    gtk_tree_model_get (model, a, COL_IS_DIR, &is_dir_a, -1);
+    gtk_tree_model_get (model, b, COL_IS_DIR, &is_dir_b, -1);
+    
+    if (is_dir_a && !is_dir_b) {
+        return -1;
+    }
+    if (!is_dir_a && is_dir_b) {
+        return 1;
+    }
+    
+    switch (sort_col_id) {
+        case COL_NAME: {
+            gchar *name_a, *name_b;
+            gtk_tree_model_get (model, a, COL_NAME, &name_a, -1);
+            gtk_tree_model_get (model, b, COL_NAME, &name_b, -1);
+            gint res = g_utf8_collate (name_a, name_b);
+            g_free (name_a);
+            g_free (name_b);
+            return res;
+        }
+        case COL_SIZE: {
+            gint64 size_a, size_b;
+            gtk_tree_model_get (model, a, COL_SIZE, &size_a, -1);
+            gtk_tree_model_get (model, b, COL_SIZE, &size_b, -1);
+            if (size_a < size_b) return -1;
+            if (size_a > size_b) return 1;
+            return 0;
+        }
+        case COL_TYPE: {
+            gchar *type_a, *type_b;
+            gtk_tree_model_get (model, a, COL_TYPE, &type_a, -1);
+            gtk_tree_model_get (model, b, COL_TYPE, &type_b, -1);
+            gint res = g_utf8_collate (type_a, type_b);
+            g_free (type_a);
+            g_free (type_b);
+            return res;
+        }
+        case COL_MODIFIED_TIME: {
+            gint64 time_a, time_b;
+            gtk_tree_model_get (model, a, COL_MODIFIED_TIME, &time_a, -1);
+            gtk_tree_model_get (model, b, COL_MODIFIED_TIME, &time_b, -1);
+            if (time_a < time_b) return -1;
+            if (time_a > time_b) return 1;
+            return 0;
+        }
+        default:
+            return 0;
+    }
+}
+
+static void
+free_dialog_data (gpointer user_data)
+{
+    DialogData *data = user_data;
+    g_clear_object (&data->builder);
+    g_clear_object (&data->current_folder);
+    
+    g_list_free_full (data->history_back, g_object_unref);
+    g_list_free_full (data->history_forward, g_object_unref);
+    
+    g_slist_free_full (data->selected_uris, g_free);
+    g_free (data->selected_uri);
+    
+    g_free (data);
+}
+
+static void
+update_navigation_buttons (DialogData *data)
+{
+    GtkWidget *back_btn = GTK_WIDGET (gtk_builder_get_object (data->builder, "back_button"));
+    GtkWidget *fwd_btn = GTK_WIDGET (gtk_builder_get_object (data->builder, "forward_button"));
+    GtkWidget *up_btn = GTK_WIDGET (gtk_builder_get_object (data->builder, "up_button"));
+    
+    gtk_widget_set_sensitive (back_btn, data->history_back != NULL);
+    gtk_widget_set_sensitive (fwd_btn, data->history_forward != NULL);
+    
+    if (up_btn) {
+        gboolean has_parent = FALSE;
+        if (data->current_folder) {
+            GFile *parent = g_file_get_parent (data->current_folder);
+            if (parent) {
+                has_parent = TRUE;
+                g_object_unref (parent);
+            }
+        }
+        gtk_widget_set_sensitive (up_btn, has_parent);
+    }
+}
+
+static void
+navigate_to (DialogData *data, GFile *folder, gboolean save_history)
+{
+    if (!folder)
+        return;
+        
+    if (save_history && data->current_folder) {
+        data->history_back = g_list_prepend (data->history_back, g_object_ref (data->current_folder));
+        g_list_free_full (data->history_forward, g_object_unref);
+        data->history_forward = NULL;
+    }
+    
+    g_clear_object (&data->current_folder);
+    data->current_folder = g_object_ref (folder);
+    
+    // Update path label
+    gchar *parse_name = g_file_get_parse_name (folder);
+    gtk_label_set_text (GTK_LABEL (data->path_bar_label), parse_name);
+    g_free (parse_name);
+    
+    // Update path entry
+    if (data->path_entry) {
+        gchar *path = g_file_get_path (folder);
+        if (path) {
+            gtk_entry_set_text (GTK_ENTRY (data->path_entry), path);
+            g_free (path);
+        } else {
+            gchar *uri = g_file_get_uri (folder);
+            gtk_entry_set_text (GTK_ENTRY (data->path_entry), uri);
+            g_free (uri);
+        }
+    }
+    
+    // Set places sidebar focus
+    gtk_places_sidebar_set_location (GTK_PLACES_SIDEBAR (data->places_sidebar), folder);
+    
+    load_directory (data, folder);
+    update_navigation_buttons (data);
+}
+
+static void
+on_back_clicked (GtkButton *btn, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (data->history_back) {
+        GFile *folder = G_FILE (data->history_back->data);
+        data->history_back = g_list_remove_link (data->history_back, data->history_back);
+        
+        if (data->current_folder)
+            data->history_forward = g_list_prepend (data->history_forward, g_object_ref (data->current_folder));
+            
+        navigate_to (data, folder, FALSE);
+        g_object_unref (folder);
+    }
+}
+
+static void
+on_forward_clicked (GtkButton *btn, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (data->history_forward) {
+        GFile *folder = G_FILE (data->history_forward->data);
+        data->history_forward = g_list_remove_link (data->history_forward, data->history_forward);
+        
+        if (data->current_folder)
+            data->history_back = g_list_prepend (data->history_back, g_object_ref (data->current_folder));
+            
+        navigate_to (data, folder, FALSE);
+        g_object_unref (folder);
+    }
+}
+
+static void
+on_up_clicked (GtkButton *btn, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (data->current_folder) {
+        GFile *parent = g_file_get_parent (data->current_folder);
+        if (parent) {
+            navigate_to (data, parent, TRUE);
+            g_object_unref (parent);
+        }
+    }
+}
+
+static void
+on_places_sidebar_open_location (GtkPlacesSidebar *sidebar, GFile *location, GtkPlacesOpenFlags flags, gpointer user_data)
+{
+    navigate_to (user_data, location, TRUE);
+}
+
+static void
+preview_info_ready_cb (GObject *source_object, GAsyncResult *res, gpointer user_data)
+{
+    DialogData *data = user_data;
+    g_autoptr(GFileInfo) info = g_file_query_info_finish (G_FILE (source_object), res, NULL);
+    if (!info) {
+        gtk_image_set_from_icon_name (GTK_IMAGE (data->preview_image), "text-x-generic", GTK_ICON_SIZE_DIALOG);
+        return;
+    }
+    
+    gchar *uri = g_file_get_uri (G_FILE (source_object));
+    if (!data->selected_uri || g_strcmp0 (data->selected_uri, uri) != 0) {
+        g_free (uri);
+        return;
+    }
+    g_free (uri);
+    
+    const gchar *thumb_path = g_file_info_get_attribute_byte_string (info, "thumbnail::path");
+    g_autoptr(GdkPixbuf) pixbuf = NULL;
+    
+    if (thumb_path) {
+        pixbuf = gdk_pixbuf_new_from_file_at_size (thumb_path, 192, 192, NULL);
+    }
+    
+    if (!pixbuf) {
+        gchar *path = g_file_get_path (G_FILE (source_object));
+        if (path) {
+            pixbuf = gdk_pixbuf_new_from_file_at_size (path, 192, 192, NULL);
+            g_free (path);
+        }
+    }
+    
+    if (pixbuf) {
+        gtk_image_set_from_pixbuf (GTK_IMAGE (data->preview_image), pixbuf);
+    } else {
+        GIcon *icon = g_file_info_get_icon (info);
+        g_autoptr(GtkIconInfo) icon_info = gtk_icon_theme_lookup_by_gicon (gtk_icon_theme_get_default (), icon, 128, GTK_ICON_LOOKUP_FORCE_SIZE);
+        g_autoptr(GdkPixbuf) fallback_pixbuf = NULL;
+        if (icon_info) {
+            fallback_pixbuf = gtk_icon_info_load_icon (icon_info, NULL);
+        }
+        if (fallback_pixbuf) {
+            gtk_image_set_from_pixbuf (GTK_IMAGE (data->preview_image), fallback_pixbuf);
+        } else {
+            gtk_image_set_from_icon_name (GTK_IMAGE (data->preview_image), "text-x-generic", GTK_ICON_SIZE_DIALOG);
+        }
+    }
+}
+
+static void
+update_preview (DialogData *data, const gchar *uri, const gchar *name, gboolean is_dir, goffset size)
+{
+    gtk_label_set_text (GTK_LABEL (data->preview_name_label), name ? name : _("No File Selected"));
+    
+    if (is_dir) {
+        gtk_label_set_text (GTK_LABEL (data->preview_size_val), _("Folder"));
+        gtk_image_set_from_icon_name (GTK_IMAGE (data->preview_image), "folder", GTK_ICON_SIZE_DIALOG);
+    } else if (uri) {
+        gchar *size_str = g_format_size (size);
+        gtk_label_set_text (GTK_LABEL (data->preview_size_val), size_str);
+        g_free (size_str);
+        
+        gtk_image_set_from_icon_name (GTK_IMAGE (data->preview_image), "image-missing", GTK_ICON_SIZE_DIALOG);
+        
+        GFile *file = g_file_new_for_uri (uri);
+        g_file_query_info_async (file,
+                                 "standard::*,thumbnail::path",
+                                 G_FILE_QUERY_INFO_NONE,
+                                 G_PRIORITY_DEFAULT,
+                                 NULL,
+                                 preview_info_ready_cb,
+                                 data);
+        g_object_unref (file);
+    } else {
+        gtk_label_set_text (GTK_LABEL (data->preview_size_val), "-");
+        gtk_image_set_from_icon_name (GTK_IMAGE (data->preview_image), "image-missing", GTK_ICON_SIZE_DIALOG);
+    }
+}
+
+static void
+on_selection_changed (DialogData *data, GtkTreeModel *model, GtkTreePath *path, gboolean selected)
+{
+    GtkTreeIter iter;
+    if (gtk_tree_model_get_iter (model, &iter, path)) {
+        gchar *name;
+        gchar *uri;
+        gboolean is_dir;
+        goffset size;
+        
+        gtk_tree_model_get (model, &iter,
+                            COL_NAME, &name,
+                            COL_URI, &uri,
+                            COL_IS_DIR, &is_dir,
+                            COL_SIZE, &size,
+                            -1);
+                            
+        if (selected) {
+            gtk_entry_set_text (GTK_ENTRY (data->filename_entry), name);
+            
+            g_slist_free_full (data->selected_uris, g_free);
+            data->selected_uris = NULL;
+            data->selected_uris = g_slist_append (data->selected_uris, g_strdup (uri));
+            
+            g_free (data->selected_uri);
+            data->selected_uri = g_strdup (uri);
+
+            update_preview (data, uri, name, is_dir, size);
+        }
+        
+        g_free (name);
+        g_free (uri);
+    }
+}
+
+static void
+on_tree_selection_changed (GtkTreeSelection *selection, gpointer user_data)
+{
+    DialogData *data = user_data;
+    GtkTreeModel *model;
+    GList *paths = gtk_tree_selection_get_selected_rows (selection, &model);
+    
+    if (paths) {
+        on_selection_changed (data, model, (GtkTreePath *)paths->data, TRUE);
+        g_list_free_full (paths, (GDestroyNotify)gtk_tree_path_free);
+    }
+}
+
+static void
+on_icon_view_item_activated (GtkIconView *icon_view, GtkTreePath *path, gpointer user_data)
+{
+    DialogData *data = user_data;
+    GtkTreeModel *model = gtk_icon_view_get_model (icon_view);
+    GtkTreeIter iter;
+    
+    if (gtk_tree_model_get_iter (model, &iter, path)) {
+        gboolean is_dir;
+        gchar *uri;
+        
+        gtk_tree_model_get (model, &iter, COL_IS_DIR, &is_dir, COL_URI, &uri, -1);
+        
+        if (is_dir) {
+            GFile *folder = g_file_new_for_uri (uri);
+            navigate_to (data, folder, TRUE);
+            g_object_unref (folder);
+        } else {
+            gtk_dialog_response (GTK_DIALOG (data->dialog), GTK_RESPONSE_ACCEPT);
+        }
+        g_free (uri);
+    }
+}
+
+static void
+on_icon_view_selection_changed (GtkIconView *icon_view, gpointer user_data)
+{
+    DialogData *data = user_data;
+    GList *paths = gtk_icon_view_get_selected_items (icon_view);
+    
+    if (paths) {
+        on_selection_changed (data, gtk_icon_view_get_model (icon_view), (GtkTreePath *)paths->data, TRUE);
+        g_list_free_full (paths, (GDestroyNotify)gtk_tree_path_free);
+    }
+}
+
+static void
+on_tree_view_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *col, gpointer user_data)
+{
+    DialogData *data = user_data;
+    GtkTreeModel *model = gtk_tree_view_get_model (tree_view);
+    GtkTreeIter iter;
+    
+    if (gtk_tree_model_get_iter (model, &iter, path)) {
+        gboolean is_dir;
+        gchar *uri;
+        
+        gtk_tree_model_get (model, &iter, COL_IS_DIR, &is_dir, COL_URI, &uri, -1);
+        
+        if (is_dir) {
+            GFile *folder = g_file_new_for_uri (uri);
+            navigate_to (data, folder, TRUE);
+            g_object_unref (folder);
+        } else {
+            gtk_dialog_response (GTK_DIALOG (data->dialog), GTK_RESPONSE_ACCEPT);
+        }
+        g_free (uri);
+    }
+}
+
+static void
+on_view_toggle_changed (GtkToggleButton *btn, gpointer user_data)
+{
+    DialogData *data = user_data;
+    gboolean is_grid = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object (data->builder, "grid_view_toggle")));
+    gboolean is_compact = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object (data->builder, "compact_view_toggle")));
+    GtkWidget *stack = GTK_WIDGET (gtk_builder_get_object (data->builder, "browser_stack"));
+    
+    if (is_grid) {
+        gtk_stack_set_visible_child_name (GTK_STACK (stack), "grid");
+    } else if (is_compact) {
+        gtk_stack_set_visible_child_name (GTK_STACK (stack), "compact");
+    } else {
+        gtk_stack_set_visible_child_name (GTK_STACK (stack), "list");
+    }
+}
+
+static void
+update_store_icons (DialogData *data, gint small_icon_size, gint large_icon_size)
+{
+    GtkTreeIter iter;
+    gboolean valid = gtk_tree_model_get_iter_first (GTK_TREE_MODEL (data->list_store), &iter);
+    
+    while (valid) {
+        GIcon *icon = NULL;
+        gchar *thumbnail_path = NULL;
+        
+        gtk_tree_model_get (GTK_TREE_MODEL (data->list_store), &iter,
+                            COL_GICON, &icon,
+                            COL_THUMBNAIL_PATH, &thumbnail_path,
+                            -1);
+                            
+        g_autoptr(GdkPixbuf) pixbuf_small = NULL;
+        g_autoptr(GdkPixbuf) pixbuf_large = NULL;
+        
+        if (thumbnail_path) {
+            pixbuf_small = gdk_pixbuf_new_from_file_at_size (thumbnail_path, small_icon_size, small_icon_size, NULL);
+            pixbuf_large = gdk_pixbuf_new_from_file_at_size (thumbnail_path, large_icon_size, large_icon_size, NULL);
+        }
+        
+        if (icon) {
+            if (!pixbuf_small) {
+                g_autoptr(GtkIconInfo) icon_info = gtk_icon_theme_lookup_by_gicon (
+                    gtk_icon_theme_get_default (), icon, small_icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
+                if (icon_info) {
+                    pixbuf_small = gtk_icon_info_load_icon (icon_info, NULL);
+                }
+            }
+            if (!pixbuf_large) {
+                g_autoptr(GtkIconInfo) icon_info = gtk_icon_theme_lookup_by_gicon (
+                    gtk_icon_theme_get_default (), icon, large_icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
+                if (icon_info) {
+                    pixbuf_large = gtk_icon_info_load_icon (icon_info, NULL);
+                }
+            }
+            g_object_unref (icon);
+        }
+        
+        gtk_list_store_set (data->list_store, &iter,
+                            COL_ICON, pixbuf_small,
+                            COL_GRID_ICON, pixbuf_large,
+                            -1);
+                            
+        g_free (thumbnail_path);
+        valid = gtk_tree_model_iter_next (GTK_TREE_MODEL (data->list_store), &iter);
+    }
+}
+
+static gboolean
+on_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+{
+    DialogData *data = user_data;
+    
+    if (event->state & GDK_CONTROL_MASK) {
+        gdouble delta_y = 0.0;
+        gdouble delta_x = 0.0;
+        gboolean is_scroll_up = FALSE;
+        gboolean has_delta = FALSE;
+        
+        if (event->direction == GDK_SCROLL_SMOOTH) {
+            if (gdk_event_get_scroll_deltas ((GdkEvent *)event, &delta_x, &delta_y)) {
+                if (delta_y != 0.0) {
+                    is_scroll_up = (delta_y < 0.0);
+                    has_delta = TRUE;
+                }
+            }
+        } else {
+            is_scroll_up = (event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_LEFT);
+            has_delta = TRUE;
+        }
+        
+        if (has_delta) {
+            GtkWidget *stack = GTK_WIDGET (gtk_builder_get_object (data->builder, "browser_stack"));
+            const gchar *current_view = gtk_stack_get_visible_child_name (GTK_STACK (stack));
+            
+            if (g_strcmp0 (current_view, "grid") == 0) {
+                gint item_width = gtk_icon_view_get_item_width (GTK_ICON_VIEW (data->icon_view));
+                if (is_scroll_up) {
+                    item_width = CLAMP (item_width + 16, 48, 256);
+                } else {
+                    item_width = CLAMP (item_width - 16, 48, 256);
+                }
+                gtk_icon_view_set_item_width (GTK_ICON_VIEW (data->icon_view), item_width);
+                
+                data->large_icon_size = CLAMP (item_width - 16, 32, 220);
+                update_store_icons (data, data->small_icon_size, data->large_icon_size);
+            } else if (g_strcmp0 (current_view, "compact") == 0) {
+                gint item_width = gtk_icon_view_get_item_width (GTK_ICON_VIEW (data->compact_view));
+                if (item_width < 0) {
+                    item_width = 120;
+                }
+                if (is_scroll_up) {
+                    item_width = CLAMP (item_width + 16, 80, 320);
+                } else {
+                    item_width = CLAMP (item_width - 16, 80, 320);
+                }
+                gtk_icon_view_set_item_width (GTK_ICON_VIEW (data->compact_view), item_width);
+                
+                data->small_icon_size = CLAMP (item_width / 5, 16, 48);
+                update_store_icons (data, data->small_icon_size, data->large_icon_size);
+            } else if (g_strcmp0 (current_view, "list") == 0) {
+                if (is_scroll_up) {
+                    data->small_icon_size = CLAMP (data->small_icon_size + 4, 16, 48);
+                } else {
+                    data->small_icon_size = CLAMP (data->small_icon_size - 4, 16, 48);
+                }
+                update_store_icons (data, data->small_icon_size, data->large_icon_size);
+            }
+            return TRUE; // Consume event
+        }
+    }
+    
+    return FALSE;
+}
+
+static void
+directory_enumerated_cb (GObject *source_object, GAsyncResult *res, gpointer user_data)
+{
+    DialogData *data = user_data;
+    g_autoptr(GFileEnumerator) enumerator = NULL;
+    g_autoptr(GError) error = NULL;
+    
+    enumerator = g_file_enumerate_children_finish (G_FILE (source_object), res, &error);
+    if (error) {
+        g_warning ("Failed to list directory contents: %s", error->message);
+        return;
+    }
+    
+    // Save active sort columns to temporarily disable sorting during batch inserts
+    gint sort_id;
+    GtkSortType sort_type;
+    gboolean has_sort = gtk_tree_sortable_get_sort_column_id (GTK_TREE_SORTABLE (data->list_store), &sort_id, &sort_type);
+    gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (data->list_store), GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, 0);
+    
+    gtk_list_store_clear (data->list_store);
+    
+    GList *files = NULL;
+    GFileInfo *info;
+    while ((info = g_file_enumerator_next_file (enumerator, NULL, &error)) != NULL) {
+        files = g_list_prepend (files, info);
+    }
+    
+    // Sort files (folders first, then alphabetically)
+    files = g_list_reverse (files);
+    
+    GList *l;
+    for (l = files; l != NULL; l = l->next) {
+        GFileInfo *file_info = l->data;
+        const gchar *name = g_file_info_get_display_name (file_info);
+        gboolean is_dir = g_file_info_get_file_type (file_info) == G_FILE_TYPE_DIRECTORY;
+        goffset size = g_file_info_get_size (file_info);
+        
+        if (data->action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER && !is_dir) {
+            g_object_unref (file_info);
+            continue;
+        }
+        
+        gboolean is_hidden = g_file_info_get_is_hidden (file_info) || g_file_info_get_is_backup (file_info);
+        if (is_hidden && !data->show_hidden) {
+            g_object_unref (file_info);
+            continue;
+        }
+        
+        // 1. File Type (Description)
+        const gchar *content_type = g_file_info_get_content_type (file_info);
+        gchar *type_desc = NULL;
+        if (is_dir) {
+            type_desc = g_strdup (_("Folder"));
+        } else if (content_type) {
+            type_desc = g_content_type_get_description (content_type);
+        } else {
+            type_desc = g_strdup (_("Unknown"));
+        }
+        
+        // 2. Last Modified Date/Time
+        GDateTime *mod_time = g_file_info_get_modification_date_time (file_info);
+        gint64 mod_timestamp = 0;
+        gchar *mod_str = NULL;
+        if (mod_time) {
+            mod_timestamp = g_date_time_to_unix (mod_time);
+            mod_str = g_date_time_format (mod_time, "%Y-%m-%d %H:%M:%S");
+        } else {
+            mod_str = g_strdup ("-");
+        }
+        
+        GIcon *icon = g_file_info_get_icon (file_info);
+        g_autoptr(GtkIconInfo) icon_info_small = gtk_icon_theme_lookup_by_gicon (gtk_icon_theme_get_default (), icon, data->small_icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
+        g_autoptr(GtkIconInfo) icon_info_large = gtk_icon_theme_lookup_by_gicon (gtk_icon_theme_get_default (), icon, data->large_icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
+        
+        g_autoptr(GdkPixbuf) pixbuf_small = NULL;
+        g_autoptr(GdkPixbuf) pixbuf_large = NULL;
+        
+        const gchar *thumbnail_path = g_file_info_get_attribute_byte_string (file_info, "thumbnail::path");
+        if (thumbnail_path) {
+            pixbuf_small = gdk_pixbuf_new_from_file_at_size (thumbnail_path, data->small_icon_size, data->small_icon_size, NULL);
+            pixbuf_large = gdk_pixbuf_new_from_file_at_size (thumbnail_path, data->large_icon_size, data->large_icon_size, NULL);
+        }
+        
+        if (!pixbuf_small && icon_info_small) {
+            pixbuf_small = gtk_icon_info_load_icon (icon_info_small, NULL);
+        }
+        if (!pixbuf_large && icon_info_large) {
+            pixbuf_large = gtk_icon_info_load_icon (icon_info_large, NULL);
+        }
+        
+        g_autoptr(GFile) child_file = g_file_get_child (G_FILE (source_object), g_file_info_get_name (file_info));
+        gchar *uri = g_file_get_uri (child_file);
+        
+        gchar *size_str = is_dir ? g_strdup (_("Folder")) : g_format_size (size);
+        
+        GtkTreeIter iter;
+        gtk_list_store_append (data->list_store, &iter);
+        gtk_list_store_set (data->list_store, &iter,
+                             COL_NAME, name,
+                             COL_ICON, pixbuf_small,
+                             COL_GRID_ICON, pixbuf_large,
+                             COL_SIZE, size,
+                             COL_SIZE_STR, size_str,
+                             COL_TYPE, type_desc,
+                             COL_MODIFIED_TIME, mod_timestamp,
+                             COL_MODIFIED_STR, mod_str,
+                             COL_IS_DIR, is_dir,
+                             COL_URI, uri,
+                             COL_GICON, icon,
+                             COL_THUMBNAIL_PATH, thumbnail_path,
+                             -1);
+                             
+        g_free (uri);
+        g_free (size_str);
+        g_free (type_desc);
+        g_free (mod_str);
+        g_object_unref (file_info);
+    }
+    
+    g_list_free (files);
+    
+    // Restore sort settings on the list model
+    if (has_sort) {
+        gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (data->list_store), sort_id, sort_type);
+    } else {
+        gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (data->list_store), COL_NAME, GTK_SORT_ASCENDING);
+    }
+}
+
+static void
+load_directory (DialogData *data, GFile *folder)
+{
+    g_file_enumerate_children_async (folder,
+                                     "standard::*,thumbnail::path,time::modified",
+                                     G_FILE_QUERY_INFO_NONE,
+                                     G_PRIORITY_DEFAULT,
+                                     NULL,
+                                     directory_enumerated_cb,
+                                     data);
+}
+
+static void
+on_menu_item_toggled (GtkCheckMenuItem *menu_item, gpointer user_data)
+{
+    GtkTreeViewColumn *column = GTK_TREE_VIEW_COLUMN (user_data);
+    gboolean visible = gtk_check_menu_item_get_active (menu_item);
+    gtk_tree_view_column_set_visible (column, visible);
+}
+
+static void
+show_header_context_menu (GtkWidget *tree_view, GdkEventButton *event, DialogData *data)
+{
+    GtkWidget *menu = gtk_menu_new ();
+    GList *columns = gtk_tree_view_get_columns (GTK_TREE_VIEW (tree_view));
+    GList *l;
+    
+    for (l = columns; l != NULL; l = l->next) {
+        GtkTreeViewColumn *col = GTK_TREE_VIEW_COLUMN (l->data);
+        const gchar *title = gtk_tree_view_column_get_title (col);
+        
+        if (!title || !*title)
+            continue;
+            
+        GtkWidget *item = gtk_check_menu_item_new_with_label (title);
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), gtk_tree_view_column_get_visible (col));
+        
+        if (g_strcmp0 (title, _("Name")) == 0) {
+            gtk_widget_set_sensitive (item, FALSE);
+        }
+        
+        g_signal_connect (item, "toggled", G_CALLBACK (on_menu_item_toggled), col);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+    }
+    
+    g_list_free (columns);
+    gtk_widget_show_all (menu);
+    
+    gtk_menu_popup_at_pointer (GTK_MENU (menu), (GdkEvent *)event);
+}
+
+static void
+on_show_hidden_toggled (GtkCheckMenuItem *menu_item, gpointer user_data)
+{
+    DialogData *data = user_data;
+    data->show_hidden = gtk_check_menu_item_get_active (menu_item);
+    load_directory (data, data->current_folder);
+}
+
+static void
+on_sort_method_selected (GtkRadioMenuItem *menu_item, gpointer user_data)
+{
+    if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (menu_item))) {
+        DialogData *data = g_object_get_data (G_OBJECT (menu_item), "dialog-data");
+        gint sort_col_id = GPOINTER_TO_INT (user_data);
+        
+        GtkTreeSortable *sortable = GTK_TREE_SORTABLE (data->list_store);
+        gint current_id;
+        GtkSortType current_type;
+        
+        if (gtk_tree_sortable_get_sort_column_id (sortable, &current_id, &current_type)) {
+            gtk_tree_sortable_set_sort_column_id (sortable, sort_col_id, current_type);
+        } else {
+            gtk_tree_sortable_set_sort_column_id (sortable, sort_col_id, GTK_SORT_ASCENDING);
+        }
+    }
+}
+
+
+static void
+on_show_in_file_manager_clicked (GtkWidget *menu_item, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (data->current_folder) {
+        gchar *uri = g_file_get_uri (data->current_folder);
+        g_app_info_launch_default_for_uri (uri, NULL, NULL);
+        g_free (uri);
+    }
+}
+
+static void
+on_copy_path_clicked (GtkWidget *menu_item, gpointer user_data)
+{
+    DialogData *data = user_data;
+    gchar *text = NULL;
+    
+    if (data->selected_uri) {
+        GFile *file = g_file_new_for_uri (data->selected_uri);
+        text = g_file_get_path (file);
+        if (!text) {
+            text = g_strdup (data->selected_uri);
+        }
+        g_object_unref (file);
+    } else if (data->current_folder) {
+        text = g_file_get_path (data->current_folder);
+    }
+    
+    if (text) {
+        GtkClipboard *clipboard = gtk_clipboard_get (GDK_SELECTION_CLIPBOARD);
+        gtk_clipboard_set_text (clipboard, text, -1);
+        g_free (text);
+    }
+}
+
+static void
+on_refresh_clicked (GtkWidget *menu_item, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (data->current_folder) {
+        load_directory (data, data->current_folder);
+    }
+}
+
+static void
+on_properties_clicked (GtkWidget *menu_item, gpointer user_data)
+{
+    DialogData *data = user_data;
+    GFile *file = NULL;
+    if (data->selected_uri) {
+        file = g_file_new_for_uri (data->selected_uri);
+    } else if (data->current_folder) {
+        file = g_object_ref (data->current_folder);
+    }
+    
+    if (file) {
+        g_autoptr(GFileInfo) info = g_file_query_info (file, "standard::*,time::modified", G_FILE_QUERY_INFO_NONE, NULL, NULL);
+        if (info) {
+            const gchar *display_name = g_file_info_get_display_name (info);
+            gchar *path = g_file_get_path (file);
+            goffset size = g_file_info_get_size (info);
+            const gchar *content_type = g_file_info_get_content_type (info);
+            g_autofree gchar *type_desc = g_content_type_get_description (content_type);
+            
+            GDateTime *mod_time = g_file_info_get_modification_date_time (info);
+            g_autofree gchar *mod_str = mod_time ? g_date_time_format (mod_time, "%Y-%m-%d %H:%M:%S") : g_strdup ("-");
+            
+            g_autofree gchar *size_str = g_format_size (size);
+            
+            gchar *message = g_strdup_printf (
+                _("Name: %s\nPath: %s\nType: %s\nSize: %s\nModified: %s"),
+                display_name ? display_name : "-",
+                path ? path : "-",
+                type_desc ? type_desc : "-",
+                size_str ? size_str : "-",
+                mod_str ? mod_str : "-"
+            );
+            
+            GtkWidget *dialog = gtk_message_dialog_new (GTK_WINDOW (data->dialog),
+                                                         GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                         GTK_MESSAGE_INFO,
+                                                         GTK_BUTTONS_OK,
+                                                         "%s", _("Properties"));
+            gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "%s", message);
+            gtk_dialog_run (GTK_DIALOG (dialog));
+            gtk_widget_destroy (dialog);
+            
+            g_free (path);
+            g_free (message);
+        }
+        g_object_unref (file);
+    }
+}
+
+static void
+do_create_folder (DialogData *data)
+{
+    if (!data->current_folder)
+        return;
+        
+    GtkWidget *dialog = gtk_dialog_new_with_buttons (_("Create Folder"),
+                                                     GTK_WINDOW (data->dialog),
+                                                     GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                     _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                                     _("_Create"), GTK_RESPONSE_ACCEPT,
+                                                     NULL);
+                                                     
+    gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_ACCEPT);
+    
+    GtkWidget *content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+    gtk_container_set_border_width (GTK_CONTAINER (box), 12);
+    gtk_container_add (GTK_CONTAINER (content_area), box);
+    
+    GtkWidget *label = gtk_label_new (_("Enter name for new folder:"));
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+    
+    GtkWidget *entry = gtk_entry_new ();
+    gtk_entry_set_text (GTK_ENTRY (entry), _("New Folder"));
+    gtk_entry_set_activates_default (GTK_ENTRY (entry), TRUE);
+    gtk_box_pack_start (GTK_BOX (box), entry, FALSE, FALSE, 0);
+    
+    gtk_widget_show_all (box);
+    
+    if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT) {
+        const gchar *name = gtk_entry_get_text (GTK_ENTRY (entry));
+        if (name && *name) {
+            GFile *new_dir = g_file_get_child (data->current_folder, name);
+            g_autoptr(GError) error = NULL;
+            if (g_file_make_directory (new_dir, NULL, &error)) {
+                load_directory (data, data->current_folder);
+            } else {
+                GtkWidget *err_dialog = gtk_message_dialog_new (GTK_WINDOW (data->dialog),
+                                                                 GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                                 GTK_MESSAGE_ERROR,
+                                                                 GTK_BUTTONS_OK,
+                                                                 _("Failed to create folder: %s"),
+                                                                 error->message);
+                gtk_dialog_run (GTK_DIALOG (err_dialog));
+                gtk_widget_destroy (err_dialog);
+            }
+            g_object_unref (new_dir);
+        }
+    }
+    gtk_widget_destroy (dialog);
+}
+
+static void
+on_create_folder_clicked (GtkWidget *widget, gpointer user_data)
+{
+    do_create_folder (user_data);
+}
+
+static void
+on_location_toggle_button_toggled (GtkToggleButton *toggle_button, gpointer user_data)
+{
+    DialogData *data = user_data;
+    gboolean active = gtk_toggle_button_get_active (toggle_button);
+    
+    if (active) {
+        gtk_stack_set_visible_child_name (GTK_STACK (data->path_stack), "entry");
+        if (data->current_folder) {
+            gchar *path = g_file_get_path (data->current_folder);
+            if (path) {
+                gtk_entry_set_text (GTK_ENTRY (data->path_entry), path);
+                g_free (path);
+            } else {
+                gchar *uri = g_file_get_uri (data->current_folder);
+                gtk_entry_set_text (GTK_ENTRY (data->path_entry), uri);
+                g_free (uri);
+            }
+        }
+        gtk_widget_grab_focus (data->path_entry);
+        gtk_editable_select_region (GTK_EDITABLE (data->path_entry), 0, -1);
+    } else {
+        gtk_stack_set_visible_child_name (GTK_STACK (data->path_stack), "label");
+    }
+}
+
+static void
+on_path_entry_activate (GtkEntry *entry, gpointer user_data)
+{
+    DialogData *data = user_data;
+    const gchar *text = gtk_entry_get_text (entry);
+    
+    if (text && *text) {
+        GFile *new_folder = g_file_new_for_commandline_arg (text);
+        if (g_file_query_exists (new_folder, NULL)) {
+            navigate_to (data, new_folder, TRUE);
+            gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object (data->builder, "location_toggle_button")), FALSE);
+        } else {
+            // Keep focus, do nothing
+        }
+        g_object_unref (new_folder);
+    }
+}
+
+static gboolean
+on_path_entry_key_press (GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+    DialogData *data = user_data;
+    if (event->keyval == GDK_KEY_Escape) {
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object (data->builder, "location_toggle_button")), FALSE);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static void
+show_files_context_menu (GtkWidget *widget, GdkEventButton *event, DialogData *data)
+{
+    GtkWidget *menu = gtk_menu_new ();
+    
+    // 1. Create Folder
+    GtkWidget *create_item = gtk_menu_item_new_with_label (_("Create Folder..."));
+    g_signal_connect (create_item, "activate", G_CALLBACK (on_create_folder_clicked), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), create_item);
+    
+    // 2. Show in File Manager
+    GtkWidget *fm_item = gtk_menu_item_new_with_label (_("Show in File Manager"));
+    g_signal_connect (fm_item, "activate", G_CALLBACK (on_show_in_file_manager_clicked), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), fm_item);
+    
+    // 3. Copy Path
+    GtkWidget *copy_item = gtk_menu_item_new_with_label (_("Copy Location"));
+    g_signal_connect (copy_item, "activate", G_CALLBACK (on_copy_path_clicked), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), copy_item);
+    
+    // 4. Refresh
+    GtkWidget *refresh_item = gtk_menu_item_new_with_label (_("Refresh"));
+    g_signal_connect (refresh_item, "activate", G_CALLBACK (on_refresh_clicked), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), refresh_item);
+    
+    // 5. Properties
+    GtkWidget *prop_item = gtk_menu_item_new_with_label (_("Properties"));
+    g_signal_connect (prop_item, "activate", G_CALLBACK (on_properties_clicked), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), prop_item);
+    
+    // Separator
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new ());
+    
+    // 6. Show Hidden Files Item
+    GtkWidget *hidden_item = gtk_check_menu_item_new_with_label (_("Show Hidden Files"));
+    gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (hidden_item), data->show_hidden);
+    g_signal_connect (hidden_item, "toggled", G_CALLBACK (on_show_hidden_toggled), data);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), hidden_item);
+    
+    // Separator
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new ());
+    
+    // 7. Sort By Submenu
+    GtkWidget *sort_submenu_item = gtk_menu_item_new_with_label (_("Sort By"));
+    GtkWidget *sort_submenu = gtk_menu_new ();
+    
+    GSList *group = NULL;
+    GtkTreeSortable *sortable = GTK_TREE_SORTABLE (data->list_store);
+    gint current_sort_id = COL_NAME;
+    GtkSortType current_sort_type;
+    gtk_tree_sortable_get_sort_column_id (sortable, &current_sort_id, &current_sort_type);
+    
+    struct {
+        const gchar *label;
+        gint col_id;
+    } sort_options[] = {
+        { N_("Name"), COL_NAME },
+        { N_("Size"), COL_SIZE },
+        { N_("Type"), COL_TYPE },
+        { N_("Modified"), COL_MODIFIED_TIME }
+    };
+    
+    for (gint i = 0; i < G_N_ELEMENTS (sort_options); i++) {
+        GtkWidget *item = gtk_radio_menu_item_new_with_label (group, _(sort_options[i].label));
+        group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (item));
+        
+        g_object_set_data (G_OBJECT (item), "dialog-data", data);
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), (current_sort_id == sort_options[i].col_id));
+        g_signal_connect (item, "toggled", G_CALLBACK (on_sort_method_selected), GINT_TO_POINTER (sort_options[i].col_id));
+        
+        gtk_menu_shell_append (GTK_MENU_SHELL (sort_submenu), item);
+    }
+    
+    gtk_menu_item_set_submenu (GTK_MENU_ITEM (sort_submenu_item), sort_submenu);
+    gtk_menu_shell_append (GTK_MENU_SHELL (menu), sort_submenu_item);
+    
+    gtk_widget_show_all (menu);
+    gtk_menu_popup_at_pointer (GTK_MENU (menu), (GdkEvent *)event);
+}
+
+static gboolean
+on_tree_view_button_press (GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+{
+    DialogData *data = user_data;
+    
+    if (event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY) {
+        GdkWindow *bin_window = gtk_tree_view_get_bin_window (GTK_TREE_VIEW (widget));
+        if (event->window != bin_window) {
+            show_header_context_menu (widget, event, data);
+            return TRUE; // Consume event
+        } else {
+            show_files_context_menu (widget, event, data);
+            return TRUE; // Consume event
+        }
+    }
+    return FALSE;
+}
+
+static gboolean
+on_icon_view_button_press (GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+{
+    DialogData *data = user_data;
+    
+    if (event->type == GDK_BUTTON_PRESS && event->button == GDK_BUTTON_SECONDARY) {
+        show_files_context_menu (widget, event, data);
+        return TRUE; // Consume event
+    }
+    return FALSE;
+}
+
+static gboolean
+on_dialog_key_press (GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+    DialogData *data = user_data;
+    
+    if ((event->state & GDK_CONTROL_MASK) && (event->keyval == GDK_KEY_h || event->keyval == GDK_KEY_H)) {
+        data->show_hidden = !data->show_hidden;
+        load_directory (data, data->current_folder);
+        return TRUE; // Consume event
+    }
+    
+    if ((event->state & GDK_CONTROL_MASK) && (event->keyval == GDK_KEY_l || event->keyval == GDK_KEY_L)) {
+        GtkToggleButton *toggle = GTK_TOGGLE_BUTTON (gtk_builder_get_object (data->builder, "location_toggle_button"));
+        gtk_toggle_button_set_active (toggle, !gtk_toggle_button_get_active (toggle));
+        return TRUE; // Consume event
+    }
+    
+    return FALSE;
+}
+
+GtkWidget *
+nemo_file_chooser_dialog_new (const gchar *title,
+                              GtkFileChooserAction action,
+                              gboolean select_multiple,
+                              const gchar *initial_folder_uri,
+                              const gchar *suggested_name)
+{
+    GtkBuilder *builder = gtk_builder_new ();
+    gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
+    
+    GError *error = NULL;
+    if (!gtk_builder_add_from_resource (builder, "/org/nemo/nemo-file-chooser-dialog.glade", &error)) {
+        g_warning ("Failed to load file chooser UI resource: %s", error->message);
+        g_object_unref (builder);
+        return NULL;
+    }
+    
+    GtkWidget *dialog = GTK_WIDGET (gtk_builder_get_object (builder, "nemo_file_chooser_dialog"));
+    if (title && *title) {
+        gtk_window_set_title (GTK_WINDOW (dialog), title);
+    }
+    
+    DialogData *data = g_new0 (DialogData, 1);
+    data->builder = builder;
+    data->dialog = dialog;
+    data->action = action;
+    data->select_multiple = select_multiple;
+    data->show_hidden = FALSE;
+    
+    if (action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER) {
+        GtkWidget *ok_btn = GTK_WIDGET (gtk_builder_get_object (builder, "ok_button"));
+        if (ok_btn) {
+            gtk_button_set_label (GTK_BUTTON (ok_btn), _("_Select"));
+        }
+    }
+    
+    g_object_set_data_full (G_OBJECT (dialog), "dialog-data", data, free_dialog_data);
+    
+    g_signal_connect (dialog, "key-press-event", G_CALLBACK (on_dialog_key_press), data);
+    
+    // Bind UI elements
+    data->path_bar_label = GTK_WIDGET (gtk_builder_get_object (builder, "path_label"));
+    data->path_stack = GTK_WIDGET (gtk_builder_get_object (builder, "path_stack"));
+    data->path_entry = GTK_WIDGET (gtk_builder_get_object (builder, "path_entry"));
+    
+    data->filename_entry = GTK_WIDGET (gtk_builder_get_object (builder, "filename_entry"));
+    data->filter_combo = GTK_WIDGET (gtk_builder_get_object (builder, "filter_combo"));
+    
+    data->preview_image = GTK_WIDGET (gtk_builder_get_object (builder, "preview_image"));
+    data->preview_name_label = GTK_WIDGET (gtk_builder_get_object (builder, "preview_name_label"));
+    data->preview_size_val = GTK_WIDGET (gtk_builder_get_object (builder, "preview_size_val"));
+    
+    // Places Sidebar Setup
+    data->places_sidebar = gtk_places_sidebar_new ();
+    gtk_places_sidebar_set_show_desktop (GTK_PLACES_SIDEBAR (data->places_sidebar), TRUE);
+    gtk_places_sidebar_set_show_recent (GTK_PLACES_SIDEBAR (data->places_sidebar), TRUE);
+    gtk_widget_show (data->places_sidebar);
+    gtk_container_add (GTK_CONTAINER (gtk_builder_get_object (builder, "sidebar_scrolled")), data->places_sidebar);
+    
+    g_signal_connect (data->places_sidebar, "open-location", G_CALLBACK (on_places_sidebar_open_location), data);
+    
+    g_signal_connect (data->path_entry, "activate", G_CALLBACK (on_path_entry_activate), data);
+    g_signal_connect (data->path_entry, "key-press-event", G_CALLBACK (on_path_entry_key_press), data);
+    g_signal_connect (gtk_builder_get_object (builder, "location_toggle_button"), "toggled", G_CALLBACK (on_location_toggle_button_toggled), data);
+    g_signal_connect (gtk_builder_get_object (builder, "create_folder_button"), "clicked", G_CALLBACK (on_create_folder_clicked), data);
+    
+    // Set default icon sizes
+    data->small_icon_size = 24;
+    data->large_icon_size = 96;
+    
+    // List Store & Views Setup
+    data->list_store = gtk_list_store_new (COL_NUM_COLUMNS,
+                                           G_TYPE_STRING,   // NAME
+                                           GDK_TYPE_PIXBUF, // ICON (small)
+                                           GDK_TYPE_PIXBUF, // GRID_ICON (large)
+                                           G_TYPE_INT64,    // SIZE
+                                           G_TYPE_STRING,   // SIZE STR
+                                           G_TYPE_STRING,   // TYPE
+                                           G_TYPE_INT64,    // MODIFIED TIME
+                                           G_TYPE_STRING,   // MODIFIED STR
+                                           G_TYPE_BOOLEAN,  // IS DIR
+                                           G_TYPE_STRING,   // URI
+                                           G_TYPE_ICON,     // GICON
+                                           G_TYPE_STRING);  // THUMBNAIL_PATH
+                                           
+    // Setup Custom Folders-First Sorting Rules on List Store
+    GtkTreeSortable *sortable = GTK_TREE_SORTABLE (data->list_store);
+    gtk_tree_sortable_set_sort_func (sortable, COL_NAME, compare_rows_folders_first, GINT_TO_POINTER (COL_NAME), NULL);
+    gtk_tree_sortable_set_sort_func (sortable, COL_SIZE, compare_rows_folders_first, GINT_TO_POINTER (COL_SIZE), NULL);
+    gtk_tree_sortable_set_sort_func (sortable, COL_TYPE, compare_rows_folders_first, GINT_TO_POINTER (COL_TYPE), NULL);
+    gtk_tree_sortable_set_sort_func (sortable, COL_MODIFIED_TIME, compare_rows_folders_first, GINT_TO_POINTER (COL_MODIFIED_TIME), NULL);
+    gtk_tree_sortable_set_sort_column_id (sortable, COL_NAME, GTK_SORT_ASCENDING);
+    
+    // 1. Setup Tree View (List Mode)
+    data->tree_view = gtk_tree_view_new_with_model (GTK_TREE_MODEL (data->list_store));
+    GtkCellRenderer *renderer_icon = gtk_cell_renderer_pixbuf_new ();
+    GtkCellRenderer *renderer_text = gtk_cell_renderer_text_new ();
+    
+    GtkTreeViewColumn *col_name = gtk_tree_view_column_new ();
+    gtk_tree_view_column_set_title (col_name, _("Name"));
+    gtk_tree_view_column_pack_start (col_name, renderer_icon, FALSE);
+    gtk_tree_view_column_pack_start (col_name, renderer_text, TRUE);
+    gtk_tree_view_column_add_attribute (col_name, renderer_icon, "pixbuf", COL_ICON);
+    gtk_tree_view_column_add_attribute (col_name, renderer_text, "text", COL_NAME);
+    gtk_tree_view_column_set_sort_column_id (col_name, COL_NAME);
+    gtk_tree_view_column_set_resizable (col_name, TRUE);
+    gtk_tree_view_append_column (GTK_TREE_VIEW (data->tree_view), col_name);
+    
+    GtkTreeViewColumn *col_size = gtk_tree_view_column_new_with_attributes (_("Size"), renderer_text, "text", COL_SIZE_STR, NULL);
+    gtk_tree_view_column_set_sort_column_id (col_size, COL_SIZE);
+    gtk_tree_view_column_set_resizable (col_size, TRUE);
+    gtk_tree_view_append_column (GTK_TREE_VIEW (data->tree_view), col_size);
+    
+    GtkTreeViewColumn *col_type = gtk_tree_view_column_new_with_attributes (_("Type"), renderer_text, "text", COL_TYPE, NULL);
+    gtk_tree_view_column_set_sort_column_id (col_type, COL_TYPE);
+    gtk_tree_view_column_set_resizable (col_type, TRUE);
+    gtk_tree_view_append_column (GTK_TREE_VIEW (data->tree_view), col_type);
+    
+    GtkTreeViewColumn *col_modified = gtk_tree_view_column_new_with_attributes (_("Modified"), renderer_text, "text", COL_MODIFIED_STR, NULL);
+    gtk_tree_view_column_set_sort_column_id (col_modified, COL_MODIFIED_TIME);
+    gtk_tree_view_column_set_resizable (col_modified, TRUE);
+    gtk_tree_view_append_column (GTK_TREE_VIEW (data->tree_view), col_modified);
+    
+    gtk_widget_show (data->tree_view);
+    gtk_container_add (GTK_CONTAINER (gtk_builder_get_object (builder, "tree_scrolled")), data->tree_view);
+    
+    GtkTreeSelection *selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (data->tree_view));
+    gtk_tree_selection_set_mode (selection, select_multiple ? GTK_SELECTION_MULTIPLE : GTK_SELECTION_SINGLE);
+    g_signal_connect (selection, "changed", G_CALLBACK (on_tree_selection_changed), data);
+    g_signal_connect (data->tree_view, "row-activated", G_CALLBACK (on_tree_view_row_activated), data);
+    
+    // Connect Scroll event for Zooming in List View
+    gtk_widget_add_events (data->tree_view, GDK_SCROLL_MASK);
+    g_signal_connect (data->tree_view, "scroll-event", G_CALLBACK (on_view_scroll_event), data);
+    
+    // Connect Button Press event for Right Click Header Menu
+    gtk_widget_add_events (data->tree_view, GDK_BUTTON_PRESS_MASK);
+    g_signal_connect (data->tree_view, "button-press-event", G_CALLBACK (on_tree_view_button_press), data);
+    
+    // 2. Setup Icon View (Grid Mode)
+    data->icon_view = gtk_icon_view_new_with_model (GTK_TREE_MODEL (data->list_store));
+    gtk_icon_view_set_text_column (GTK_ICON_VIEW (data->icon_view), COL_NAME);
+    gtk_icon_view_set_pixbuf_column (GTK_ICON_VIEW (data->icon_view), COL_GRID_ICON);
+    gtk_icon_view_set_item_width (GTK_ICON_VIEW (data->icon_view), 80);
+    gtk_icon_view_set_selection_mode (GTK_ICON_VIEW (data->icon_view), select_multiple ? GTK_SELECTION_MULTIPLE : GTK_SELECTION_SINGLE);
+    
+    gtk_widget_show (data->icon_view);
+    gtk_container_add (GTK_CONTAINER (gtk_builder_get_object (builder, "icon_scrolled")), data->icon_view);
+    
+    g_signal_connect (data->icon_view, "selection-changed", G_CALLBACK (on_icon_view_selection_changed), data);
+    g_signal_connect (data->icon_view, "item-activated", G_CALLBACK (on_icon_view_item_activated), data);
+    
+    // Connect Scroll event for Zooming in Icon View
+    gtk_widget_add_events (data->icon_view, GDK_SCROLL_MASK);
+    g_signal_connect (data->icon_view, "scroll-event", G_CALLBACK (on_view_scroll_event), data);
+    
+    // Connect Button Press event for Right Click Context Menu in Icon View
+    gtk_widget_add_events (data->icon_view, GDK_BUTTON_PRESS_MASK);
+    g_signal_connect (data->icon_view, "button-press-event", G_CALLBACK (on_icon_view_button_press), data);
+    
+    // 3. Setup Compact View (Compact Mode)
+    data->compact_view = gtk_icon_view_new_with_model (GTK_TREE_MODEL (data->list_store));
+    gtk_icon_view_set_text_column (GTK_ICON_VIEW (data->compact_view), COL_NAME);
+    gtk_icon_view_set_pixbuf_column (GTK_ICON_VIEW (data->compact_view), COL_ICON);
+    gtk_icon_view_set_item_orientation (GTK_ICON_VIEW (data->compact_view), GTK_ORIENTATION_HORIZONTAL);
+    gtk_icon_view_set_item_width (GTK_ICON_VIEW (data->compact_view), 120);
+    gtk_icon_view_set_selection_mode (GTK_ICON_VIEW (data->compact_view), select_multiple ? GTK_SELECTION_MULTIPLE : GTK_SELECTION_SINGLE);
+    
+    gtk_widget_show (data->compact_view);
+    gtk_container_add (GTK_CONTAINER (gtk_builder_get_object (builder, "compact_scrolled")), data->compact_view);
+    
+    g_signal_connect (data->compact_view, "selection-changed", G_CALLBACK (on_icon_view_selection_changed), data);
+    g_signal_connect (data->compact_view, "item-activated", G_CALLBACK (on_icon_view_item_activated), data);
+    
+    // Connect Scroll event for Zooming in Compact View
+    gtk_widget_add_events (data->compact_view, GDK_SCROLL_MASK);
+    g_signal_connect (data->compact_view, "scroll-event", G_CALLBACK (on_view_scroll_event), data);
+    
+    // Connect Button Press event for Right Click Context Menu in Compact View
+    gtk_widget_add_events (data->compact_view, GDK_BUTTON_PRESS_MASK);
+    g_signal_connect (data->compact_view, "button-press-event", G_CALLBACK (on_icon_view_button_press), data);
+    
+    // Connect header buttons
+    g_signal_connect (gtk_builder_get_object (builder, "back_button"), "clicked", G_CALLBACK (on_back_clicked), data);
+    g_signal_connect (gtk_builder_get_object (builder, "forward_button"), "clicked", G_CALLBACK (on_forward_clicked), data);
+    g_signal_connect (gtk_builder_get_object (builder, "up_button"), "clicked", G_CALLBACK (on_up_clicked), data);
+    
+    g_signal_connect (gtk_builder_get_object (builder, "grid_view_toggle"), "toggled", G_CALLBACK (on_view_toggle_changed), data);
+    g_signal_connect (gtk_builder_get_object (builder, "compact_view_toggle"), "toggled", G_CALLBACK (on_view_toggle_changed), data);
+    
+    // Initialize view states (Grid View active by default)
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (gtk_builder_get_object (builder, "grid_view_toggle")), TRUE);
+    gtk_stack_set_visible_child_name (GTK_STACK (gtk_builder_get_object (builder, "browser_stack")), "grid");
+    
+    // Set initial directory
+    GFile *initial_dir = NULL;
+    if (initial_folder_uri && *initial_folder_uri) {
+        initial_dir = g_file_new_for_uri (initial_folder_uri);
+    } else {
+        initial_dir = g_file_new_for_path (g_get_home_dir ());
+    }
+    navigate_to (data, initial_dir, TRUE);
+    g_object_unref (initial_dir);
+    
+    if (suggested_name && *suggested_name) {
+        gtk_entry_set_text (GTK_ENTRY (data->filename_entry), suggested_name);
+    }
+    
+    // Setup filter text
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (data->filter_combo), _("All Files"));
+    gtk_combo_box_set_active (GTK_COMBO_BOX (data->filter_combo), 0);
+    
+    return dialog;
+}
+
+GSList *
+nemo_file_chooser_dialog_get_selected_uris (GtkDialog *dialog)
+{
+    DialogData *data = g_object_get_data (G_OBJECT (dialog), "dialog-data");
+    if (!data)
+        return NULL;
+        
+    GSList *list = NULL;
+    GSList *l;
+    for (l = data->selected_uris; l != NULL; l = l->next) {
+        list = g_slist_append (list, g_strdup (l->data));
+    }
+    
+    if (data->action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER && list == NULL) {
+        if (data->current_folder) {
+            gchar *uri = g_file_get_uri (data->current_folder);
+            list = g_slist_append (list, uri);
+        }
+    }
+    
+    return list;
+}
+
+gchar *
+nemo_file_chooser_dialog_get_selected_uri (GtkDialog *dialog)
+{
+    DialogData *data = g_object_get_data (G_OBJECT (dialog), "dialog-data");
+    if (!data)
+        return NULL;
+        
+    if (data->selected_uri) {
+        return g_strdup (data->selected_uri);
+    }
+    
+    if (data->action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER && data->current_folder) {
+        return g_file_get_uri (data->current_folder);
+    }
+    
+    return NULL;
+}

--- a/src/nemo-file-chooser-dialog.c
+++ b/src/nemo-file-chooser-dialog.c
@@ -1341,6 +1341,9 @@ nemo_file_chooser_dialog_get_selected_uris (GtkDialog *dialog)
     if (!data)
         return NULL;
         
+    g_message ("nemo_file_chooser_dialog_get_selected_uris: action=%d, selected_uris_count=%d, current_folder=%p",
+               data->action, g_slist_length (data->selected_uris), data->current_folder);
+        
     GSList *list = NULL;
     GSList *l;
     for (l = data->selected_uris; l != NULL; l = l->next) {

--- a/src/nemo-file-chooser-dialog.c
+++ b/src/nemo-file-chooser-dialog.c
@@ -1148,10 +1148,12 @@ nemo_file_chooser_dialog_new (const gchar *title,
     data->select_multiple = select_multiple;
     data->show_hidden = FALSE;
     
-    if (action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER) {
-        GtkWidget *ok_btn = GTK_WIDGET (gtk_builder_get_object (builder, "ok_button"));
-        if (ok_btn) {
+    GtkWidget *ok_btn = GTK_WIDGET (gtk_builder_get_object (builder, "ok_button"));
+    if (ok_btn) {
+        if (action == GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER) {
             gtk_button_set_label (GTK_BUTTON (ok_btn), _("_Select"));
+        } else if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
+            gtk_button_set_label (GTK_BUTTON (ok_btn), _("_Save"));
         }
     }
     

--- a/src/nemo-file-chooser-dialog.h
+++ b/src/nemo-file-chooser-dialog.h
@@ -1,0 +1,19 @@
+/*
+ * nemo-file-chooser-dialog: Custom layout file picker dialog header
+ */
+
+#ifndef __NEMO_FILE_CHOOSER_DIALOG_H__
+#define __NEMO_FILE_CHOOSER_DIALOG_H__
+
+#include <gtk/gtk.h>
+
+GtkWidget * nemo_file_chooser_dialog_new (const gchar *title,
+                                          GtkFileChooserAction action,
+                                          gboolean select_multiple,
+                                          const gchar *initial_folder_uri,
+                                          const gchar *suggested_name);
+
+GSList * nemo_file_chooser_dialog_get_selected_uris (GtkDialog *dialog);
+gchar *  nemo_file_chooser_dialog_get_selected_uri  (GtkDialog *dialog);
+
+#endif /* __NEMO_FILE_CHOOSER_DIALOG_H__ */

--- a/src/nemo-main-application.c
+++ b/src/nemo-main-application.c
@@ -31,6 +31,7 @@
 #endif /* ENABLE_EMPTY_VIEW */
 
 #include "nemo-freedesktop-dbus.h"
+#include "nemo-file-chooser-dbus.h"
 #include "nemo-icon-view.h"
 #include "nemo-image-properties-page.h"
 #include "nemo-list-view.h"
@@ -107,6 +108,7 @@ struct _NemoMainApplicationPriv {
 
 	NemoDBusManager *dbus_manager;
 	NemoFreedesktopDBus *fdb_manager;
+	NemoFileChooserDBus *file_chooser_dbus;
 
 	gchar *geometry;
 };
@@ -792,6 +794,7 @@ nemo_main_application_finalize (GObject *object)
 
     g_clear_object (&application->priv->dbus_manager);
     g_clear_object (&application->priv->fdb_manager);
+    g_clear_object (&application->priv->file_chooser_dbus);
 
     free_search_helpers ();
 
@@ -1148,6 +1151,7 @@ nemo_main_application_continue_startup (NemoApplication *app)
 	/* create DBus manager */
 	self->priv->dbus_manager = nemo_dbus_manager_new ();
 	self->priv->fdb_manager = nemo_freedesktop_dbus_new ();
+	self->priv->file_chooser_dbus = nemo_file_chooser_dbus_new ();
 
     /* Check the user's ~/.config/nemo directory and post warnings
      * if there are problems.


### PR DESCRIPTION
## Overview & Rationale
Currently, Cinnamon environments running sandboxed Flatpaks or host applications rely on basic or external file chooser portals. These defaults lack visual coherence with the rest of the Cinnamon desktop and Nemo. 

This Pull Request implements a custom, fully-featured native file chooser dialog for Nemo, exported over D-Bus via the `org.Nemo.FileChooser` service. When paired with the accompanying changes in `xdg-desktop-portal-xapp`, this allows all application file-picking requests (from GitKraken, Web Browsers, Flatpaks, etc.) to use a premium, native-feeling Nemo file selection interface.

---

## Features Implemented

### 1. Unified Multi-Pane Layout
*   **Places Sidebar**: Integrates the standard Places sidebar (`GtkPlacesSidebar`), ensuring user bookmarks, network mounts, removable media, and recent paths are instantly accessible.
*   **Main Browser Stack**: A dynamic layout supporting three view modes:
    *   **Grid View (Icons)**: High-fidelity layout with custom large icons.
    *   **List View (Columns)**: Standard layout showing file details.
    *   **Compact View**: Horizontal icon flow for rapid list traversal.
*   **Dynamic Preview Pane**: A sidebar on the right displaying real-time previews for selected files, including:
    *   Image/video metadata (dimensions, size).
    *   High-quality thumbnail previews retrieved asynchronously via the Freedesktop.org thumbnail cache specifications.

### 2. Directory Selection (`SELECT_FOLDER` / `GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER`)
*   **Targeted Folder Listings**: When operating in directory-selection mode, files are automatically hidden from the main browser list so users see and navigate only folders.
*   **Action Button Label**: The main accept action dynamically switches its label to `_Select` rather than `_Open`.
*   **Hierarchical Fallback Selection**: If a user is inside their target directory (e.g. `/home/user/Projects/nemo`) and clicks **Select** without highlighting a specific sub-folder, the dialog correctly falls back and returns the URI of the current folder.

### 3. Navigation & Context Enhancements
*   **Up Button**: Placed on the header bar to navigate to the parent folder. Its sensitivity is dynamically calculated (disabled at the system root `/`).
*   **Interactive Location Bar**: Switches between a clickable breadcrumb path and a text entry box via the edit button or `Ctrl+L` shortcut. Supports `Escape` to return to breadcrumbs.
*   **Create Folder Modal**: A dedicated button on the header and options in the context menu to create folders instantly.
*   **Header Sorting (List View)**: Columns (Name, Size, Type, Date Modified) support clicking to sort. Folders are always grouped before files. Sorting is paused during list loads to avoid UI freezes.
*   **Column Customization**: Right-clicking the List View header exposes a context menu to toggle the visibility of the Size, Type, and Date Modified columns.
*   **Context Menus**: Right-clicking the file browser area provides options to toggle hidden files, customize sorting options, refresh the directory, copy locations, and create folders.
*   **Keyboard Shortcuts**: Fully maps `Ctrl+H` to toggle hidden files and `Ctrl+L` to edit the location path text.

### 4. D-Bus Daemon Integration
*   Updated the `org.Nemo.FileChooser` D-Bus XML specification to support folder selection:
    *   `OpenFile` method signature updated to `(sasbbs)` to accept the `directory` boolean.
*   Fixed the dialog response matching in `nemo-file-chooser-dbus.c` to accept both `GTK_RESPONSE_ACCEPT` (-3) and `GTK_RESPONSE_OK` (-5), resolving empty return values when using the Glade-defined `ok_button`.

---

## Testing Verification
1.  **D-Bus Interface**: Invoked using custom Python test scripts calling the desktop portal.
2.  **Directory Picking**: Verified directory selection returns the correct path structure to the calling process.
3.  **Application Test**: Verified GitKraken (host Electron app) successfully uses this dialog to open local repositories via the portal.