### PR TITLE
places-sidebar: keep ejecting devices visible until the eject completes

### DIFF
--- a/src/nemo-places-sidebar.c
+++ b/src/nemo-places-sidebar.c
@@ -429,6 +429,93 @@ free_place_info (PlaceInfo *info)
     g_free (info);
 }
 
+/* Devices with an eject in progress, keyed by their unix-device identifier
+ * (e.g. "/dev/sdb1").
+ *
+ * A GMount's mount-removed signal fires at the *start* of an eject, while
+ * flushing cached writes to the device can take minutes.  Without extra
+ * bookkeeping the sidebar would rebuild on that early signal and show the
+ * device as a plain unmounted volume ("Mount and open ..."), which reads as
+ * "safe to unplug" long before it actually is - inviting data loss.
+ *
+ * Entries here let update_places () keep showing such devices as busy until
+ * the eject operation really completes (see do_eject and the eject
+ * callbacks).  The table is shared by every NemoPlacesSidebar instance so
+ * that all windows agree on what is currently ejecting; it is created
+ * lazily and lives for the whole process. */
+static GHashTable *ejecting_devices = NULL;
+
+typedef struct {
+    NemoPlacesSidebar *sidebar;   /* weak pointer: the eject can outlive the sidebar */
+    NemoWindow *window;           /* strong reference, kept for the duration */
+    gchar *key;                   /* unix-device id being ejected, or NULL */
+} EjectData;
+
+static gchar *
+get_eject_key (GMount *mount,
+               GVolume *volume,
+               GDrive *drive)
+{
+    GVolume *vol = NULL;
+    gchar *key = NULL;
+
+    if (volume != NULL) {
+        vol = g_object_ref (volume);
+    } else if (mount != NULL) {
+        vol = g_mount_get_volume (mount);
+    } else if (drive != NULL) {
+        GList *volumes = g_drive_get_volumes (drive);
+        if (volumes != NULL) {
+            vol = g_object_ref (volumes->data);
+            g_list_free_full (volumes, g_object_unref);
+        }
+    }
+
+    if (vol != NULL) {
+        key = g_volume_get_identifier (vol, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
+        g_object_unref (vol);
+    }
+
+    return key;
+}
+
+static gboolean
+volume_is_ejecting (GVolume *volume)
+{
+    gchar *id;
+    gboolean ret = FALSE;
+
+    if (ejecting_devices == NULL || volume == NULL) {
+        return FALSE;
+    }
+
+    id = g_volume_get_identifier (volume, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
+    if (id != NULL) {
+        ret = g_hash_table_contains (ejecting_devices, id);
+        g_free (id);
+    }
+
+    return ret;
+}
+
+static void
+eject_data_finish (EjectData *data)
+{
+    if (data->key != NULL && ejecting_devices != NULL) {
+        g_hash_table_remove (ejecting_devices, data->key);
+    }
+
+    if (data->sidebar != NULL) {
+        update_places_on_idle (data->sidebar);
+        g_object_remove_weak_pointer (G_OBJECT (data->sidebar),
+                                      (gpointer *) &data->sidebar);
+    }
+
+    g_object_unref (data->window);
+    g_free (data->key);
+    g_free (data);
+}
+
 static GtkTreeIter
 add_place (NemoPlacesSidebar *sidebar,
 	   PlaceType place_type,
@@ -449,6 +536,7 @@ add_place (NemoPlacesSidebar *sidebar,
     GIcon *gicon;
 	gboolean show_eject, show_unmount;
 	gboolean show_eject_button;
+	gboolean ejecting;
 
 	cat_iter = check_heading_for_devices (sidebar, section_type, cat_iter);
 
@@ -459,8 +547,13 @@ add_place (NemoPlacesSidebar *sidebar,
 		g_assert (place_type != PLACES_BOOKMARK);
 	}
 
+	ejecting = volume_is_ejecting (volume);
+
 	if (mount == NULL) {
-		show_eject_button = FALSE;
+		/* An ejecting device has no mount anymore, but its eject cell
+		 * is kept to show the busy indicator in the same spot the
+		 * user clicked. */
+		show_eject_button = ejecting;
 	} else {
 		show_eject_button = (show_unmount || show_eject);
 	}
@@ -481,7 +574,8 @@ add_place (NemoPlacesSidebar *sidebar,
 			    PLACES_SIDEBAR_COLUMN_NO_EJECT, !show_eject_button,
 			    PLACES_SIDEBAR_COLUMN_BOOKMARK, place_type != PLACES_BOOKMARK,
                 PLACES_SIDEBAR_COLUMN_TOOLTIP, tooltip,
-                PLACES_SIDEBAR_COLUMN_EJECT_ICON, show_eject_button ? "xsi-media-eject-symbolic" : NULL,
+                PLACES_SIDEBAR_COLUMN_EJECT_ICON, !show_eject_button ? NULL :
+                    (ejecting ? "xsi-emblem-synchronizing-symbolic" : "xsi-media-eject-symbolic"),
 			    PLACES_SIDEBAR_COLUMN_EJECT_ICON_SIZE, EJECT_ICON_SIZE_NOT_HOVERED,
 			    PLACES_SIDEBAR_COLUMN_SECTION_TYPE, section_type,
                 PLACES_SIDEBAR_COLUMN_DF_PERCENT, df_percent,
@@ -750,6 +844,35 @@ update_places (NemoPlacesSidebar *sidebar)
 	DEBUG ("Updating places sidebar");
 
     sidebar->updating_sidebar = TRUE;
+
+    /* Drop stale eject-in-progress entries: a device whose volume is no
+     * longer present has finished ejecting or was physically removed. */
+    if (ejecting_devices != NULL && g_hash_table_size (ejecting_devices) > 0) {
+        GVolumeMonitor *vm = g_volume_monitor_get ();
+        GList *present = g_volume_monitor_get_volumes (vm);
+        GHashTable *present_ids = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                         g_free, NULL);
+        GHashTableIter eject_iter;
+        gpointer eject_key;
+
+        for (l = present; l != NULL; l = l->next) {
+            gchar *id = g_volume_get_identifier (l->data,
+                                                 G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
+            if (id != NULL) {
+                g_hash_table_add (present_ids, id);
+            }
+        }
+        g_list_free_full (present, g_object_unref);
+
+        g_hash_table_iter_init (&eject_iter, ejecting_devices);
+        while (g_hash_table_iter_next (&eject_iter, &eject_key, NULL)) {
+            if (!g_hash_table_contains (present_ids, eject_key)) {
+                g_hash_table_iter_remove (&eject_iter);
+            }
+        }
+        g_hash_table_destroy (present_ids);
+        g_object_unref (vm);
+    }
 
 	model = NULL;
 	last_uri = NULL;
@@ -1086,12 +1209,27 @@ update_places (NemoPlacesSidebar *sidebar)
                      * he just unmounted it.
                      */
                     gchar *volume_id;
-                    icon = nemo_get_volume_icon_name (volume);
-                    name = g_volume_get_name (volume);
 
                     volume_id = g_volume_get_identifier (volume,
                                                          G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
-                    tooltip = g_strdup_printf (_("Mount and open %s (%s)"), name, volume_id);
+
+                    if (volume_is_ejecting (volume)) {
+                        /* The eject is still flushing data to the device;
+                         * keep it visible and clearly busy instead of
+                         * offering to mount it again. The device keeps its
+                         * normal icon; the busy indicator is shown in the
+                         * eject cell (see add_place). */
+                        gchar *volume_name = g_volume_get_name (volume);
+                        name = g_strdup_printf (_("%s (ejecting...)"), volume_name);
+                        icon = nemo_get_volume_icon_name (volume);
+                        tooltip = g_strdup_printf (_("Still writing data to %s. Do not unplug it yet."),
+                                                   volume_name);
+                        g_free (volume_name);
+                    } else {
+                        icon = nemo_get_volume_icon_name (volume);
+                        name = g_volume_get_name (volume);
+                        tooltip = g_strdup_printf (_("Mount and open %s (%s)"), name, volume_id);
+                    }
 
                     place_info = new_place_info (PLACES_MOUNTED_VOLUME,
                                                  SECTION_DEVICES,
@@ -1193,17 +1331,34 @@ update_places (NemoPlacesSidebar *sidebar)
             g_free (mount_uri);
         } else {
             /* see comment above in why we add an icon for an unmounted mountable volume */
-            icon = nemo_get_volume_icon_name (volume);
-            name = g_volume_get_name (volume);
+            gchar *row_tooltip;
+
+            if (volume_is_ejecting (volume)) {
+                /* The eject is still flushing data to the device; keep it
+                 * visible and clearly busy instead of offering to mount it
+                 * again. The device keeps its normal icon; the busy
+                 * indicator is shown in the eject cell (see add_place). */
+                gchar *volume_name = g_volume_get_name (volume);
+                name = g_strdup_printf (_("%s (ejecting...)"), volume_name);
+                icon = nemo_get_volume_icon_name (volume);
+                row_tooltip = g_strdup_printf (_("Still writing data to %s. Do not unplug it yet."),
+                                               volume_name);
+                g_free (volume_name);
+            } else {
+                icon = nemo_get_volume_icon_name (volume);
+                name = g_volume_get_name (volume);
+                row_tooltip = g_strdup (name);
+            }
 
             place_info = new_place_info (PLACES_MOUNTED_VOLUME,
                                          SECTION_DEVICES,
                                          name, icon, NULL,
-                                         NULL, volume, NULL, 0, name, 0, FALSE);
+                                         NULL, volume, NULL, 0, row_tooltip, 0, FALSE);
             place_infos = g_list_prepend (place_infos, place_info);
 
             g_free (icon);
             g_free (name);
+            g_free (row_tooltip);
         }
         g_object_unref (volume);
     }
@@ -2528,7 +2683,7 @@ open_selected_bookmark (NemoPlacesSidebar *sidebar,
 				    PLACES_SIDEBAR_COLUMN_VOLUME, &volume,
 				    -1);
 
-		if (volume != NULL && !sidebar->mounting) {
+		if (volume != NULL && !sidebar->mounting && !volume_is_ejecting (volume)) {
 			sidebar->mounting = TRUE;
 
 			g_assert (sidebar->go_to_after_mount_slot == NULL);
@@ -2842,11 +2997,10 @@ drive_eject_cb (GObject *source_object,
 		GAsyncResult *res,
 		gpointer user_data)
 {
-	NemoWindow *window;
+	EjectData *data;
 	GError *error;
 
-	window = user_data;
-	g_object_unref (window);
+	data = user_data;
 
 	error = NULL;
 	if (!g_drive_eject_with_operation_finish (G_DRIVE (source_object), res, &error)) {
@@ -2861,6 +3015,8 @@ drive_eject_cb (GObject *source_object,
         g_free (primary);
         g_clear_error (&error);
     }
+
+	eject_data_finish (data);
 }
 
 static void
@@ -2868,11 +3024,10 @@ volume_eject_cb (GObject *source_object,
 		GAsyncResult *res,
 		gpointer user_data)
 {
-	NemoWindow *window;
+	EjectData *data;
 	GError *error;
 
-	window = user_data;
-	g_object_unref (window);
+	data = user_data;
 
 	error = NULL;
 	if (!g_volume_eject_with_operation_finish (G_VOLUME (source_object), res, &error)) {
@@ -2887,6 +3042,8 @@ volume_eject_cb (GObject *source_object,
         g_free (primary);
         g_clear_error (&error);
     }
+
+	eject_data_finish (data);
 }
 
 static void
@@ -2894,11 +3051,10 @@ mount_eject_cb (GObject *source_object,
 		GAsyncResult *res,
 		gpointer user_data)
 {
-	NemoWindow *window;
+	EjectData *data;
 	GError *error;
 
-	window = user_data;
-	g_object_unref (window);
+	data = user_data;
 
 	error = NULL;
 	if (!g_mount_eject_with_operation_finish (G_MOUNT (source_object), res, &error)) {
@@ -2913,6 +3069,8 @@ mount_eject_cb (GObject *source_object,
         g_free (primary);
         g_clear_error (&error);
     }
+
+	eject_data_finish (data);
 }
 
 static void
@@ -2921,17 +3079,53 @@ do_eject (GMount *mount,
 	  GDrive *drive,
 	  NemoPlacesSidebar *sidebar)
 {
-    GMountOperation *mount_op = get_unmount_operation (sidebar);
+    GMountOperation *mount_op;
+    EjectData *data;
+    gchar *key;
+
+    key = get_eject_key (mount, volume, drive);
+
+    /* Ignore repeated eject requests (eject cell, context menu, ...) for
+     * a device whose eject is already in flight. */
+    if (key != NULL && ejecting_devices != NULL &&
+        g_hash_table_contains (ejecting_devices, key)) {
+        g_free (key);
+        return;
+    }
+
+    mount_op = get_unmount_operation (sidebar);
+
+    data = g_new0 (EjectData, 1);
+    data->window = g_object_ref (sidebar->window);
+    data->sidebar = sidebar;
+    g_object_add_weak_pointer (G_OBJECT (sidebar), (gpointer *) &data->sidebar);
+    data->key = key;
+
+    /* Remember that this device has an eject in progress: its GMount
+     * disappears as soon as the operation *starts*, while flushing cached
+     * writes to the device can take a long time.  update_places () uses
+     * this to keep the device visible (and clearly busy) until the eject
+     * really completes, instead of showing it as safely removable. */
+    if (data->key != NULL) {
+        if (ejecting_devices == NULL) {
+            ejecting_devices = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                      g_free, NULL);
+        }
+        g_hash_table_add (ejecting_devices, g_strdup (data->key));
+        update_places_on_idle (sidebar);
+    }
 
 	if (mount != NULL) {
 		g_mount_eject_with_operation (mount, 0, mount_op, NULL, mount_eject_cb,
-					      g_object_ref (sidebar->window));
+					      data);
 	} else if (volume != NULL) {
 		g_volume_eject_with_operation (volume, 0, mount_op, NULL, volume_eject_cb,
-					      g_object_ref (sidebar->window));
+					      data);
 	} else if (drive != NULL) {
 		g_drive_eject_with_operation (drive, 0, mount_op, NULL, drive_eject_cb,
-					      g_object_ref (sidebar->window));
+					      data);
+	} else {
+		eject_data_finish (data);
 	}
 	g_object_unref (mount_op);
 }


### PR DESCRIPTION
### The problem

When a removable drive is ejected from the sidebar, its row disappears within about one second, while the kernel may still be flushing cached writes to the device for a minute or more. The only warning is a desktop notification ("Writing data..."), which is transient, easily missed, and may be disabled altogether; nothing in the file manager's own UI indicates the device is still busy. The user may reasonably conclude the eject is done, and unplugs. The files that were still in flight are truncated and the filesystem is left dirty.

This is easy to hit in real life: copying a large file to a USB stick returns almost immediately (the data lands in the page cache), the user clicks eject, the row vanishes, they pull the stick. On a 2 GB backlog I measured about 90 seconds between the row disappearing and the device actually being safe to remove (desktop system, source file on an NVMe SSD so the copy is cache-speed, ordinary consumer USB 3 flash sticks with exFAT sustaining roughly 20-50 MB/s; the size of the window is essentially backlog size over the stick's sequential write speed).

The eject operation itself (GVFS/udisks) is correct: it flushes everything and only reports completion when the device is truly safe. Only the sidebar UI reacts to the wrong signal.

### Root cause

Verified at runtime with an isolation harness that makes the exact GIO calls Nemo makes, on Mint 22.3 / Nemo 6.6.3 / GVFS 1.54.4, with a 2 GB write-back backlog on an exFAT USB stick:

```
+0.8s   eject starts (g_mount_eject_with_operation)
+0.8s   GVolumeMonitor emits mount-removed        <- sidebar rebuilds here
+2.3s   show-unmount-progress: "Writing data ... should not be unplugged."
 ...    page-cache backlog drains for ~90 s ...
+94.6s  show-unmount-progress: "... can be safely unplugged." + eject completes
+94.7s  volume-removed
```

`mount-removed` fires at the **start** of the eject, not at completion. The GVolume however stays present the whole time, so on rebuild the device falls into the "unmounted volume" branch of `update_places ()` and is rendered as a plain unmounted device: no eject button, a "Mount and open ..." tooltip, looks finished. The eject completion callbacks (`mount_eject_cb` and friends), the one place that knows the device is truly safe, do nothing on success.

Two extra consequences of the current behavior:

- The row now behaves like an unmounted volume, so activating it mid-flush starts a **re-mount of a device that is being flushed**. This is a plausible trigger for the "an operation is already pending" message storms reported in #3463.
- Nemo does send the urgent "Writing data" notification, but the false cue (row gone) appears about 1.5 s **before** it, and remains for the whole flush.

### The fix

All in `nemo-places-sidebar.c`, UI-only; the eject operation itself is untouched.

- Track devices with an eject in progress in a small process-global table keyed by unix-device id (process-global so that every window agrees on the state, not just the one where eject was clicked).
- `do_eject ()` records the device before starting the operation.
- While the eject is in progress, the unmounted-volume render paths keep the device visible as busy: it keeps its normal device icon, the name gains an "(ejecting...)" suffix, the eject button is replaced by a busy indicator (`xsi-emblem-synchronizing-symbolic`) in the same spot the user clicked, and the tooltip reads "Still writing data to <name>. Do not unplug it yet."
- Row activation is ignored for a device in this state (no more accidental re-mount mid-flush).
- Repeated eject requests for a device already ejecting (eject cell, context menu) are ignored while the operation is in flight, instead of spawning a second operation that fails with "an operation is already pending".
- The eject completion callbacks (success or failure) remove the entry and refresh, so the row disappears exactly when the device is safe to remove, in every window. On failure the row heals back to its normal mounted state.
- A sweep in `update_places ()` drops entries whose volume is gone, so a physically yanked device can never leave a stale "ejecting" row.
- The completion callbacks now receive a small context struct (window keep-alive as before, plus a weak pointer to the sidebar, which can legitimately be destroyed during a long eject, and the device key).

The resulting semantics are simple and truthful: **row present and marked busy = not safe to unplug; row gone = safe.** This also lines up with the existing "can be safely unplugged" notification, which fires at the same moment the row now disappears.

<img width="600" height="286" alt="demo-final-zoom" src="https://github.com/user-attachments/assets/9520bf79-a81c-4c15-be08-fd4f21531590" />

<img width="950" height="264" alt="demo-tooltip" src="https://github.com/user-attachments/assets/51e4c228-4653-40a3-a891-1f7a94b636ae" />

### Testing

Tested on Linux Mint 22.3 (Cinnamon 6.6.9, X11), Nemo built from this branch at 6.6.3, GVFS 1.54.4, kernels 6.17 and 7.0, against exFAT USB sticks, driven both manually and by a scripted harness that timestamps every GVolumeMonitor signal alongside /proc/meminfo Dirty. The branch was subsequently rebased onto current master (6.7.4-dev, 932438f) and re-verified there with a live large-backlog eject cycle: busy state renders, the re-trigger guard holds, completion clears the row, no kernel I/O errors. Detailed results:

- Large-backlog eject (1.4 GB dirty): row stays as "(ejecting...)" for the full ~35-90 s flush and disappears exactly at completion. MD5 of the copied files verified identical to the source after remount.
- Idle-drive eject: near-instant completion, row clears promptly, no stuck state.
- Clicking the ejecting row: inert (previously started a re-mount).
- Two windows: both show the busy state during the flush and both clear on completion.
- "Volume is busy" dialog: Cancel aborts the eject and the row heals back to the normal mounted state; letting the blocking process exit lets the eject proceed and complete safely.
- Unmount (not eject): still renders as a normal unmounted volume with its "Mount and open ..." tooltip; activating it mounts and opens as before.
- No kernel I/O errors across all cycles; no regressions observed in normal mount/unmount flows.

### Notes for reviewers

- Busy indicator placement: it lives in the eject cell, so the feedback appears exactly where the user clicked, the device keeps its identity icon, and the row's layout does not shift; a future animated spinner (see below) would occupy the same cell.
- Busy indicator icon: an hourglass or spinner glyph might have been the clearer "busy" metaphor, but neither has a standard name in the freedesktop icon spec, so they would not resolve reliably across themes and distros. `xsi-emblem-synchronizing-symbolic` was chosen instead: the xsi set ships with libxapp (already a hard dependency) and matches the sidebar's existing icons, so it resolves everywhere Nemo runs and is the closest portable fit semantically.
- The row text is deliberately kept short so it does not truncate at default sidebar widths; the full warning lives in the tooltip. The text matters for accessibility: screen readers announce the row name, not icon changes.
- Two new translatable strings are introduced.
- Follow-up candidates, intentionally out of scope to keep this minimal: an animated spinner in the eject cell (GtkCellRendererSpinner needs a model column plus animation plumbing), and determinate progress, which would require GVFS/udisks to emit real unmount progress (today `show-unmount-progress` fires only at start and completion; verified with the harness).

### Related issues

- #2172 (confusing identical eject notifications): same problem area; a persistent in-sidebar busy state makes the notification ambiguity much less harmful.
- #3463 (message storms about pending operations): the mid-flush re-mount this patch prevents is a plausible trigger.
- Cross-desktop corroboration: mate-desktop/caja#286 describes the same premature "unmounted" rendering in Caja, which shares the GVFS lineage.

The reproduction harness (Python/GIO, ~60 lines) is available on request; happy to attach it or adapt this patch based on feedback.