### PR TITLE
docs: fix parameter names left from the nautilus era

### DIFF
--- a/libnemo-private/nemo-program-choosing.c
+++ b/libnemo-private/nemo-program-choosing.c
@@ -69,7 +69,7 @@ nemo_launch_application_for_mount (GAppInfo *app_info,
  * parameter. Provide a parent window for error dialogs. 
  * 
  * @application: The application to be launched.
- * @uris: The files whose locations should be passed as a parameter to the application.
+ * @files: The files whose locations should be passed as a parameter to the application.
  * @parent_window: A window to use as the parent for any error dialogs.
  */
 void

--- a/src/nemo-mime-actions.c
+++ b/src/nemo-mime-actions.c
@@ -2235,7 +2235,7 @@ activation_start_mountables (ActivateParameters *parameters)
  *
  * Activate a list of files. Each one might launch with an application or
  * with a component. This is normally called only by subclasses.
- * @view: FMDirectoryView in question.
+ * @parent_window: The window to parent dialogs on.
  * @files: A GList of NemoFiles to activate.
  *
  **/
@@ -2316,9 +2316,9 @@ nemo_mime_activate_files (GtkWindow *parent_window,
  *
  * Activate a file in this view. This might involve switching the displayed
  * location for the current window, or launching an application.
- * @view: FMDirectoryView in question.
+ * @parent_window: The window to parent dialogs on.
  * @file: A NemoFile representing the file in this view to activate.
- * @use_new_window: Should this item be opened in a new window?
+ * @flags: How the location should be opened.
  *
  **/
 

--- a/src/nemo-mime-actions.c
+++ b/src/nemo-mime-actions.c
@@ -2232,11 +2232,15 @@ activation_start_mountables (ActivateParameters *parameters)
 
 /**
  * nemo_mime_activate_files:
+ * @parent_window: The window to parent dialogs on.
+ * @slot: The window slot to open locations in.
+ * @files: A GList of NemoFiles to activate.
+ * @launch_directory: Working directory for launching executable files, or NULL.
+ * @flags: How the location should be opened.
+ * @user_confirmation: Whether to request confirmation before opening multiple windows or tabs.
  *
  * Activate a list of files. Each one might launch with an application or
  * with a component. This is normally called only by subclasses.
- * @parent_window: The window to parent dialogs on.
- * @files: A GList of NemoFiles to activate.
  *
  **/
 void
@@ -2313,12 +2317,14 @@ nemo_mime_activate_files (GtkWindow *parent_window,
 
 /**
  * nemo_mime_activate_file:
+ * @parent_window: The window to parent dialogs on.
+ * @slot: The window slot to open locations in.
+ * @file: A NemoFile representing the file in this view to activate.
+ * @launch_directory: Working directory for launching executable files, or NULL.
+ * @flags: How the location should be opened.
  *
  * Activate a file in this view. This might involve switching the displayed
  * location for the current window, or launching an application.
- * @parent_window: The window to parent dialogs on.
- * @file: A NemoFile representing the file in this view to activate.
- * @flags: How the location should be opened.
  *
  **/
 


### PR DESCRIPTION
These names date back to nautilus: `nemo_mime_activate_file` still documents `@view` and `@use_new_window`, which became `parent_window` and `flags` when the window slot work landed, and `nemo_launch_application` documents `@uris` although it takes a list of files and builds the uris itself. I left the block above `nemo_launch_application_from_command_array` alone, since it names the non-array function and moving it is a judgement call.
