### PR TITLE
Add gsettings option to automatically merge directories during conflicts

### DIFF
--- a/libnemo-private/nemo-file-operations.c
+++ b/libnemo-private/nemo-file-operations.c
@@ -4398,6 +4398,16 @@ get_target_file_for_display_name (GFile *dir,
 	return dest;
 }
 
+static gboolean
+should_always_merge_dirs (void)
+{
+	gboolean confirm_merge;
+
+	confirm_merge = g_settings_get_boolean (nemo_preferences, NEMO_PREFERENCES_ALWAYS_MERGE_DIRS);
+
+	return confirm_merge;
+}
+
 /* Debuting files is non-NULL only for toplevel items */
 static void
 copy_move_file (CopyMoveJob *copy_job,
@@ -4663,6 +4673,10 @@ copy_move_file (CopyMoveJob *copy_job,
 
 		if (is_dir (dest) && is_dir (src)) {
 			is_a_merge = TRUE;
+		}
+
+		if (is_a_merge && should_always_merge_dirs()) {
+			job->merge_all = TRUE;
 		}
 
 		if ((is_a_merge && job->merge_all) ||
@@ -5336,6 +5350,10 @@ move_file_prepare (CopyMoveJob *move_job,
 		is_merge = FALSE;
 		if (is_dir (dest) && is_dir (src)) {
 			is_merge = TRUE;
+		}
+
+		if (is_merge && should_always_merge_dirs()) {
+			job->merge_all = TRUE;
 		}
 
 		if ((is_merge && job->merge_all) ||

--- a/libnemo-private/nemo-global-preferences.h
+++ b/libnemo-private/nemo-global-preferences.h
@@ -36,6 +36,9 @@ G_BEGIN_DECLS
 #define NEMO_PREFERENCES_ENABLE_DELETE			"enable-delete"
 #define NEMO_PREFERENCES_SWAP_TRASH_DELETE      "swap-trash-delete"
 
+/* Conflic Behavior */
+#define NEMO_PREFERENCES_ALWAYS_MERGE_DIRS            "always-merge-directories"
+
 /* Desktop options */
 #define NEMO_PREFERENCES_DESKTOP_IS_HOME_DIR                "desktop-is-home-dir"
 

--- a/libnemo-private/org.nemo.gschema.xml
+++ b/libnemo-private/org.nemo.gschema.xml
@@ -206,6 +206,11 @@
       <summary>Whether to swap the hotkeys for Trash and Delete</summary>
       <description>If set to true, the Delete key will permanently delete a file, and the Shift-Delete key will only trash a file.</description>
     </key>
+    <key name="always-merge-directories" type="b">
+      <default>false</default>
+      <summary>Whether to automatically resolve conflicts between two directories by merging them.</summary>
+      <description>If set to true, a file conflict between two directories will always automatically be resolved to "Merge", rather than "Skip" or "Duplicate".</description>
+    </key>
     <key name="show-directory-item-counts"  enum="org.nemo.SpeedTradeoff">
       <aliases><alias value='local_only' target='local-only'/></aliases>
       <default>'local-only'</default>


### PR DESCRIPTION
### What does this patch do?

This patch adds a gsettings option that automatically chooses the "Merge" action during file conflicts involving only directories. It does not have a corresponding UI element in Preferences.

### What problem does this solve?

Currently, when a copied or moved directory already exists, Nemo always prompts the user to choose how to resolve the conflict. Users who routinely merge directory trees currently need to confirm the "Merge" action every time a directory conflict occurs. This setting allows those users to opt into automatically selecting the merge action.

### Does it change existing behavior?

No. The default remains exactly the same. Only users who explicitly enable the setting see different behavior.

### Why a gsettings key?

A gsettings option was chosen so that existing behavior remains unchanged while allowing users who prefer automatic directory merging to opt in.

### Why no UI element?

This patch intentionally adds only the underlying gsettings key. Whether it should be exposed through the Preferences dialog is a separate UI decision, so this change keeps the implementation focused and leaves that discussion open.