### PR TITLE
Implement checkboxes to select multiple files/folders for desktop and touch

### DIFF
--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1224,6 +1224,23 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="show_selection_checkboxes_always_checkbutton">
+                                            <property name="label" translatable="yes">Touch mode: Always show selection checkboxes</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <property name="margin-start">18</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="ignore_view_metadata_checkbutton">
                                             <property name="label" translatable="yes">Ignore per-folder view preferences</property>
                                             <property name="visible">True</property>
@@ -1236,7 +1253,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">2</property>
+                                            <property name="position">3</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1252,7 +1269,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">3</property>
+                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1286,7 +1303,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">5</property>
+                                            <property name="position">6</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1302,7 +1319,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">6</property>
+                                            <property name="position">7</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1208,6 +1208,22 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="show_selection_checkboxes_checkbutton">
+                                            <property name="label" translatable="yes">Enable item selection checkboxes</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="ignore_view_metadata_checkbutton">
                                             <property name="label" translatable="yes">Ignore per-folder view preferences</property>
                                             <property name="visible">True</property>
@@ -1220,7 +1236,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1236,7 +1252,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">2</property>
+                                            <property name="position">3</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1253,7 +1269,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">3</property>
+                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1270,7 +1286,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">4</property>
+                                            <property name="position">5</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1286,7 +1302,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="position">5</property>
+                                            <property name="position">6</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/gresources/nemo-file-management-properties.glade
+++ b/gresources/nemo-file-management-properties.glade
@@ -1286,7 +1286,7 @@ along with .  If not, see <http://www.gnu.org/licenses/>.
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
                                             <property name="padding">3</property>
-                                            <property name="position">4</property>
+                                            <property name="position">5</property>
                                           </packing>
                                         </child>
                                         <child>

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -146,6 +146,7 @@ typedef enum
 #define NEMO_PREFERENCES_START_WITH_DUAL_PANE "start-with-dual-pane"
 #define NEMO_PREFERENCES_RESTORE_TABS_ON_STARTUP "restore-tabs-on-startup"
 #define NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES "show-selection-checkboxes"
+#define NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES_ALWAYS "show-selection-checkboxes-always"
 #define NEMO_PREFERENCES_IGNORE_VIEW_METADATA "ignore-view-metadata"
 #define NEMO_PREFERENCES_SHOW_BOOKMARKS_IN_TO_MENUS "show-bookmarks-in-to-menus"
 #define NEMO_PREFERENCES_SHOW_PLACES_IN_TO_MENUS "show-places-in-to-menus"

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -145,6 +145,7 @@ typedef enum
 
 #define NEMO_PREFERENCES_START_WITH_DUAL_PANE "start-with-dual-pane"
 #define NEMO_PREFERENCES_RESTORE_TABS_ON_STARTUP "restore-tabs-on-startup"
+#define NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES "show-selection-checkboxes"
 #define NEMO_PREFERENCES_IGNORE_VIEW_METADATA "ignore-view-metadata"
 #define NEMO_PREFERENCES_SHOW_BOOKMARKS_IN_TO_MENUS "show-bookmarks-in-to-menus"
 #define NEMO_PREFERENCES_SHOW_PLACES_IN_TO_MENUS "show-places-in-to-menus"

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1369,13 +1369,13 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 		return;
 	}
 
-	if (!icon_item->details->is_prelit) {
+	selected = icon_item->details->is_highlighted_for_selection;
+	if (!icon_item->details->is_prelit && !selected) {
 		return;
 	}
 
 	widget = GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas);
 	pixels_per_unit = EEL_CANVAS_ITEM (icon_item)->canvas->pixels_per_unit;
-	selected = icon_item->details->is_highlighted_for_selection;
 	checkbox_pixbuf = get_selection_checkbox_pixbuf (widget, selected);
 	if (checkbox_pixbuf == NULL) {
 		return;

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -51,6 +51,8 @@
 /* gap between bottom of icon and start of text box */
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
+#define SELECTION_CHECKBOX_SIZE 12
+#define SELECTION_CHECKBOX_MARGIN 2
 
 
 /* special text height handling
@@ -174,6 +176,9 @@ static void     draw_pixbuf                          (GdkPixbuf                 
 						      cairo_t                       *cr,
 						      int                            x,
 						      int                            y);
+static void     draw_selection_checkbox              (NemoIconCanvasItem            *item,
+							      cairo_t                       *cr,
+							      EelIRect                       icon_rect);
 static PangoLayout *get_label_layout                 (PangoLayout                  **layout,
 						      NemoIconCanvasItem        *item,
 						      const char                    *text);
@@ -1288,6 +1293,88 @@ draw_pixbuf (GdkPixbuf *pixbuf,
         cairo_restore (cr);
 }
 
+static void
+draw_selection_checkbox (NemoIconCanvasItem *icon_item,
+			      cairo_t *cr,
+			      EelIRect icon_rect)
+{
+	GtkWidget *widget;
+	GtkStyleContext *context;
+	GdkRGBA border_color;
+	GdkRGBA fill_color;
+	GdkRGBA check_color;
+	double pixels_per_unit;
+	double checkbox_size;
+	double inset;
+	double checkbox_x;
+	double checkbox_y;
+	double check_x0;
+	double check_y0;
+	double check_x1;
+	double check_y1;
+	double check_x2;
+	double check_y2;
+	gboolean selected;
+
+	widget = GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas);
+	context = gtk_widget_get_style_context (widget);
+	pixels_per_unit = EEL_CANVAS_ITEM (icon_item)->canvas->pixels_per_unit;
+	checkbox_size = SELECTION_CHECKBOX_SIZE / pixels_per_unit;
+	checkbox_x = icon_rect.x0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
+	checkbox_y = icon_rect.y0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
+	selected = icon_item->details->is_highlighted_for_selection;
+	inset = MAX (1.0, 1.0 / pixels_per_unit);
+
+	gtk_style_context_get_border_color (context,
+					    selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
+					    &border_color);
+	gtk_style_context_get_background_color (context,
+						   selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
+						   &fill_color);
+	gtk_style_context_get_color (context,
+					 selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
+					 &check_color);
+
+	gtk_style_context_save (context);
+	gtk_style_context_set_state (context,
+				    selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL);
+
+	gdk_cairo_set_source_rgba (cr, &fill_color);
+	cairo_rectangle (cr,
+			 checkbox_x,
+			 checkbox_y,
+			 checkbox_size,
+			 checkbox_size);
+	cairo_fill_preserve (cr);
+
+	gdk_cairo_set_source_rgba (cr, &border_color);
+	cairo_set_line_width (cr, inset);
+	cairo_stroke (cr);
+
+	if (selected) {
+		double tick_width;
+
+		tick_width = MAX (1.0, 2.0 / pixels_per_unit);
+		cairo_set_line_width (cr, tick_width);
+		cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
+		gdk_cairo_set_source_rgba (cr, &check_color);
+
+		check_x0 = checkbox_x + checkbox_size * 0.22;
+		check_y0 = checkbox_y + checkbox_size * 0.55;
+		check_x1 = checkbox_x + checkbox_size * 0.42;
+		check_y1 = checkbox_y + checkbox_size * 0.72;
+		check_x2 = checkbox_x + checkbox_size * 0.78;
+		check_y2 = checkbox_y + checkbox_size * 0.30;
+
+		cairo_move_to (cr, check_x0, check_y0);
+		cairo_line_to (cr, check_x1, check_y1);
+		cairo_line_to (cr, check_x2, check_y2);
+		cairo_stroke (cr);
+	}
+
+	gtk_style_context_restore (context);
+}
+
 /* shared code to highlight or dim the passed-in pixbuf */
 static cairo_surface_t *
 real_map_surface (NemoIconCanvasItem *icon_item)
@@ -1386,6 +1473,8 @@ nemo_icon_canvas_item_draw (EelCanvasItem *item,
                              temp_surface,
                              icon_rect.x0, icon_rect.y0);
     cairo_surface_destroy (temp_surface);
+
+	draw_selection_checkbox (icon_item, cr, icon_rect);
 
 	/* Draw stretching handles (if necessary). */
 	draw_stretch_handles (icon_item, cr, &icon_rect);
@@ -1986,6 +2075,31 @@ nemo_icon_canvas_item_hit_test_rectangle (NemoIconCanvasItem *item, EelIRect can
 	g_return_val_if_fail (NEMO_IS_ICON_CANVAS_ITEM (item), FALSE);
 
 	return hit_test (item, canvas_rect);
+}
+
+gboolean
+nemo_icon_canvas_item_hit_test_selection_checkbox (NemoIconCanvasItem *item,
+					   gdouble world_x,
+					   gdouble world_y)
+{
+	EelDRect icon_rect;
+	double pixels_per_unit;
+	double checkbox_size;
+	double checkbox_x;
+	double checkbox_y;
+
+	g_return_val_if_fail (NEMO_IS_ICON_CANVAS_ITEM (item), FALSE);
+
+	icon_rect = nemo_icon_canvas_item_get_icon_rectangle (item);
+	pixels_per_unit = EEL_CANVAS_ITEM (item)->canvas->pixels_per_unit;
+	checkbox_size = SELECTION_CHECKBOX_SIZE / pixels_per_unit;
+	checkbox_x = icon_rect.x0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
+	checkbox_y = icon_rect.y0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
+
+	return world_x >= checkbox_x &&
+	       world_x <= checkbox_x + checkbox_size &&
+	       world_y >= checkbox_y &&
+	       world_y <= checkbox_y + checkbox_size;
 }
 
 const char *

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1316,6 +1316,10 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 	double check_y2;
 	gboolean selected;
 
+	if (!icon_item->details->is_prelit) {
+		return;
+	}
+
 	widget = GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas);
 	context = gtk_widget_get_style_context (widget);
 	pixels_per_unit = EEL_CANVAS_ITEM (icon_item)->canvas->pixels_per_unit;

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -51,7 +51,6 @@
 /* gap between bottom of icon and start of text box */
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
-#define SELECTION_CHECKBOX_SIZE 12
 #define SELECTION_CHECKBOX_MARGIN 2
 
 
@@ -179,6 +178,9 @@ static void     draw_pixbuf                          (GdkPixbuf                 
 static void     draw_selection_checkbox              (NemoIconCanvasItem            *item,
 							      cairo_t                       *cr,
 							      EelIRect                       icon_rect);
+static double   get_selection_checkbox_size           (GtkWidget                     *widget);
+static GdkPixbuf *get_selection_checkbox_pixbuf       (GtkWidget                     *widget,
+							      gboolean                       selected);
 static PangoLayout *get_label_layout                 (PangoLayout                  **layout,
 						      NemoIconCanvasItem        *item,
 						      const char                    *text);
@@ -1293,29 +1295,73 @@ draw_pixbuf (GdkPixbuf *pixbuf,
         cairo_restore (cr);
 }
 
+static double
+get_selection_checkbox_size (GtkWidget *widget)
+{
+	int width = 0;
+	int height = 0;
+
+	if (gtk_icon_size_lookup_for_settings (gtk_widget_get_settings (widget),
+					       GTK_ICON_SIZE_MENU,
+					       &width,
+					       &height)) {
+		return MAX (width, height);
+	}
+
+	return 16.0;
+}
+
+static GdkPixbuf *
+get_selection_checkbox_pixbuf (GtkWidget *widget,
+				      gboolean selected)
+{
+	GtkIconTheme *icon_theme;
+	GtkStyleContext *context;
+	GtkIconInfo *icon_info;
+	GdkRGBA fg_color;
+	GdkPixbuf *pixbuf;
+	int icon_size;
+	const char *icon_name;
+	GError *error = NULL;
+	gboolean was_symbolic = FALSE;
+
+	context = gtk_widget_get_style_context (widget);
+	icon_theme = gtk_icon_theme_get_for_screen (gtk_widget_get_screen (widget));
+	icon_size = (int) get_selection_checkbox_size (widget);
+	icon_name = selected ? "checkbox-checked-symbolic" : "checkbox-symbolic";
+
+	icon_info = gtk_icon_theme_lookup_icon (icon_theme,
+						 icon_name,
+						 icon_size,
+						 GTK_ICON_LOOKUP_FORCE_SIZE);
+	if (icon_info == NULL) {
+		return NULL;
+	}
+
+	gtk_style_context_get_color (context, GTK_STATE_FLAG_SELECTED, &fg_color);
+	pixbuf = gtk_icon_info_load_symbolic_for_context (icon_info,
+							  context,
+							  &was_symbolic,
+							  &error);
+	g_object_unref (icon_info);
+
+	if (pixbuf == NULL) {
+		g_clear_error (&error);
+	}
+
+	return pixbuf;
+}
+
 static void
 draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 			      cairo_t *cr,
 			      EelIRect icon_rect)
 {
 	GtkWidget *widget;
-	GtkStyleContext *context;
-	GdkRGBA border_color;
-	GdkRGBA fill_color;
-	GdkRGBA check_color;
 	double pixels_per_unit;
-	double checkbox_size;
-	double inset;
-	double checkbox_x;
-	double checkbox_y;
-	double check_x0;
-	double check_y0;
-	double check_x1;
-	double check_y1;
-	double check_x2;
-	double check_y2;
 	gboolean selected;
 	gboolean show_selection_checkboxes;
+	GdkPixbuf *checkbox_pixbuf;
 
 	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
 						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
@@ -1328,62 +1374,19 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 	}
 
 	widget = GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas);
-	context = gtk_widget_get_style_context (widget);
 	pixels_per_unit = EEL_CANVAS_ITEM (icon_item)->canvas->pixels_per_unit;
-	checkbox_size = SELECTION_CHECKBOX_SIZE / pixels_per_unit;
-	checkbox_x = icon_rect.x0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
-	checkbox_y = icon_rect.y0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
 	selected = icon_item->details->is_highlighted_for_selection;
-	inset = MAX (1.0, 1.0 / pixels_per_unit);
-
-	gtk_style_context_get_border_color (context,
-					    selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
-					    &border_color);
-	gtk_style_context_get_background_color (context,
-						   selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
-						   &fill_color);
-	gtk_style_context_get_color (context,
-					 selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL,
-					 &check_color);
-
-	gtk_style_context_save (context);
-	gtk_style_context_set_state (context,
-				    selected ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_NORMAL);
-
-	gdk_cairo_set_source_rgba (cr, &fill_color);
-	cairo_rectangle (cr,
-			 checkbox_x,
-			 checkbox_y,
-			 checkbox_size,
-			 checkbox_size);
-	cairo_fill_preserve (cr);
-
-	gdk_cairo_set_source_rgba (cr, &border_color);
-	cairo_set_line_width (cr, inset);
-	cairo_stroke (cr);
-
-	if (selected) {
-		double tick_width;
-
-		tick_width = MAX (1.0, 2.0 / pixels_per_unit);
-		cairo_set_line_width (cr, tick_width);
-		cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
-		gdk_cairo_set_source_rgba (cr, &check_color);
-
-		check_x0 = checkbox_x + checkbox_size * 0.22;
-		check_y0 = checkbox_y + checkbox_size * 0.55;
-		check_x1 = checkbox_x + checkbox_size * 0.42;
-		check_y1 = checkbox_y + checkbox_size * 0.72;
-		check_x2 = checkbox_x + checkbox_size * 0.78;
-		check_y2 = checkbox_y + checkbox_size * 0.30;
-
-		cairo_move_to (cr, check_x0, check_y0);
-		cairo_line_to (cr, check_x1, check_y1);
-		cairo_line_to (cr, check_x2, check_y2);
-		cairo_stroke (cr);
+	checkbox_pixbuf = get_selection_checkbox_pixbuf (widget, selected);
+	if (checkbox_pixbuf == NULL) {
+		return;
 	}
 
-	gtk_style_context_restore (context);
+	draw_pixbuf (checkbox_pixbuf,
+		     cr,
+		     icon_rect.x0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit),
+		     icon_rect.y0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit));
+	g_object_unref (checkbox_pixbuf);
+
 }
 
 /* shared code to highlight or dim the passed-in pixbuf */
@@ -2110,7 +2113,7 @@ nemo_icon_canvas_item_hit_test_selection_checkbox (NemoIconCanvasItem *item,
 
 	icon_rect = nemo_icon_canvas_item_get_icon_rectangle (item);
 	pixels_per_unit = EEL_CANVAS_ITEM (item)->canvas->pixels_per_unit;
-	checkbox_size = SELECTION_CHECKBOX_SIZE / pixels_per_unit;
+	checkbox_size = get_selection_checkbox_size (GTK_WIDGET (EEL_CANVAS_ITEM (item)->canvas)) / pixels_per_unit;
 	checkbox_x = icon_rect.x0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
 	checkbox_y = icon_rect.y0 + (SELECTION_CHECKBOX_MARGIN / pixels_per_unit);
 

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -52,7 +52,7 @@
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
 #define SELECTION_CHECKBOX_MARGIN 2
-#define SELECTION_CHECKBOX_SIZE 22.0
+#define SELECTION_CHECKBOX_SIZE 20.0
 
 
 /* special text height handling

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1361,6 +1361,7 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 	double pixels_per_unit;
 	gboolean selected;
 	gboolean show_selection_checkboxes;
+	gboolean show_selection_checkboxes_always;
 	GdkPixbuf *checkbox_pixbuf;
 
 	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
@@ -1370,7 +1371,9 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 	}
 
 	selected = icon_item->details->is_highlighted_for_selection;
-	if (!icon_item->details->is_prelit && !selected) {
+	show_selection_checkboxes_always = g_settings_get_boolean (nemo_preferences,
+						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES_ALWAYS);
+	if (!show_selection_checkboxes_always && !icon_item->details->is_prelit && !selected) {
 		return;
 	}
 

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -52,6 +52,7 @@
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
 #define SELECTION_CHECKBOX_MARGIN 2
+#define SELECTION_CHECKBOX_SCALE 1.5
 
 
 /* special text height handling
@@ -1305,10 +1306,10 @@ get_selection_checkbox_size (GtkWidget *widget)
 					       GTK_ICON_SIZE_MENU,
 					       &width,
 					       &height)) {
-		return MAX (width, height);
+		return MAX (width, height) * SELECTION_CHECKBOX_SCALE;
 	}
 
-	return 16.0;
+	return 16.0 * SELECTION_CHECKBOX_SCALE;
 }
 
 static GdkPixbuf *

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1315,6 +1315,13 @@ draw_selection_checkbox (NemoIconCanvasItem *icon_item,
 	double check_x2;
 	double check_y2;
 	gboolean selected;
+	gboolean show_selection_checkboxes;
+
+	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
+						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
+	if (!show_selection_checkboxes) {
+		return;
+	}
 
 	if (!icon_item->details->is_prelit) {
 		return;
@@ -2091,8 +2098,15 @@ nemo_icon_canvas_item_hit_test_selection_checkbox (NemoIconCanvasItem *item,
 	double checkbox_size;
 	double checkbox_x;
 	double checkbox_y;
+	gboolean show_selection_checkboxes;
 
 	g_return_val_if_fail (NEMO_IS_ICON_CANVAS_ITEM (item), FALSE);
+
+	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
+						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
+	if (!show_selection_checkboxes) {
+		return FALSE;
+	}
 
 	icon_rect = nemo_icon_canvas_item_get_icon_rectangle (item);
 	pixels_per_unit = EEL_CANVAS_ITEM (item)->canvas->pixels_per_unit;

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -1309,7 +1309,6 @@ get_selection_checkbox_pixbuf (GtkWidget *widget,
 	GtkIconTheme *icon_theme;
 	GtkStyleContext *context;
 	GtkIconInfo *icon_info;
-	GdkRGBA fg_color;
 	GdkPixbuf *pixbuf;
 	int icon_size;
 	const char *icon_name;
@@ -1329,7 +1328,6 @@ get_selection_checkbox_pixbuf (GtkWidget *widget,
 		return NULL;
 	}
 
-	gtk_style_context_get_color (context, GTK_STATE_FLAG_SELECTED, &fg_color);
 	pixbuf = gtk_icon_info_load_symbolic_for_context (icon_info,
 							  context,
 							  &was_symbolic,

--- a/libnemo-private/nemo-icon-canvas-item.c
+++ b/libnemo-private/nemo-icon-canvas-item.c
@@ -52,7 +52,7 @@
 #define LABEL_OFFSET_BESIDES 3
 #define LABEL_LINE_SPACING 0
 #define SELECTION_CHECKBOX_MARGIN 2
-#define SELECTION_CHECKBOX_SCALE 1.5
+#define SELECTION_CHECKBOX_SIZE 22.0
 
 
 /* special text height handling
@@ -1299,17 +1299,7 @@ draw_pixbuf (GdkPixbuf *pixbuf,
 static double
 get_selection_checkbox_size (GtkWidget *widget)
 {
-	int width = 0;
-	int height = 0;
-
-	if (gtk_icon_size_lookup_for_settings (gtk_widget_get_settings (widget),
-					       GTK_ICON_SIZE_MENU,
-					       &width,
-					       &height)) {
-		return MAX (width, height) * SELECTION_CHECKBOX_SCALE;
-	}
-
-	return 16.0 * SELECTION_CHECKBOX_SCALE;
+	return SELECTION_CHECKBOX_SIZE;
 }
 
 static GdkPixbuf *

--- a/libnemo-private/nemo-icon-canvas-item.h
+++ b/libnemo-private/nemo-icon-canvas-item.h
@@ -74,6 +74,9 @@ void        nemo_icon_canvas_item_set_emblems              (NemoIconCanvasItem  
 								GList                        *emblem_pixbufs);
 void        nemo_icon_canvas_item_set_show_stretch_handles (NemoIconCanvasItem       *item,
 								gboolean                      show_stretch_handles);
+gboolean    nemo_icon_canvas_item_hit_test_selection_checkbox (NemoIconCanvasItem       *item,
+								gdouble                       world_x,
+								gdouble                       world_y);
 double      nemo_icon_canvas_item_get_max_text_width       (NemoIconCanvasItem       *item);
 const char *nemo_icon_canvas_item_get_editable_text        (NemoIconCanvasItem       *icon_item);
 void        nemo_icon_canvas_item_set_renaming             (NemoIconCanvasItem       *icon_item,

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -217,6 +217,12 @@ tooltip_prefs_changed_callback (NemoIconContainer *container)
     nemo_icon_container_request_update_all (container);
 }
 
+static void
+selection_checkboxes_prefs_changed_callback (NemoIconContainer *container)
+{
+    gtk_widget_queue_draw (GTK_WIDGET (container));
+}
+
 /* Functions dealing with NemoIcons.  */
 
 static gboolean
@@ -2766,6 +2772,9 @@ finalize (GObject *object)
     g_signal_handlers_disconnect_by_func (nemo_preferences,
                                           tooltip_prefs_changed_callback,
                                           object);
+    g_signal_handlers_disconnect_by_func (nemo_preferences,
+                                          selection_checkboxes_prefs_changed_callback,
+                                          object);
 
 	g_hash_table_destroy (details->icon_set);
 	details->icon_set = NULL;
@@ -5009,6 +5018,16 @@ nemo_icon_container_init (NemoIconContainer *container)
     g_signal_connect_swapped (nemo_preferences,
                               "changed::" NEMO_PREFERENCES_TOOLTIP_FULL_PATH,
                               G_CALLBACK (tooltip_prefs_changed_callback),
+                              container);
+
+    g_signal_connect_swapped (nemo_preferences,
+                              "changed::" NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES,
+                              G_CALLBACK (selection_checkboxes_prefs_changed_callback),
+                              container);
+
+    g_signal_connect_swapped (nemo_preferences,
+                              "changed::" NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES_ALWAYS,
+                              G_CALLBACK (selection_checkboxes_prefs_changed_callback),
                               container);
 
     container->details->show_desktop_tooltips = g_settings_get_boolean (nemo_preferences,

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5225,6 +5225,7 @@ clicked_on_selection_checkbox (NemoIconContainer *container,
 				 NemoIcon *icon,
 				 GdkEventButton *event)
 {
+	gboolean show_selection_checkboxes;
 	double raw_x;
 	double raw_y;
 	double world_x;
@@ -5237,6 +5238,12 @@ clicked_on_selection_checkbox (NemoIconContainer *container,
 
 	g_return_val_if_fail (NEMO_IS_ICON_CONTAINER (container), FALSE);
 	g_return_val_if_fail (icon != NULL, FALSE);
+
+	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
+						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
+	if (!show_selection_checkboxes) {
+		return FALSE;
+	}
 
 	raw_x = event->x;
 	raw_y = event->y;

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5220,6 +5220,44 @@ handle_icon_button_press (NemoIconContainer *container,
 	return TRUE;
 }
 
+static gboolean
+clicked_on_selection_checkbox (NemoIconContainer *container,
+				 NemoIcon *icon,
+				 GdkEventButton *event)
+{
+	double raw_x;
+	double raw_y;
+	double world_x;
+	double world_y;
+	EelDRect icon_rect;
+	double pixels_per_unit;
+	double checkbox_size;
+	double checkbox_x;
+	double checkbox_y;
+
+	g_return_val_if_fail (NEMO_IS_ICON_CONTAINER (container), FALSE);
+	g_return_val_if_fail (icon != NULL, FALSE);
+
+	raw_x = event->x;
+	raw_y = event->y;
+	eel_canvas_window_to_world (EEL_CANVAS (container), event->x, event->y,
+				   &world_x, &world_y);
+	if (nemo_icon_canvas_item_hit_test_selection_checkbox (icon->item, world_x, world_y)) {
+		return TRUE;
+	}
+
+	icon_rect = nemo_icon_canvas_item_get_icon_rectangle (icon->item);
+	pixels_per_unit = EEL_CANVAS (container)->pixels_per_unit;
+	checkbox_size = 12 / pixels_per_unit;
+	checkbox_x = icon_rect.x0 + (2 / pixels_per_unit);
+	checkbox_y = icon_rect.y0 + (2 / pixels_per_unit);
+
+	return raw_x >= checkbox_x &&
+	       raw_x <= checkbox_x + checkbox_size &&
+	       raw_y >= checkbox_y &&
+	       raw_y <= checkbox_y + checkbox_size;
+}
+
 static int
 item_event_callback (EelCanvasItem *item,
 		     GdkEvent *event,
@@ -5234,6 +5272,13 @@ item_event_callback (EelCanvasItem *item,
 	g_assert (icon != NULL);
 
     if (event->type == GDK_BUTTON_PRESS) {
+		if (clicked_on_selection_checkbox (container, icon, &event->button)) {
+			icon_toggle_selected (container, icon);
+			g_signal_emit (container,
+					   signals[SELECTION_CHANGED], 0);
+			return TRUE;
+		}
+
         if (handle_icon_button_press (container, icon, &event->button)) {
 			/* Stop the event from being passed along further. Returning
 			 * TRUE ain't enough.

--- a/libnemo-private/nemo-icon-container.c
+++ b/libnemo-private/nemo-icon-container.c
@@ -5244,44 +5244,21 @@ clicked_on_selection_checkbox (NemoIconContainer *container,
 				 NemoIcon *icon,
 				 GdkEventButton *event)
 {
-	gboolean show_selection_checkboxes;
-	double raw_x;
-	double raw_y;
 	double world_x;
 	double world_y;
-	EelDRect icon_rect;
-	double pixels_per_unit;
-	double checkbox_size;
-	double checkbox_x;
-	double checkbox_y;
 
 	g_return_val_if_fail (NEMO_IS_ICON_CONTAINER (container), FALSE);
 	g_return_val_if_fail (icon != NULL, FALSE);
 
-	show_selection_checkboxes = g_settings_get_boolean (nemo_preferences,
-						   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
-	if (!show_selection_checkboxes) {
+	if (!g_settings_get_boolean (nemo_preferences,
+				     NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES)) {
 		return FALSE;
 	}
 
-	raw_x = event->x;
-	raw_y = event->y;
 	eel_canvas_window_to_world (EEL_CANVAS (container), event->x, event->y,
 				   &world_x, &world_y);
-	if (nemo_icon_canvas_item_hit_test_selection_checkbox (icon->item, world_x, world_y)) {
-		return TRUE;
-	}
 
-	icon_rect = nemo_icon_canvas_item_get_icon_rectangle (icon->item);
-	pixels_per_unit = EEL_CANVAS (container)->pixels_per_unit;
-	checkbox_size = 12 / pixels_per_unit;
-	checkbox_x = icon_rect.x0 + (2 / pixels_per_unit);
-	checkbox_y = icon_rect.y0 + (2 / pixels_per_unit);
-
-	return raw_x >= checkbox_x &&
-	       raw_x <= checkbox_x + checkbox_size &&
-	       raw_y >= checkbox_y &&
-	       raw_y <= checkbox_y + checkbox_size;
+	return nemo_icon_canvas_item_hit_test_selection_checkbox (icon->item, world_x, world_y);
 }
 
 static int

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -351,6 +351,11 @@
       <summary>Restore the previous window tabs on startup</summary>
       <description>If set to true, Nemo will restore the last saved window tab state when launched without explicit locations.</description>
     </key>
+    <key name="show-selection-checkboxes" type="b">
+      <default>true</default>
+      <summary>Enable item selection checkboxes</summary>
+      <description>If set to true, Nemo will show clickable checkboxes on hovered items in icon and compact views, and beside all items in list view to make mouse-only multi-selection easier.</description>
+    </key>
     <key name="ignore-view-metadata" type="b">
       <default>false</default>
       <summary>Whether to ignore folder metadata for view zoom levels and layouts</summary>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -354,7 +354,12 @@
     <key name="show-selection-checkboxes" type="b">
       <default>false</default>
       <summary>Enable item selection checkboxes</summary>
-      <description>If set to true, Nemo will show clickable checkboxes on hovered items in icon and compact views, and beside all items in list view to make mouse-only multi-selection easier.</description>
+      <description>If set to true, Nemo will show clickable checkboxes on items in icon and compact views, and beside all items in list view to make mouse-only multi-selection easier.</description>
+    </key>
+    <key name="show-selection-checkboxes-always" type="b">
+      <default>false</default>
+      <summary>Always show item selection checkboxes</summary>
+      <description>If set to true, Nemo will always show item selection checkboxes in icon and compact views instead of showing them only for selected or hovered items.</description>
     </key>
     <key name="ignore-view-metadata" type="b">
       <default>false</default>

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -352,7 +352,7 @@
       <description>If set to true, Nemo will restore the last saved window tab state when launched without explicit locations.</description>
     </key>
     <key name="show-selection-checkboxes" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Enable item selection checkboxes</summary>
       <description>If set to true, Nemo will show clickable checkboxes on hovered items in icon and compact views, and beside all items in list view to make mouse-only multi-selection easier.</description>
     </key>

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -101,6 +101,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_START_WITH_DUAL_PANE_WIDGET "start_with_dual_pane_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_RESTORE_TABS_ON_STARTUP_WIDGET "restore_tabs_on_startup_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_WIDGET "show_selection_checkboxes_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_IN_TO_MENUS_WIDGET "places_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_SHOW_THUMBNAILS_WIDGET "inherit_show_thumbnails_checkbutton"
@@ -1075,6 +1076,10 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET,
                        NEMO_PREFERENCES_IGNORE_VIEW_METADATA);
+
+	bind_builder_bool (builder, nemo_preferences,
+					   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_WIDGET,
+					   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET,

--- a/src/nemo-file-management-properties.c
+++ b/src/nemo-file-management-properties.c
@@ -102,6 +102,7 @@
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_RESTORE_TABS_ON_STARTUP_WIDGET "restore_tabs_on_startup_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_IGNORE_VIEW_METADATA_WIDGET "ignore_view_metadata_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_WIDGET "show_selection_checkboxes_checkbutton"
+#define NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_ALWAYS_WIDGET "show_selection_checkboxes_always_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET "bookmarks_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_PLACES_IN_TO_MENUS_WIDGET "places_in_to_checkbutton"
 #define NEMO_FILE_MANAGEMENT_PROPERTIES_INHERIT_SHOW_THUMBNAILS_WIDGET "inherit_show_thumbnails_checkbutton"
@@ -1080,6 +1081,13 @@ nemo_file_management_properties_dialog_setup (GtkBuilder  *builder,
 	bind_builder_bool (builder, nemo_preferences,
 					   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_WIDGET,
 					   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
+
+	bind_builder_bool (builder, nemo_preferences,
+					   NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_ALWAYS_WIDGET,
+					   NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES_ALWAYS);
+	g_settings_bind (nemo_preferences, NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES,
+			 gtk_builder_get_object (builder, NEMO_FILE_MANAGEMENT_PROPERTIES_SHOW_SELECTION_CHECKBOXES_ALWAYS_WIDGET),
+			 "sensitive", G_SETTINGS_BIND_GET);
 
     bind_builder_bool (builder, nemo_preferences,
                        NEMO_FILE_MANAGEMENT_PROPERTIES_BOOKMARKS_IN_TO_MENUS_WIDGET,

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -196,6 +196,7 @@ static void   selection_toggle_cell_data_func                    (GtkTreeViewCol
 static void   selection_toggle_toggled_callback                  (GtkCellRendererToggle *cell,
 																  gchar                *path_str,
 																  gpointer              data);
+static void   selection_checkboxes_preferences_changed_callback  (NemoListView         *view);
 
 G_DEFINE_TYPE (NemoListView, nemo_list_view, NEMO_TYPE_VIEW);
 
@@ -452,6 +453,11 @@ clicked_on_selection_toggle (NemoListView *view,
 	int start_x;
 	GtkTreePath *event_path = NULL;
 
+	if (!g_settings_get_boolean (nemo_preferences,
+				     NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES)) {
+		return FALSE;
+	}
+
 	if (!gtk_tree_view_get_path_at_pos (view->details->tree_view,
 					    event->x, event->y,
 					    &event_path, &column, NULL, NULL)) {
@@ -488,14 +494,34 @@ selection_toggle_cell_data_func (GtkTreeViewColumn *column,
 	NemoListView *view = NEMO_LIST_VIEW (data);
 	GtkTreePath *path;
 	gboolean active;
+	gboolean visible;
 
+	visible = g_settings_get_boolean (nemo_preferences,
+					  NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES);
 	path = gtk_tree_model_get_path (model, iter);
-	active = gtk_tree_selection_path_is_selected (gtk_tree_view_get_selection (view->details->tree_view), path);
+	active = visible &&
+		 gtk_tree_selection_path_is_selected (gtk_tree_view_get_selection (view->details->tree_view), path);
 	g_object_set (cell,
 		      "active", active,
-		      "activatable", TRUE,
+		      "activatable", visible,
+		      "visible", visible,
 		      NULL);
 	gtk_tree_path_free (path);
+}
+
+static void
+toggle_selection_at_path (NemoListView *view,
+			  GtkTreePath  *path)
+{
+	GtkTreeSelection *selection;
+
+	selection = gtk_tree_view_get_selection (view->details->tree_view);
+
+	if (gtk_tree_selection_path_is_selected (selection, path)) {
+		gtk_tree_selection_unselect_path (selection, path);
+	} else {
+		gtk_tree_selection_select_path (selection, path);
+	}
 }
 
 static void
@@ -505,18 +531,27 @@ selection_toggle_toggled_callback (GtkCellRendererToggle *cell,
 {
 	NemoListView *view = NEMO_LIST_VIEW (data);
 	GtkTreePath *path;
-	GtkTreeSelection *selection;
 
-	path = gtk_tree_path_new_from_string (path_str);
-	selection = gtk_tree_view_get_selection (view->details->tree_view);
-
-	if (gtk_tree_selection_path_is_selected (selection, path)) {
-		gtk_tree_selection_unselect_path (selection, path);
-	} else {
-		gtk_tree_selection_select_path (selection, path);
+	if (!g_settings_get_boolean (nemo_preferences,
+				     NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES)) {
+		return;
 	}
 
+	path = gtk_tree_path_new_from_string (path_str);
+	if (path == NULL) {
+		return;
+	}
+
+	toggle_selection_at_path (view, path);
 	gtk_tree_path_free (path);
+}
+
+static void
+selection_checkboxes_preferences_changed_callback (NemoListView *view)
+{
+	if (view->details->tree_view != NULL) {
+		gtk_widget_queue_draw (GTK_WIDGET (view->details->tree_view));
+	}
 }
 
 static void
@@ -1239,12 +1274,7 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
 		if (view->details->selection_toggle_cell != NULL &&
 		    clicked_on_selection_toggle (view, path, event) &&
 		    (event->button == 1 || event->button == 2)) {
-			GtkTreeSelection *selection = gtk_tree_view_get_selection (tree_view);
-			if (gtk_tree_selection_path_is_selected (selection, path)) {
-				gtk_tree_selection_unselect_path (selection, path);
-			} else {
-				gtk_tree_selection_select_path (selection, path);
-			}
+			toggle_selection_at_path (view, path);
 			gtk_tree_path_free (path);
 			return GDK_EVENT_STOP;
 		}
@@ -4368,12 +4398,15 @@ nemo_list_view_finalize (GObject *object)
 	g_signal_handlers_disconnect_by_func (nemo_list_view_preferences,
 					      default_column_order_changed_callback,
 					      list_view);
-    g_signal_handlers_disconnect_by_func (nemo_list_view_preferences,
-                                          expanders_enabled_changed_cb,
-                                          list_view);
-    g_signal_handlers_disconnect_by_func (nemo_preferences,
-                                          tooltip_prefs_changed_callback,
-                                          list_view);
+	g_signal_handlers_disconnect_by_func (nemo_list_view_preferences,
+					      expanders_enabled_changed_cb,
+					      list_view);
+	g_signal_handlers_disconnect_by_func (nemo_preferences,
+					      tooltip_prefs_changed_callback,
+					      list_view);
+	g_signal_handlers_disconnect_by_func (nemo_preferences,
+					      selection_checkboxes_preferences_changed_callback,
+					      list_view);
 
 	G_OBJECT_CLASS (nemo_list_view_parent_class)->finalize (object);
 }
@@ -4616,12 +4649,17 @@ nemo_list_view_init (NemoListView *list_view)
                               G_CALLBACK (tooltip_prefs_changed_callback),
                               list_view);
 
-    g_signal_connect_swapped (nemo_preferences,
-                              "changed::" NEMO_PREFERENCES_TOOLTIP_FULL_PATH,
-                              G_CALLBACK (tooltip_prefs_changed_callback),
-                              list_view);
+	g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_TOOLTIP_FULL_PATH,
+				  G_CALLBACK (tooltip_prefs_changed_callback),
+				  list_view);
 
-    tooltip_prefs_changed_callback (list_view);
+	g_signal_connect_swapped (nemo_preferences,
+				  "changed::" NEMO_PREFERENCES_SHOW_SELECTION_CHECKBOXES,
+				  G_CALLBACK (selection_checkboxes_preferences_changed_callback),
+				  list_view);
+
+	tooltip_prefs_changed_callback (list_view);
 
 	nemo_list_view_click_policy_changed (NEMO_VIEW (list_view));
     nemo_list_view_click_to_rename_mode_changed (NEMO_VIEW (list_view));

--- a/src/nemo-list-view.c
+++ b/src/nemo-list-view.c
@@ -76,6 +76,7 @@ struct NemoListViewDetails {
 	GtkTreeViewColumn   *file_name_column;
 	int file_name_column_num;
 
+	GtkCellRendererToggle *selection_toggle_cell;
 	GtkCellRendererPixbuf *pixbuf_cell;
 	GtkCellRendererText   *file_name_cell;
 	GList *cells;
@@ -187,6 +188,14 @@ static void   set_columns_settings_from_metadata_and_preferences (NemoListView *
 static void   queue_update_visible_icons (NemoListView *view, gint delay);
 static NemoZoomLevel nemo_list_view_get_zoom_level (NemoView *view);
 static void   prioritize_visible_files (NemoListView *view);
+static void   selection_toggle_cell_data_func                    (GtkTreeViewColumn *column,
+																  GtkCellRenderer   *cell,
+																  GtkTreeModel      *model,
+																  GtkTreeIter       *iter,
+																  gpointer           data);
+static void   selection_toggle_toggled_callback                  (GtkCellRendererToggle *cell,
+																  gchar                *path_str,
+																  gpointer              data);
 
 G_DEFINE_TYPE (NemoListView, nemo_list_view, NEMO_TYPE_VIEW);
 
@@ -429,6 +438,85 @@ static gboolean
 button_event_modifies_selection (GdkEventButton *event)
 {
 	return (event->state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) != 0;
+}
+
+static gboolean
+clicked_on_selection_toggle (NemoListView *view,
+				 GtkTreePath *path,
+				 GdkEventButton *event)
+{
+	GtkTreeViewColumn *column;
+	int x_col_offset;
+	int x_cell_offset;
+	int width;
+	int start_x;
+	GtkTreePath *event_path = NULL;
+
+	if (!gtk_tree_view_get_path_at_pos (view->details->tree_view,
+					    event->x, event->y,
+					    &event_path, &column, NULL, NULL)) {
+		return FALSE;
+	}
+
+	if (path != NULL && gtk_tree_path_compare (path, event_path) != 0) {
+		gtk_tree_path_free (event_path);
+		return FALSE;
+	}
+
+	gtk_tree_path_free (event_path);
+
+	if (column != view->details->file_name_column) {
+		return FALSE;
+	}
+
+	gtk_tree_view_column_cell_get_position (view->details->file_name_column,
+						GTK_CELL_RENDERER (view->details->selection_toggle_cell),
+						&x_cell_offset, &width);
+	x_col_offset = gtk_tree_view_column_get_x_offset (view->details->file_name_column);
+	start_x = x_col_offset + x_cell_offset;
+
+	return event->x >= start_x && event->x <= start_x + width;
+}
+
+static void
+selection_toggle_cell_data_func (GtkTreeViewColumn *column,
+					 GtkCellRenderer *cell,
+					 GtkTreeModel *model,
+					 GtkTreeIter *iter,
+					 gpointer data)
+{
+	NemoListView *view = NEMO_LIST_VIEW (data);
+	GtkTreePath *path;
+	gboolean active;
+
+	path = gtk_tree_model_get_path (model, iter);
+	active = gtk_tree_selection_path_is_selected (gtk_tree_view_get_selection (view->details->tree_view), path);
+	g_object_set (cell,
+		      "active", active,
+		      "activatable", TRUE,
+		      NULL);
+	gtk_tree_path_free (path);
+}
+
+static void
+selection_toggle_toggled_callback (GtkCellRendererToggle *cell,
+					 gchar *path_str,
+					 gpointer data)
+{
+	NemoListView *view = NEMO_LIST_VIEW (data);
+	GtkTreePath *path;
+	GtkTreeSelection *selection;
+
+	path = gtk_tree_path_new_from_string (path_str);
+	selection = gtk_tree_view_get_selection (view->details->tree_view);
+
+	if (gtk_tree_selection_path_is_selected (selection, path)) {
+		gtk_tree_selection_unselect_path (selection, path);
+	} else {
+		gtk_tree_selection_select_path (selection, path);
+	}
+
+	gtk_tree_path_free (path);
 }
 
 static void
@@ -1148,6 +1236,19 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
 	call_parent = TRUE;
 	if (gtk_tree_view_get_path_at_pos (tree_view, event->x, event->y,
 					   &path, NULL, NULL, NULL)) {
+		if (view->details->selection_toggle_cell != NULL &&
+		    clicked_on_selection_toggle (view, path, event) &&
+		    (event->button == 1 || event->button == 2)) {
+			GtkTreeSelection *selection = gtk_tree_view_get_selection (tree_view);
+			if (gtk_tree_selection_path_is_selected (selection, path)) {
+				gtk_tree_selection_unselect_path (selection, path);
+			} else {
+				gtk_tree_selection_select_path (selection, path);
+			}
+			gtk_tree_path_free (path);
+			return GDK_EVENT_STOP;
+		}
+
         if (g_settings_get_boolean (nemo_list_view_preferences,
                                       NEMO_PREFERENCES_LIST_VIEW_ENABLE_EXPANSION)) {
     		gtk_widget_style_get (widget,
@@ -2710,6 +2811,7 @@ create_and_set_up_tree_view (NemoListView *view)
 		 * has the icon in it.*/
 		if (!strcmp (name, "name")) {
 			/* Create the file name column */
+			GtkCellRendererToggle *toggle_cell;
 			cell = gtk_cell_renderer_pixbuf_new ();
 			view->details->pixbuf_cell = (GtkCellRendererPixbuf *)cell;
 
@@ -2740,6 +2842,26 @@ create_and_set_up_tree_view (NemoListView *view)
             gtk_tree_view_column_set_min_width (view->details->file_name_column, 100);
             gtk_tree_view_column_set_reorderable (view->details->file_name_column, TRUE);
             gtk_tree_view_column_set_expand (view->details->file_name_column, TRUE);
+
+			toggle_cell = GTK_CELL_RENDERER_TOGGLE (gtk_cell_renderer_toggle_new ());
+			view->details->selection_toggle_cell = toggle_cell;
+			g_object_set (toggle_cell,
+				      "xpad", 0,
+				      "ypad", 0,
+				      "activatable", TRUE,
+				      NULL);
+			gtk_tree_view_column_pack_start (view->details->file_name_column,
+							 GTK_CELL_RENDERER (toggle_cell),
+							 FALSE);
+			gtk_tree_view_column_set_cell_data_func (view->details->file_name_column,
+							 GTK_CELL_RENDERER (toggle_cell),
+							 selection_toggle_cell_data_func,
+							 view,
+							 NULL);
+			g_signal_connect (toggle_cell,
+					  "toggled",
+					  G_CALLBACK (selection_toggle_toggled_callback),
+					  view);
 
 			gtk_tree_view_column_pack_start (view->details->file_name_column, cell, FALSE);
 			gtk_tree_view_column_set_attributes (view->details->file_name_column,


### PR DESCRIPTION
This pull request implements very handy feature to be able to select multiple items with checkboxes (without requiring to press `ctrl` with a keyboard). This feature is present in Microsoft Windows as well as in KDE's Dolphin file manager. This was discussed in https://github.com/orgs/linuxmint/discussions/353

Here is a video preview (updated version):



https://github.com/user-attachments/assets/e10b0d1d-b9ef-4cb5-b5ac-ee52b9f67369


When the single click to open item is selected, clicking on the checkbox only selects, but clicking elsewhere on the icon opens, as expected.
The checkbox gets a light color under dark themes and vice versa.

The feature can be easily turned off in the settings to restore previous behavior:

<img width="804" height="631" alt="image" src="https://github.com/user-attachments/assets/2302b75c-10a8-4fca-9655-c4008245941c" />
