### PR TITLE
Fix focus loss during inline rename when pressing Alt+Shift

### DIFF
--- a/src/nemo-window.c
+++ b/src/nemo-window.c
@@ -1207,6 +1207,21 @@ nemo_window_key_press_event (GtkWidget *widget,
       }
 
 	if (view != NULL && nemo_view_get_is_renaming (view) && event->keyval != GDK_KEY_F2) {
+		/* Consume bare Alt key presses during rename to prevent GTK from
+		 * interpreting them as menubar toggle triggers, which would cause
+		 * the rename entry to lose focus.
+		 *
+		 * Alt+letter combinations (Alt+F, Alt+B, etc.) are still passed
+		 * through for word movement in EelEditableLabel.
+		 */
+		if (event->keyval == GDK_KEY_Alt_L || event->keyval == GDK_KEY_Alt_R) {
+			guint modifiers = event->state & gtk_accelerator_get_default_mod_mask();
+			if (modifiers == 0) {
+				/* Bare Alt press (no other modifiers) - consume it */
+				return TRUE;
+			}
+		}
+
 		/* if we're renaming, just forward the event to the
 		 * focused widget and return. We don't want to process the window
 		 * accelerator bindings, as they might conflict with the
@@ -1285,6 +1300,23 @@ nemo_window_key_release_event (GtkWidget *widget,
                              GdkEventKey *event)
 {
     NemoWindow *window = NEMO_WINDOW (widget);
+    NemoWindowSlot *active_slot;
+    NemoView *view;
+
+    active_slot = nemo_window_get_active_slot (window);
+    view = active_slot->content_view;
+
+    /* Consume bare Alt key release during rename to prevent GTK from
+     * interpreting it as menubar toggle trigger.
+     */
+    if (view != NULL && nemo_view_get_is_renaming (view)) {
+        if (event->keyval == GDK_KEY_Alt_L || event->keyval == GDK_KEY_Alt_R) {
+            guint modifiers = event->state & gtk_accelerator_get_default_mod_mask();
+            if (modifiers == 0) {
+                return TRUE;
+            }
+        }
+    }
 
     /* Conditions to show the menu via the alt key is that it must have been pressed and
      * released without any other key events in between, and we must not have hidden the


### PR DESCRIPTION
## Summary

When renaming a file or folder (F2) in Nemo, pressing Alt+Shift to switch keyboard
layout causes the rename text entry to lose focus. The rename operation is cancelled
and the file returns to its original name. This affects all three view modes:
Icon View, List View, and Compact View.

## Root Cause

The rename guard at `nemo-window.c` correctly bypasses Nemo's own accelerator
bindings, but does NOT prevent GTK from processing the unhandled Alt key event.
The unhandled bare Alt key falls through to GTK's default handler, which interprets
it as a menubar toggle trigger, causing focus loss on the rename entry.

## Fix

Consume bare Alt key press/release events during rename in
`nemo_window_key_press_event()` and `nemo_window_key_release_event()` before GTK
can process them as menubar toggles.

- Only blocks bare Alt presses (no other modifiers) during rename
- Alt+letter combinations (Alt+F, Alt+B for word movement) still work
- Ctrl+Alt, Shift+Alt combinations still propagate normally
- Minimal change contained to a single file

## Testing

1. Open Nemo in Icon View, List View, and Compact View
2. Select a file and press F2 to rename
3. While the rename text entry is focused, press Alt+Shift
4. **Expected:** The keyboard layout switches, rename field keeps focus
5. **Before fix:** Rename field loses focus, rename is cancelled

Additional test cases:
- Alt+F / Alt+B should still move cursor by word in rename field
- Alt+Tab should work normally when NOT in rename mode
- Escape should cancel rename, Enter should confirm rename

Video:
https://youtu.be/pSitfxwCchM