### PR TITLE
nemo-search-engine-advanced.c: Fix Unicode content search

### DIFF
--- a/libnemo-private/nemo-search-engine-advanced.c
+++ b/libnemo-private/nemo-search-engine-advanced.c
@@ -365,17 +365,15 @@ nemo_search_engine_advanced_create_content_regex (NemoQuery  *query,
 {
     GRegexCompileFlags flags;
     g_autofree gchar *text = NULL;
-    g_autofree gchar *normalized = NULL;
     g_autofree gchar *escaped = NULL;
     g_autofree gchar *format = NULL;
 
     text = nemo_query_get_content_pattern (query);
-    normalized = g_utf8_normalize (text, -1, G_NORMALIZE_NFD);
 
     if (nemo_query_get_use_content_regex (query)) {
-        escaped = g_strdup (normalized);
+        escaped = g_strdup (text);
     } else {
-        escaped = g_regex_escape_string (normalized, -1);
+        escaped = g_regex_escape_string (text, -1);
     }
 
     flags = G_REGEX_MULTILINE |

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,3 +26,12 @@ test('Copy test',
   ),
   args: []
 )
+
+test('Content Search test',
+  executable('test-nemo-search-content',
+    [ 'test-nemo-search-content.c' ],
+    include_directories: [ rootInclude, ],
+    dependencies: [ gtk, nemo_private ],
+  ),
+  args: []
+)

--- a/test/test-nemo-search-content.c
+++ b/test/test-nemo-search-content.c
@@ -1,0 +1,113 @@
+#include <libnemo-private/nemo-global-preferences.h>
+#include <libnemo-private/nemo-search-engine-advanced.h>
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+typedef struct {
+    GMainLoop *loop;
+    guint hits;
+    gchar *snippet;
+    gboolean timed_out;
+} SearchResult;
+
+static void
+hits_added_cb (NemoSearchEngine *engine,
+               GList            *hits,
+               SearchResult     *result)
+{
+    for (GList *l = hits; l != NULL; l = l->next) {
+        FileSearchResult *hit = l->data;
+
+        result->hits++;
+        if (result->snippet == NULL) {
+            result->snippet = g_strdup (hit->snippet);
+        }
+        file_search_result_free (hit);
+    }
+}
+
+static void
+finished_cb (NemoSearchEngine *engine,
+             SearchResult     *result)
+{
+    g_main_loop_quit (result->loop);
+}
+
+static gboolean
+timeout_cb (gpointer user_data)
+{
+    SearchResult *result = user_data;
+
+    result->timed_out = TRUE;
+    g_main_loop_quit (result->loop);
+    return G_SOURCE_REMOVE;
+}
+
+static void
+test_content_search_matches_precomposed_unicode (void)
+{
+    g_autofree gchar *tmpdir = NULL;
+    g_autofree gchar *path = NULL;
+    g_autofree gchar *uri = NULL;
+    NemoQuery *query = NULL;
+    NemoSearchEngine *engine = NULL;
+    g_autoptr (GError) error = NULL;
+    SearchResult result = { 0 };
+    guint timeout_id;
+
+    tmpdir = g_dir_make_tmp ("nemo-search-content-XXXXXX", &error);
+    g_assert_no_error (error);
+
+    path = g_build_filename (tmpdir, "katakana.txt", NULL);
+    g_file_set_contents (path, "ランプ\n", -1, &error);
+    g_assert_no_error (error);
+
+    uri = g_filename_to_uri (tmpdir, NULL, &error);
+    g_assert_no_error (error);
+
+    query = nemo_query_new ();
+    nemo_query_set_file_pattern (query, "*");
+    nemo_query_set_content_pattern (query, "ランプ");
+    nemo_query_set_location (query, uri);
+
+    engine = nemo_search_engine_advanced_new ();
+    result.loop = g_main_loop_new (NULL, FALSE);
+
+    g_signal_connect (engine, "hits-added", G_CALLBACK (hits_added_cb), &result);
+    g_signal_connect (engine, "finished", G_CALLBACK (finished_cb), &result);
+
+    nemo_search_engine_set_query (engine, query);
+    nemo_search_engine_start (engine);
+
+    timeout_id = g_timeout_add_seconds (5, timeout_cb, &result);
+    g_main_loop_run (result.loop);
+    if (!result.timed_out) {
+        g_source_remove (timeout_id);
+    }
+
+    g_assert_false (result.timed_out);
+    g_assert_cmpuint (result.hits, ==, 1);
+    g_assert_nonnull (result.snippet);
+    g_assert_nonnull (g_strstr_len (result.snippet, -1, "ランプ"));
+
+    g_free (result.snippet);
+    g_main_loop_unref (result.loop);
+    g_object_unref (engine);
+    g_object_unref (query);
+    g_remove (path);
+    g_rmdir (tmpdir);
+}
+
+int
+main (int argc, char **argv)
+{
+    g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
+    g_test_init (&argc, &argv, NULL);
+    nemo_global_preferences_init ();
+
+    g_test_add_func ("/search/content/precomposed-unicode", test_content_search_matches_precomposed_unicode);
+
+    return g_test_run ();
+}


### PR DESCRIPTION
Content search started normalizing the query pattern to NFD while matching file contents in their original UTF-8 form. Precomposed characters such as Katakana with dakuten or handakuten therefore stopped matching.

Keep content patterns unchanged, restoring the pre-6.6 behavior and leaving filename normalization unaffected. Add an end-to-end regression test that searches a temporary text file containing `ランプ` through the advanced search engine.

Fixes #3817

Tested with a full Ninja build and the new Meson content-search test on Linux Mint 22.3.
