### PR TITLE
nemo-odf-to-txt: fix IndexError in handle_data on leading text:s tag

### DIFF
--- a/search-helpers/nemo-odf-to-txt
+++ b/search-helpers/nemo-odf-to-txt
@@ -22,11 +22,11 @@ class Parser(HTMLParser):
     def handle_data(self, data):
         if self.get_next_data:
             if data != "\n":
-                if self.concat_next_data:
+                if self.concat_next_data and self.parsed:
                     self.parsed[-1] += " " + data
-                    self.concat_next_data = False
                 else:
                     self.parsed.append(data.strip())
+                self.concat_next_data = False
                 self.get_next_data = False
 
 path = sys.argv[1]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2520985

```
leigh@mpd-pc:~/Desktop/nemo/search-helpers (fix-odf-helper)$ python3 /usr/bin/nemo-odf-to-txt repro.odg
Traceback (most recent call last):
  File "/usr/bin/nemo-odf-to-txt", line 41, in <module>
    parser.feed(contents)
    ~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib64/python3.14/html/parser.py", line 187, in feed
    self.goahead(0)
    ~~~~~~~~~~~~^^^
  File "/usr/lib64/python3.14/html/parser.py", line 271, in goahead
    self.handle_data(unescape(rawdata[i:j]))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/nemo-odf-to-txt", line 26, in handle_data
    self.parsed[-1] += " " + data
    ~~~~~~~~~~~^^^^
IndexError: list index out of range
leigh@mpd-pc:~/Desktop/nemo/search-helpers (fix-odf-helper)$ python3 nemo-odf-to-txt repro.odg
content: hello world

leigh@mpd-pc:~/Desktop/nemo/search-helpers (fix-odf-helper)$ 
```

test file to reproduce crash 

[repro.odg](https://github.com/user-attachments/files/31308352/repro.odg)
