### PR TITLE
nemo-file: fall back to custom-icon-name when the custom-icon path no longer exists

### DIFF
--- a/libnemo-private/nemo-file.c
+++ b/libnemo-private/nemo-file.c
@@ -4386,7 +4386,20 @@ get_custom_icon (NemoFile *file)
 
 	if (custom_icon_uri) {
 		icon_file = g_file_new_for_uri (custom_icon_uri);
-		icon = g_file_icon_new (icon_file);
+
+		/* g_file_icon_new() succeeds even when the file it points at no longer
+		 * exists, so a stale custom-icon path would win here and then fail to
+		 * render, silently masking the custom-icon-name below and leaving the
+		 * file with no custom icon at all. Only honour the path if it still
+		 * resolves, so that moving or renaming a custom icon degrades to the
+		 * icon name instead of failing silently. Existence is checked for
+		 * native files only, to avoid blocking I/O on remote locations.
+		 */
+		if (!g_file_is_native (icon_file) ||
+		    g_file_query_exists (icon_file, NULL)) {
+			icon = g_file_icon_new (icon_file);
+		}
+
 		g_object_unref (icon_file);
 		g_free (custom_icon_uri);
 	}


### PR DESCRIPTION
A custom icon set by **path** silently wins over a valid custom icon **name**, even when the path points at a file that no longer exists — so the item ends up with **no custom icon at all**, with no error and no fallback.

### Cause

In `get_custom_icon()` (`libnemo-private/nemo-file.c`):

```c
custom_icon_uri = get_custom_icon_metadata_uri (file);

if (custom_icon_uri) {
        icon_file = g_file_new_for_uri (custom_icon_uri);
        icon = g_file_icon_new (icon_file);   /* succeeds even if the file is GONE */
        ...
}

if (icon == NULL) {                            /* so this is never reached */
        custom_icon_name = get_custom_icon_metadata_name (file);
        ...
}
```

`g_file_icon_new()` does not touch the filesystem, so it happily returns a valid `GFileIcon` for a path that no longer resolves. That `GIcon` is non-NULL, so the `custom-icon-name` branch below is never taken. The `GFileIcon` then fails to load at draw time and the item simply shows no custom icon.

Preferring the path over the name is intentional and unchanged here — the bug is that a **dead** path still wins.

### Impact

Reorganising an icon collection (moving/renaming the image files) silently blanks the custom icon of every file and folder that referenced them. There is no error, no warning, and no fallback — including for items that *also* have a perfectly good `custom-icon-name` stored, which is simply never consulted.

I hit this with 26 folders whose icons went blank after the icon files were moved. Several of them had a valid `custom-icon-name` in their metadata the entire time; it was never used.

### Fix

Skip a `custom-icon` path that no longer resolves, so the existing `custom-icon-name` fallback is reached. Existence is checked for **native files only**, so no blocking I/O is introduced for remote locations.

### Reproducing

```sh
gio set -t string  DIR metadata::custom-icon-name  folder-music          # valid theme icon
gio set -t string  DIR metadata::custom-icon       file:///does/not/exist.png
```

- **Before:** DIR shows no custom icon — the valid `custom-icon-name` is ignored.
- **After:** DIR shows `folder-music`.

Verified against the two code paths with identical metadata: the old logic builds a `GFileIcon` that renders nothing; the new logic skips the dead path and resolves the themed icon.