### PR TITLE
nemo-file-conflict-dialog.c: Load folder sizes before display.

### DIFF
--- a/libnemo-private/nemo-file-conflict-dialog.c
+++ b/libnemo-private/nemo-file-conflict-dialog.c
@@ -122,9 +122,9 @@ file_list_ready_cb (GList *files,
 
 	details->handle = NULL;
 
-	dest_dir = g_list_nth_data (files, 0);
-	dest = g_list_nth_data (files, 1);
-	src = g_list_nth_data (files, 2);
+	dest_dir = details->dest_dir;
+	dest = g_list_nth_data (files, 0);
+	src = g_list_nth_data (files, 1);
 
 	src_mtime = nemo_file_get_mtime (src);
 	dest_mtime = nemo_file_get_mtime (dest);
@@ -260,7 +260,7 @@ file_list_ready_cb (GList *files,
 	label = gtk_label_new (NULL);
 	date = nemo_file_get_string_attribute (dest,
 						   "date_modified");
-	size = nemo_file_get_string_attribute (dest, "size");
+	size = nemo_file_get_string_attribute_with_default (dest, "size");
 
 	if (should_show_type) {
 		type = nemo_file_get_string_attribute (dest, "type");
@@ -293,7 +293,7 @@ file_list_ready_cb (GList *files,
 	label = gtk_label_new (NULL);
 	date = nemo_file_get_string_attribute (src,
 						   "date_modified");
-	size = nemo_file_get_string_attribute (src, "size");
+	size = nemo_file_get_string_attribute_with_default (src, "size");
 
 	if (should_show_type) {
 		type = nemo_file_get_string_attribute (src, "type");
@@ -358,10 +358,10 @@ build_dialog_appearance (NemoFileConflictDialog *fcd)
 
 	files = g_list_prepend (files, details->source);
 	files = g_list_prepend (files, details->destination);
-	files = g_list_prepend (files, details->dest_dir);
 
 	nemo_file_list_call_when_ready (files,
-					    NEMO_FILE_ATTRIBUTES_FOR_ICON,
+					    NEMO_FILE_ATTRIBUTES_FOR_ICON |
+					    NEMO_FILE_ATTRIBUTE_DIRECTORY_ITEM_COUNT,
 					    &details->handle, file_list_ready_cb, fcd);
 	g_list_free (files);
 }


### PR DESCRIPTION
The conflict dialog waits for icon metadata before reading `size`, but directory sizes depend on the directory item count. If the target folder has not been expanded yet, that count is unavailable and the dialog displays `(null)`.

Wait for item counts on the two conflicting files before building the dialog, and use Nemo's non-null fallback for counts that are intentionally unavailable. The parent directory is no longer part of the wait list, so it is not counted unnecessarily.

Tested with a full Debian package build in the official Linux Mint 22.3 image and a targeted async metadata check reproducing `(null)` before the count and `0 items` after it.

Fixes #3442
